### PR TITLE
Exec cms and poll create fixes

### DIFF
--- a/__tests__/lib/api.ts
+++ b/__tests__/lib/api.ts
@@ -1,8 +1,35 @@
-import { getPolls } from '../../lib/api';
+import { getPolls, parseExecutive } from '../../lib/api';
 import fs from 'fs';
 import { config } from '../../lib/config';
 
 const cacheFile = `/tmp/gov-portal-testnet-polls-${new Date().toISOString().substring(0, 10)}`;
+
+const Exec1 = 
+`---
+title: mock title
+summary: mock summary
+date: 2021-04-19T00:00:00.000Z
+address: "0xDb0D1af4531F59E4E7EfA4ec0AcADec7518D42B6"
+---
+# mock markdown`;
+
+const Exec2 = 
+`---
+title: mock title
+summary: mock summary
+date: invalid-date
+address: "0xDb0D1af4531F59E4E7EfA4ec0AcADec7518D42B6"
+---
+# mock markdown`;
+
+const Exec3 = 
+`---
+title: mock title
+summary: mock summary
+date: 2021-04-19T00:00:00.000Z
+address: invalid-address
+---
+# mock markdown`;
 
 beforeAll(() => {
   config.USE_FS_CACHE = '1';
@@ -17,4 +44,19 @@ test('getPolls with filesystem caching', async () => {
   jest.setTimeout(15000);
   await getPolls();
   expect(fs.existsSync(cacheFile)).toBeTruthy();
+});
+
+test('parseExecutive', async () => {
+  const parsedExec = parseExecutive(Exec1, {'testnet': ['x']}, 'x');
+  expect(!!parsedExec.about && !!parsedExec.content && !!parsedExec.title && !!parsedExec.proposalBlurb && !!parsedExec.key && !!parsedExec.address && !!parsedExec.date && !!parsedExec.active).toBe(true);
+});
+
+test('parseExecutive removes execs with invalid dates', async () => {
+  const parsedExec = parseExecutive(Exec2, {'testnet': ['x']}, 'x');
+  expect(parsedExec).toBe(null);
+});
+
+test('parseExecutive removes execs with invalid address', async () => {
+  const parsedExec = parseExecutive(Exec3, {'testnet': ['x']}, 'x');
+  expect(parsedExec).toBe(null);
 });

--- a/components/PollCreateModal.tsx
+++ b/components/PollCreateModal.tsx
@@ -79,9 +79,7 @@ const PollCreateModal = ({ close, poll, setPoll }: Props): JSX.Element => {
               borderColor: 'secondaryMuted'
             }}
           >
-            <Text variant="text" sx={{ fontSize: 1, color: 'textMuted' }}>
-              {poll?.content}
-            </Text>
+            <Text sx={{ fontWeight: 'bold', fontSize: '16px', textAlign: 'center' }}>{poll?.title}</Text>
           </Box>
         </Box>
         <Box sx={{ width: '100%', mt: 3 }}>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -61,7 +61,7 @@ export async function getExecutiveProposals(): Promise<CMSProposal[]> {
           }
 
           //remove if date is invalid
-          if (date instanceof Date && !isNaN(date.getTime())) {
+          if (!(date instanceof Date) || isNaN(date.getTime())) {
             return null;
           }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -26,7 +26,7 @@ export async function getExecutiveProposals(): Promise<CMSProposal[]> {
 
   const proposalIndex = await (await fetch(EXEC_PROPOSAL_INDEX)).json();
 
-  const owner = 'tyler17'; //todo: switch back to makerdao before merging
+  const owner = 'makerdao';
   const repo = 'community';
   const path = 'governance/votes';
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,6 +15,7 @@ import { parsePollMetadata } from './polling/parser';
 import { fetchGitHubPage } from './github';
 import fs from 'fs';
 import { config } from './config';
+import { ethers } from 'ethers';
 
 export async function getExecutiveProposals(): Promise<CMSProposal[]> {
   if (config.USE_FS_CACHE) {
@@ -25,7 +26,7 @@ export async function getExecutiveProposals(): Promise<CMSProposal[]> {
 
   const proposalIndex = await (await fetch(EXEC_PROPOSAL_INDEX)).json();
 
-  const owner = 'makerdao';
+  const owner = 'tyler17'; //todo: switch back to makerdao before merging
   const repo = 'community';
   const path = 'governance/votes';
 
@@ -48,6 +49,19 @@ export async function getExecutiveProposals(): Promise<CMSProposal[]> {
 
           // Remove empty docs
           if (!(content && title && summary && address && date)) {
+            return null;
+          }
+
+          //remove if address is not a valid address
+          try {
+            ethers.utils.getAddress(address);
+          } catch (_) {
+            console.log('invalid address: ', address, ' skipping executive: ', title);
+            return null;
+          }
+
+          //remove if date is invalid
+          if (date instanceof Date && !isNaN(date.getTime())) {
             return null;
           }
 

--- a/lib/polling/validator.ts
+++ b/lib/polling/validator.ts
@@ -26,13 +26,17 @@ type ValidationResult = {
   valid: boolean;
   errors: string[];
   parsedData?: Poll;
+  wholeDoc?: string;
 };
 
 export async function validateUrl(url: string, poll?: PartialPoll): Promise<ValidationResult> {
   const resp = await fetch(url);
   const text = await resp.text();
   const result = validateText(text);
-  if (result.valid && poll) result.parsedData = parsePollMetadata(poll, text);
+  if (result.valid && poll) {
+    result.wholeDoc = text;
+    result.parsedData = parsePollMetadata(poll, text);
+  }
   return result;
 }
 

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -18,6 +18,8 @@ import { validateUrl } from 'lib/polling/validator';
 import { Poll } from 'types/poll';
 import Hash from 'ipfs-only-hash';
 import useAccountsStore from 'stores/accounts';
+import { formatDateWithTime } from 'lib/utils';
+import { markdownToHtml } from 'lib/utils';
 
 const generateIPFSHash = async (data, options) => {
   // options object has the key encoding which defines the encoding type
@@ -42,6 +44,7 @@ const PollingCreate = () => {
   const [pollUrl, setPollUrl] = useState('');
   const [poll, setPoll] = useState<Poll | undefined>();
   const [pollErrors, setPollErrors] = useState<string[]>([]);
+  const [contentHtml, setContentHtml] = useState<string>('');
   const [creating, setCreating] = useState(false);
   const account = useAccountsStore(state => state.currentAccount);
   const urlValidation = async url => {
@@ -60,6 +63,7 @@ const PollingCreate = () => {
       }
       setPoll(poll);
       setPollErrors([]);
+      if (poll) setContentHtml(await markdownToHtml(poll.content));
     } else {
       setPollErrors(result.errors);
     }
@@ -120,27 +124,9 @@ const PollingCreate = () => {
                       <Label>Category</Label>
                       <CreateText>{poll?.categories.join(', ')}</CreateText>
                       <Label>Poll Start Time</Label>
-                      <CreateText>
-                        {poll &&
-                          new Date(poll.startDate).toLocaleString('default', {
-                            month: 'long',
-                            day: 'numeric',
-                            year: 'numeric',
-                            timeZone: 'UTC',
-                            timeZoneName: 'short'
-                          })}
-                      </CreateText>
+                      <CreateText>{poll && formatDateWithTime(poll.startDate)}</CreateText>
                       <Label>Poll End Time</Label>
-                      <CreateText>
-                        {poll &&
-                          new Date(poll.endDate).toLocaleString('default', {
-                            month: 'long',
-                            day: 'numeric',
-                            year: 'numeric',
-                            timeZone: 'UTC',
-                            timeZoneName: 'short'
-                          })}
-                      </CreateText>
+                      <CreateText>{poll && formatDateWithTime(poll.endDate)}</CreateText>
                       <Label>Poll Duration</Label>
                       <CreateText>
                         {poll &&
@@ -160,12 +146,10 @@ const PollingCreate = () => {
                         sx={{
                           width: '100%',
                           border: '1px solid #d5d9e0',
-                          borderRadius: 'small',
-                          height: '140px',
-                          overflow: 'scroll'
+                          borderRadius: 'small'
                         }}
                       >
-                        {poll?.content}
+                        <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
                       </Text>
                       <Flex>
                         <Button

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -30,7 +30,7 @@ const generateIPFSHash = async (data, options) => {
 };
 
 const editMarkdown = (content, title) => {
-  // hide the duplicate proposal title
+  //replace title from markdown content with the title in the frontmatter
   return content.replace(/^<h1>.*<\/h1>|^<h2>.*<\/h2>/, `<h2>${title}</h2>`);
 };
 

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -63,7 +63,7 @@ const PollingCreate = () => {
     if (result.valid) {
       const poll = result.parsedData;
       if (poll) {
-        poll.multiHash = await generateIPFSHash(poll.content, {});
+        poll.multiHash = await generateIPFSHash(result.wholeDoc, {});
         poll.slug = poll.multiHash.slice(0, 8);
       }
       setPoll(poll);
@@ -124,11 +124,10 @@ const PollingCreate = () => {
                       <CreateText>{poll?.summary}</CreateText>
                       <Label>Vote Options</Label>
                       <CreateText>
-                        {Object.keys(poll?.options).map((option, i) => (
-                          <div key={i}>
-                            <Text sx={{ width: '20%' }}>{`${option}: ${poll?.options[option]}`}</Text>
-                          </div>
-                        ))}
+                        {poll &&
+                          Object.keys(poll.options).map((option, i) => (
+                            <Text key={i}>{`${option}: ${poll.options[option]}`}</Text>
+                          ))}
                       </CreateText>
                       <Label>Vote Type</Label>
                       <CreateText>{poll?.voteType}</CreateText>

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -60,8 +60,13 @@ const PollingCreate = (): React.ReactElement => {
   const [creating, setCreating] = useState(false);
   const account = useAccountsStore(state => state.currentAccount);
 
+  const resetForm = () => {
+    setPoll(undefined);
+    setContentHtml('');
+  };
   const urlValidation = async url => {
     setLoading(true);
+    resetForm();
 
     try {
       const result = await validateUrl(url, {
@@ -161,23 +166,17 @@ const PollingCreate = (): React.ReactElement => {
                           } days`}
                       </CreateText>
                       <Label>Discussion Link</Label>
-                      {poll && poll.discussionLink && (
+                      {poll && poll.discussionLink ? (
                         <ExternalLink target="_blank" href={poll.discussionLink} sx={{ p: 0 }}>
                           <CreateText>{poll && poll.discussionLink}</CreateText>
                         </ExternalLink>
+                      ) : (
+                        <CreateText> </CreateText>
                       )}
                       <Label>Proposal</Label>
-                      <Text
-                        mb={3}
-                        sx={{
-                          width: '100%',
-                          border: '1px solid #d5d9e0',
-                          borderRadius: 'small',
-                          padding: 2
-                        }}
-                      >
+                      <CreateText>
                         <div dangerouslySetInnerHTML={{ __html: editMarkdown(contentHtml, poll?.title) }} />
-                      </Text>
+                      </CreateText>
                       <Flex>
                         <Button
                           variant="primary"
@@ -186,7 +185,7 @@ const PollingCreate = (): React.ReactElement => {
                         >
                           Create Poll
                         </Button>
-                        <Button variant="outline" sx={{ ml: 4 }} onClick={() => setPoll(undefined)}>
+                        <Button variant="outline" sx={{ ml: 4 }} onClick={() => resetForm()}>
                           Reset Form
                         </Button>
                       </Flex>

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -29,6 +29,11 @@ const generateIPFSHash = async (data, options) => {
   return hash;
 };
 
+const editMarkdown = (content, title) => {
+  // hide the duplicate proposal title
+  return content.replace(/^<h1>.*<\/h1>|^<h2>.*<\/h2>/, `<h2>${title}</h2>`);
+};
+
 const CreateText = ({ children }) => {
   return (
     <Text
@@ -118,7 +123,13 @@ const PollingCreate = () => {
                       <Label>Summary</Label>
                       <CreateText>{poll?.summary}</CreateText>
                       <Label>Vote Options</Label>
-                      <CreateText>{JSON.stringify(poll?.options)}</CreateText>
+                      <CreateText>
+                        {Object.keys(poll?.options).map((option, i) => (
+                          <div key={i}>
+                            <Text sx={{ width: '20%' }}>{`${option}: ${poll?.options[option]}`}</Text>
+                          </div>
+                        ))}
+                      </CreateText>
                       <Label>Vote Type</Label>
                       <CreateText>{poll?.voteType}</CreateText>
                       <Label>Category</Label>
@@ -149,7 +160,7 @@ const PollingCreate = () => {
                           borderRadius: 'small'
                         }}
                       >
-                        <div dangerouslySetInnerHTML={{ __html: contentHtml }} />
+                        <div dangerouslySetInnerHTML={{ __html: editMarkdown(contentHtml, poll?.title) }} />
                       </Text>
                       <Flex>
                         <Button


### PR DESCRIPTION
### Link to Clubhouse story

Executive improvements:
https://app.clubhouse.io/dux-makerdao/story/47/create-executive-ui-whitelisted-to-governance-facilitators-load-from-markdown-in-github
Polling improvements: https://app.clubhouse.io/dux-makerdao/story/48/create-poll-ui-refresh-whitelisted-to-governance-facilitators-load-from-markdown-in-github

### What does this PR do?

1. Ignore executive votes with invalid address and invalid dates.
2. Improves formatting in the polling/create page

### Steps for testing:
Polling changes:
1. Go to the /polling/create page.  input a url pointing to a poll, e.g. https://raw.githubusercontent.com/makerdao/community/master/governance/polls/MIP9%20Community%20Greenlight%20Poll%20-%200xBTC%20-%20July%205%2C%202021.md
2. Confirm that it still displays poll info correctly, but improves formatting of options and content markdown, and cleans up the create confirmation modal.

The executive changes are harder to test in the UI, but I've added automated tests to check that the new parseExecutive function ignores execs with invalid addresses and invalid dates.

### Screenshots (if relevant):
<img width="325" alt="Screen Shot 2021-07-08 at 2 12 10 PM" src="https://user-images.githubusercontent.com/3388550/125005106-a5b54000-dff6-11eb-862b-235f551c6bdc.png">
<img width="286" alt="Screen Shot 2021-07-08 at 2 12 18 PM" src="https://user-images.githubusercontent.com/3388550/125005127-b5348900-dff6-11eb-877d-6686cc473fd8.png">
