### PR TITLE
refactor delegations fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ _Requires node version >= v11.15.0_
 7. Set `USE_PROD_SPOCK` to true to use the production spock instance
 8. Set `USE_FS_CACHE` to true if you want to use file system cache
 9. Set `GITHUB_TOKEN` to fetch delegates information from GitHub
-10. Set `GITHUB_DELEGATES_OWNER` to indicate the owner of the delegates repo
-11. Set `GITHUB_DELEGATES_REPO` to indicate the name of the repo that contains the delegates folder
-12. Set `NEXT_PUBLIC_USE_MOCK` to indicate to use mock data.
+10. Set `NEXT_PUBLIC_USE_MOCK` to indicate to use mock data.
 
 If API keys aren't provided, both Alchemy and Infura will default to the public keys from [ethers.js](https://github.com/ethers-io/ethers.js/). This is probably fine in most cases, performance could just be a bit less consistent as many people are using these.
 

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -83,7 +83,7 @@ export default function DelegateCard({ delegate }: PropTypes): React.ReactElemen
 
             {!showLinkToDetail && (
               <Box>
-                <DelegateLastVoted delegate={delegate} />
+                {/*<DelegateLastVoted delegate={delegate} /> */}
                 <DelegateContractExpiration delegate={delegate} />
               </Box>
             )}

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -23,6 +23,7 @@ type PropTypes = {
 };
 
 export default function DelegateCard({ delegate }: PropTypes): React.ReactElement {
+  const network = getNetwork();
   const bpi = useBreakpointIndex();
   const [showDelegateModal, setShowDelegateModal] = useState(false);
   const [showUndelegateModal, setShowUndelegateModal] = useState(false);
@@ -66,7 +67,12 @@ export default function DelegateCard({ delegate }: PropTypes): React.ReactElemen
 
           <Box sx={{ mt: 3 }}>
             {showLinkToDetail && (
-              <Link href={`/delegates/${delegate.voteDelegateAddress}`}>
+              <Link
+                href={{
+                  pathname: `/delegates/${network}/${delegate.voteDelegateAddress}`,
+                  query: { network }
+                }}
+              >
                 <a title="Profile details">
                   <Button sx={{ borderColor: 'text', width: '169px', color: 'text' }} variant="outline">
                     View Profile Details

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -69,7 +69,7 @@ export default function DelegateCard({ delegate }: PropTypes): React.ReactElemen
             {showLinkToDetail && (
               <Link
                 href={{
-                  pathname: `/delegates/${network}/${delegate.voteDelegateAddress}`,
+                  pathname: `/delegates/${delegate.voteDelegateAddress}`,
                   query: { network }
                 }}
               >

--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx,  Box, Text, Link as ExternalLink, Divider } from 'theme-ui';
+import { jsx, Box, Text, Link as ExternalLink, Divider } from 'theme-ui';
 import React from 'react';
 import { Delegate } from 'types/delegate';
 import { getEtherscanLink } from 'lib/utils';
@@ -36,7 +36,10 @@ export default function DelegateDetail({ delegate }: PropTypes): React.ReactElem
         </Box>
       </Box>
       <Box sx={{ p: 3 }}>
-        <div  sx={{ variant: 'markdown.default' }} dangerouslySetInnerHTML={{ __html: delegate.description }} />
+        <div
+          sx={{ variant: 'markdown.default' }}
+          dangerouslySetInnerHTML={{ __html: delegate.description }}
+        />
       </Box>
 
       <Divider my={0} />

--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, Link as ExternalLink, Divider } from '@theme-ui/components';
+/** @jsx jsx */
+import { jsx,  Box, Text, Link as ExternalLink, Divider } from 'theme-ui';
 import React from 'react';
 import { Delegate } from 'types/delegate';
 import { getEtherscanLink } from 'lib/utils';
@@ -35,14 +36,14 @@ export default function DelegateDetail({ delegate }: PropTypes): React.ReactElem
         </Box>
       </Box>
       <Box sx={{ p: 3 }}>
-        <div dangerouslySetInnerHTML={{ __html: delegate.description }} />
+        <div  sx={{ variant: 'markdown.default' }} dangerouslySetInnerHTML={{ __html: delegate.description }} />
       </Box>
 
       <Divider my={0} />
       <Box sx={{ p: 3, display: 'flex' }}>
-        <Box sx={{ mr: 3 }}>
+        {/*<Box sx={{ mr: 3 }}>
           <DelegateLastVoted delegate={delegate} />
-        </Box>
+        </Box>*/}
         <DelegateContractExpiration delegate={delegate} />
       </Box>
     </Box>

--- a/components/delegations/modals/Confirm.tsx
+++ b/components/delegations/modals/Confirm.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const ConfirmContent = ({ mkrToDeposit, delegate, onClick, onBack }: Props): JSX.Element => {
-  const { delegateAddress, voteDelegateAddress } = delegate;
+  const { address, voteDelegateAddress } = delegate;
   return (
     <Flex sx={{ flexDirection: 'column', textAlign: 'center' }}>
       <Text variant="microHeading" sx={{ fontSize: [3, 6] }}>
@@ -36,11 +36,11 @@ const ConfirmContent = ({ mkrToDeposit, delegate, onClick, onBack }: Props): JSX
         This delegate contract was created by{' '}
         <ExternalLink
           title="View on etherescan"
-          href={getEtherscanLink(getNetwork(), delegateAddress, 'address')}
+          href={getEtherscanLink(getNetwork(), address, 'address')}
           target="_blank"
         >
           <Text sx={{ fontWeight: 'bold', color: 'text', display: 'inline', ':hover': { color: 'inherit' } }}>
-            {delegateAddress}
+            {address}
           </Text>
         </ExternalLink>
       </Text>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -10,7 +10,6 @@ import getMaker, { getNetwork, isTestnet } from './maker';
 import { Poll, PartialPoll } from 'types/poll';
 import { CMSProposal } from 'types/proposal';
 import { BlogPost } from 'types/blogPost';
-import { DelegateContractInformation } from 'types/delegate';
 import { slugify } from '../lib/utils';
 import { parsePollMetadata } from './polling/parser';
 import { fetchGitHubPage } from './github';
@@ -116,18 +115,6 @@ export async function getPolls(): Promise<Poll[]> {
 
   if (config.USE_FS_CACHE) fsCacheSet('polls', JSON.stringify(polls));
   return polls;
-}
-
-export async function getChainDelegates(): Promise<DelegateContractInformation[]> {
-  const maker = await getMaker();
-
-  const delegates = await maker.service('voteDelegate').getAllDelegates();
-
-  return delegates.map(d => ({
-    ...d,
-    delegateAddress: d.delegate,
-    voteDelegateAddress: d.voteDelegate
-  }));
 }
 
 const fsCacheCache = {};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,7 +2,6 @@ import uniqBy from 'lodash/uniqBy';
 import matter from 'gray-matter';
 import invariant from 'tiny-invariant';
 import chunk from 'lodash/chunk';
-import os from 'os';
 
 import { markdownToHtml, timeoutPromise, backoffRetry } from './utils';
 import { EXEC_PROPOSAL_INDEX } from './constants';
@@ -13,9 +12,9 @@ import { BlogPost } from 'types/blogPost';
 import { slugify } from '../lib/utils';
 import { parsePollMetadata } from './polling/parser';
 import { fetchGitHubPage } from './github';
-import fs from 'fs';
 import { config } from './config';
 import mockProposals from '../mocks/proposals.json';
+import { fsCacheGet, fsCacheSet } from './fscache';
 
 export async function getExecutiveProposals(): Promise<CMSProposal[]> {
   if (config.USE_FS_CACHE) {
@@ -117,33 +116,6 @@ export async function getPolls(): Promise<Poll[]> {
   return polls;
 }
 
-const fsCacheCache = {};
-
-const fsCacheGet = name => {
-  const path = `${os.tmpdir()}/gov-portal-${getNetwork()}-${name}-${new Date()
-    .toISOString()
-    .substring(0, 10)}`;
-  if (fsCacheCache[path]) {
-    console.log(`mem cache hit: ${path}`);
-    return fsCacheCache[path];
-  }
-  if (fs.existsSync(path)) {
-    console.log(`fs cache hit: ${path}`);
-    return fs.readFileSync(path).toString();
-  }
-};
-
-const fsCacheSet = (name, data) => {
-  try {
-    const path = `${os.tmpdir()}/gov-portal-${getNetwork()}-${name}-${new Date()
-      .toISOString()
-      .substring(0, 10)}`;
-    fs.writeFileSync(path, data);
-    fsCacheCache[path] = data;
-  } catch (e) {
-    console.error(e);
-  }
-};
 
 export async function parsePollsMetadata(pollList): Promise<Poll[]> {
   let numFailedFetches = 0;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -116,7 +116,6 @@ export async function getPolls(): Promise<Poll[]> {
   return polls;
 }
 
-
 export async function parsePollsMetadata(pollList): Promise<Poll[]> {
   let numFailedFetches = 0;
   const failedPollIds: number[] = [];

--- a/lib/delegates/fetchChainDelegates.ts
+++ b/lib/delegates/fetchChainDelegates.ts
@@ -1,0 +1,17 @@
+import { SupportedNetworks } from 'lib/constants';
+import getMaker from 'lib/maker';
+import { DelegateContractInformation } from 'types/delegate';
+
+export async function fetchChainDelegates(
+  network: SupportedNetworks
+): Promise<DelegateContractInformation[]> {
+  const maker = await getMaker(network);
+
+  const delegates = await maker.service('voteDelegate').getAllDelegates();
+
+  return delegates.map(d => ({
+    ...d,
+    address: d.delegate,
+    voteDelegateAddress: d.voteDelegate
+  }));
+}

--- a/lib/delegates/fetchGithubDelegates.ts
+++ b/lib/delegates/fetchGithubDelegates.ts
@@ -52,7 +52,7 @@ export async function fetchGithubDelegates(
 
   const delegatesCacheKey = `${network}-delegates`;
   const existingDelegates = fsCacheGet(delegatesCacheKey);
-  
+
   if (existingDelegates) {
     return Promise.resolve({
       error: false,

--- a/lib/delegates/fetchGithubDelegates.ts
+++ b/lib/delegates/fetchGithubDelegates.ts
@@ -51,7 +51,8 @@ export async function fetchGithubDelegates(
   const delegatesRepositoryInfo = getDelegatesRepositoryInformation(network);
 
   const delegatesCacheKey = `${network}-delegates`;
-  const existingDelegates = fsCacheGet(delegatesCacheKey);
+  const cacheTime = 30000;
+  const existingDelegates = fsCacheGet(delegatesCacheKey, cacheTime);
 
   if (existingDelegates) {
     return Promise.resolve({
@@ -85,7 +86,7 @@ export async function fetchGithubDelegates(
     const data = results.filter(i => !!i) as DelegateRepoInformation[];
 
     // Store in cache
-    fsCacheSet(delegatesCacheKey, JSON.stringify(data), 30000);
+    fsCacheSet(delegatesCacheKey, JSON.stringify(data), cacheTime);
 
     return {
       error: false,

--- a/lib/delegates/getDelegatesRepositoryInfo.ts
+++ b/lib/delegates/getDelegatesRepositoryInfo.ts
@@ -1,0 +1,25 @@
+import { SupportedNetworks } from 'lib/constants';
+
+type RepositoryInfo = {
+  owner: string;
+  repo: string;
+  page: string;
+};
+
+export function getDelegatesRepositoryInformation(network: SupportedNetworks): RepositoryInfo {
+  const repoMainnet = {
+    owner: 'makerdao',
+    repo: 'community',
+    page: 'governance/delegates'
+  };
+
+  const repoKovan = {
+    owner: 'makerdao-dux',
+    repo: 'voting-delegates',
+    page: 'delegates'
+  };
+
+  // TODO: Change to mainnet once mainnet is supported and merged.
+  const delegatesRepositoryInfo = network === SupportedNetworks.MAINNET ? repoKovan : repoKovan;
+  return delegatesRepositoryInfo;
+}

--- a/lib/fscache/index.ts
+++ b/lib/fscache/index.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import os from 'os';
+import { getNetwork } from 'lib/maker';
+
+const fsCacheCache = {};
+
+function getFilePath(name: string): string {
+  const date = new Date().toISOString().substring(0, 10);
+
+  return `${os.tmpdir()}/gov-portal-${getNetwork()}-${name}-${date}`;
+}
+
+export const fsCacheGet = (name: string): any => {
+  const path = getFilePath(name);
+  const memCached = fsCacheCache[path];
+
+  if (memCached) {
+    console.log(`mem cache hit: ${path}`);
+
+    if (memCached.expiry && memCached.expiry < Date.now()) {
+      console.log('Mem cache expired');
+      fs.unlinkSync(path);
+      fsCacheCache[path] = null;
+    
+      return null;
+    }
+
+    return fsCacheCache[path].data;
+  }
+
+  if (fs.existsSync(path)) {
+    console.log(`fs cache hit: ${path}`);
+    return fs.readFileSync(path).toString();
+  }
+};
+
+export const fsCacheSet = (name: string, data: any, expiryMs?: number): void => {
+  try {
+    const path = getFilePath(name);
+
+    fs.writeFileSync(path, data);
+
+    fsCacheCache[path] = {
+      expiry: expiryMs ? Date.now() + expiryMs: null,
+      data
+    };
+
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/lib/fscache/index.ts
+++ b/lib/fscache/index.ts
@@ -21,7 +21,7 @@ export const fsCacheGet = (name: string): any => {
       console.log('Mem cache expired');
       fs.unlinkSync(path);
       fsCacheCache[path] = null;
-    
+
       return null;
     }
 
@@ -41,10 +41,9 @@ export const fsCacheSet = (name: string, data: any, expiryMs?: number): void => 
     fs.writeFileSync(path, data);
 
     fsCacheCache[path] = {
-      expiry: expiryMs ? Date.now() + expiryMs: null,
+      expiry: expiryMs ? Date.now() + expiryMs : null,
       data
     };
-
   } catch (e) {
     console.error(e);
   }

--- a/lib/fscache/index.ts
+++ b/lib/fscache/index.ts
@@ -20,7 +20,7 @@ export const fsCacheDel = (path: string): void => {
 export const fsCacheGet = (name: string, expiryMs?: number): any => {
   const path = getFilePath(name);
   const memCached = fsCacheCache[path];
-  
+
   if (memCached) {
     console.log(`mem cache hit: ${path}`);
 
@@ -42,7 +42,7 @@ export const fsCacheGet = (name: string, expiryMs?: number): any => {
       fsCacheDel(path);
       return null;
     }
-    
+
     console.log(`fs cache hit: ${path}`);
     return fs.readFileSync(path).toString();
   }
@@ -50,7 +50,6 @@ export const fsCacheGet = (name: string, expiryMs?: number): any => {
 
 export const fsCacheSet = (name: string, data: any, expiryMs?: number): void => {
   try {
-    
     const path = getFilePath(name);
     console.log('fs cache set', path);
     fs.writeFileSync(path, data);

--- a/lib/fscache/index.ts
+++ b/lib/fscache/index.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import { getNetwork } from 'lib/maker';
 
+// Mem cache does not work on local instances of nextjs because nextjs creates clean memory states each time.
 const fsCacheCache = {};
 
 function getFilePath(name: string): string {
@@ -10,18 +11,22 @@ function getFilePath(name: string): string {
   return `${os.tmpdir()}/gov-portal-${getNetwork()}-${name}-${date}`;
 }
 
-export const fsCacheGet = (name: string): any => {
+export const fsCacheDel = (path: string): void => {
+  console.log('Delete cache', path);
+  fs.unlinkSync(path);
+  fsCacheCache[path] = null;
+};
+
+export const fsCacheGet = (name: string, expiryMs?: number): any => {
   const path = getFilePath(name);
   const memCached = fsCacheCache[path];
-
+  
   if (memCached) {
     console.log(`mem cache hit: ${path}`);
 
     if (memCached.expiry && memCached.expiry < Date.now()) {
-      console.log('Mem cache expired');
-      fs.unlinkSync(path);
-      fsCacheCache[path] = null;
-
+      console.log('mem cache expired');
+      fsCacheDel(path);
       return null;
     }
 
@@ -29,6 +34,15 @@ export const fsCacheGet = (name: string): any => {
   }
 
   if (fs.existsSync(path)) {
+    // In nextjs serverless instances of API functions sometimes reset their in memory cache (they are different instances)
+    // In order to have an expiry date we can also check the last time this file was accessed or it was created. This conditions having to pass the expiryMs on the cacheGet too
+    const { birthtime } = fs.statSync(path);
+
+    if (expiryMs && birthtime && birthtime.getTime() < Date.now() + expiryMs) {
+      fsCacheDel(path);
+      return null;
+    }
+    
     console.log(`fs cache hit: ${path}`);
     return fs.readFileSync(path).toString();
   }
@@ -36,8 +50,9 @@ export const fsCacheGet = (name: string): any => {
 
 export const fsCacheSet = (name: string, data: any, expiryMs?: number): void => {
   try {
+    
     const path = getFilePath(name);
-
+    console.log('fs cache set', path);
     fs.writeFileSync(path, data);
 
     fsCacheCache[path] = {

--- a/lib/maker/index.ts
+++ b/lib/maker/index.ts
@@ -3,11 +3,11 @@ import McdPlugin, { DAI } from '@makerdao/dai-plugin-mcd';
 import LedgerPlugin from '@makerdao/dai-plugin-ledger-web';
 import TrezorPlugin from '@makerdao/dai-plugin-trezor-web';
 import GovernancePlugin, { MKR } from '@makerdao/dai-plugin-governance';
-import { Web3ReactPlugin } from './maker/web3react';
+import { Web3ReactPlugin } from './web3react';
 
-import { SupportedNetworks, DEFAULT_NETWORK } from './constants';
-import { networkToRpc } from './maker/network';
-import { config } from './config';
+import { SupportedNetworks, DEFAULT_NETWORK } from '../constants';
+import { networkToRpc } from './network';
+import { config } from '../config';
 
 export const ETH = Maker.ETH;
 export const USD = Maker.USD;
@@ -62,19 +62,33 @@ function determineNetwork(): SupportedNetworks {
   }
 }
 
-let makerSingleton: Promise<Maker>;
-function getMaker(): Promise<Maker> {
-  if (!makerSingleton) {
-    makerSingleton = Maker.create('http', {
+type MakerSingletons = {
+  [SupportedNetworks.MAINNET]: null | Promise<Maker>;
+  [SupportedNetworks.KOVAN]: null | Promise<Maker>;
+  [SupportedNetworks.TESTNET]: null | Promise<Maker>;
+};
+
+const makerSingletons: MakerSingletons = {
+  [SupportedNetworks.MAINNET]: null,
+  [SupportedNetworks.KOVAN]: null,
+  [SupportedNetworks.TESTNET]: null
+};
+
+function getMaker(network?: SupportedNetworks): Promise<Maker> {
+  // Chose the network we are referring to or default to the one set by the system
+  const currentNetwork = network ? network : getNetwork();
+
+  if (!makerSingletons[currentNetwork]) {
+    makerSingletons[currentNetwork] = Maker.create('http', {
       plugins: [
         [McdPlugin, { prefetch: false }],
-        [GovernancePlugin, { network: getNetwork(), staging: !config.USE_PROD_SPOCK }],
+        [GovernancePlugin, { network: currentNetwork, staging: !config.USE_PROD_SPOCK }],
         Web3ReactPlugin,
         LedgerPlugin,
         TrezorPlugin
       ],
       provider: {
-        url: networkToRpc(getNetwork(), 'infura'),
+        url: networkToRpc(currentNetwork, 'infura'),
         type: 'HTTP'
       },
       web3: {
@@ -88,10 +102,11 @@ function getMaker(): Promise<Maker> {
     });
   }
 
-  return makerSingleton;
+  return makerSingletons[currentNetwork] as Promise<Maker>;
 }
 
 let networkSingleton: SupportedNetworks;
+
 function getNetwork(): SupportedNetworks {
   if (!networkSingleton) networkSingleton = determineNetwork();
   return networkSingleton;

--- a/lib/maker/web3react/hooks.ts
+++ b/lib/maker/web3react/hooks.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import mixpanel from 'mixpanel-browser';
 import { useWeb3React } from '@web3-react/core';
 
-import getMaker from '../../maker';
+import getMaker from '../index';
 import { injectedConnector } from './index';
 
 export const syncMakerAccount = (library, account, chainIdError) => {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -274,22 +274,20 @@ export default {
       th: {
         fontWeight: 600,
         padding: '6px 13px',
-        border: '1px solid #dfe2e5',
+        border: '1px solid #dfe2e5'
       },
       td: {
         padding: '6px 13px',
         border: '1px solid #dfe2e5'
       },
 
-      tr : {
-        backgroundColor:  '#fff',
+      tr: {
+        backgroundColor: '#fff',
         borderTop: '1px solid #c6cbd1',
         ':nth-child(2n)': {
           backgroundColor: '#f6f8fa'
         }
       }
-      
-
     }
   },
   icons: {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -263,7 +263,33 @@ export default {
       },
       '& > :first-child': {
         mt: 0
+      },
+      table: {
+        borderSpacing: 0,
+        borderCollapse: 'collapse',
+        display: 'block',
+        width: '100%',
+        overflow: 'auto'
+      },
+      th: {
+        fontWeight: 600,
+        padding: '6px 13px',
+        border: '1px solid #dfe2e5',
+      },
+      td: {
+        padding: '6px 13px',
+        border: '1px solid #dfe2e5'
+      },
+
+      tr : {
+        backgroundColor:  '#fff',
+        borderTop: '1px solid #c6cbd1',
+        ':nth-child(2n)': {
+          backgroundColor: '#f6f8fa'
+        }
       }
+      
+
     }
   },
   icons: {

--- a/pages/api/delegates/[address].ts
+++ b/pages/api/delegates/[address].ts
@@ -1,0 +1,17 @@
+import invariant from 'tiny-invariant';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { isSupportedNetwork } from 'lib/maker/index';
+import { DEFAULT_NETWORK } from 'lib/constants';
+import withApiHandler from 'lib/api/withApiHandler';
+import { fetchDelegate } from 'lib/delegates/fetchDelegates';
+
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  const network = (req.query.network as string) || DEFAULT_NETWORK;
+  const address = (req.query.address as string);
+  invariant(isSupportedNetwork(network), `unsupported network ${network}`);
+
+  const delegate = await fetchDelegate(address, network);
+  res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
+  res.status(200).json(delegate);
+});

--- a/pages/api/delegates/[address].ts
+++ b/pages/api/delegates/[address].ts
@@ -8,7 +8,7 @@ import { fetchDelegate } from 'lib/delegates/fetchDelegates';
 
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
   const network = (req.query.network as string) || DEFAULT_NETWORK;
-  const address = (req.query.address as string);
+  const address = req.query.address as string;
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
   const delegate = await fetchDelegate(address, network);

--- a/pages/api/delegates/index.ts
+++ b/pages/api/delegates/index.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { isSupportedNetwork } from 'lib/maker';
+import { isSupportedNetwork } from 'lib/maker/index';
 import { DEFAULT_NETWORK } from 'lib/constants';
 import withApiHandler from 'lib/api/withApiHandler';
 import { fetchDelegates } from 'lib/delegates/fetchDelegates';
@@ -11,7 +11,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
   // const maker = await getConnectedMakerObj(network);
-  const delegates = await fetchDelegates();
+  const delegates = await fetchDelegates(network);
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
   res.status(200).json(delegates);
 });

--- a/pages/delegates/[address].tsx
+++ b/pages/delegates/[address].tsx
@@ -19,7 +19,6 @@ import { fetchJson } from 'lib/utils';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
 import { useRouter } from 'next/router';
 
-
 const DelegateView = ({ delegate }: { delegate: Delegate }) => {
   const network = getNetwork();
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
@@ -69,7 +68,7 @@ export default function DelegatesPage(): JSX.Element {
   const { address } = router.query;
   // fetch delegates at run-time if on any network other than the default
   useEffect(() => {
-    if(address) {
+    if (address) {
       fetchJson(`/api/delegates/${address}?network=${getNetwork()}`).then(setDelegate).catch(setError);
     }
   }, [address]);
@@ -78,14 +77,13 @@ export default function DelegatesPage(): JSX.Element {
     return <ErrorPage statusCode={404} title="Error fetching delegate" />;
   }
 
-  if (!delegate ) {
+  if (!delegate) {
     return (
       <PrimaryLayout shortenFooter={true}>
         <PageLoadingPlaceholder />
       </PrimaryLayout>
     );
   }
-
 
   return <DelegateView delegate={delegate} />;
 }

--- a/pages/delegates/[network]/[address].tsx
+++ b/pages/delegates/[network]/[address].tsx
@@ -4,18 +4,19 @@ import ErrorPage from 'next/error';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { Icon } from '@makerdao/dai-ui-icons';
 
-import PrimaryLayout from '../../components/layouts/Primary';
-import SidebarLayout from '../../components/layouts/Sidebar';
-import Stack from '../../components/layouts/Stack';
-import SystemStatsSidebar from '../../components/SystemStatsSidebar';
-import ResourceBox from '../../components/ResourceBox';
+import PrimaryLayout from '../../../components/layouts/Primary';
+import SidebarLayout from '../../../components/layouts/Sidebar';
+import Stack from '../../../components/layouts/Stack';
+import SystemStatsSidebar from '../../../components/SystemStatsSidebar';
+import ResourceBox from '../../../components/ResourceBox';
 import Link from 'next/link';
 import Head from 'next/head';
 import { Delegate } from 'types/delegate';
-import DelegateDetail from '../../components/delegations/DelegateDetail';
-import { fetchDelegate, fetchDelegates } from '../../lib/delegates/fetchDelegates';
+import DelegateDetail from '../../../components/delegations/DelegateDetail';
+import { fetchDelegate, fetchDelegates } from '../../../lib/delegates/fetchDelegates';
 import { getNetwork } from 'lib/maker';
 import { useBreakpointIndex } from '@theme-ui/match-media';
+import { SupportedNetworks } from 'lib/constants';
 
 const DelegateView = ({ delegate }: { delegate: Delegate }) => {
   const network = getNetwork();
@@ -68,7 +69,7 @@ export default function DelegatesPage({ delegate }: { delegate?: Delegate }): JS
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const delegate = await fetchDelegate(params?.address as string);
+  const delegate = await fetchDelegate(params?.address as string, params?.network as SupportedNetworks);
 
   if (!delegate) {
     return { revalidate: 30, props: { delegate: null } };
@@ -83,11 +84,13 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const delegates = await fetchDelegates();
-  const paths = delegates.map(d => `/delegates/${d.voteDelegateAddress}`);
+  const delegatesMainnet = await fetchDelegates(SupportedNetworks.MAINNET);
+  const delegatesKovan = await fetchDelegates(SupportedNetworks.KOVAN);
+  const pathsMainnet = delegatesMainnet.map(d => `/delegates/mainnet/${d.voteDelegateAddress}`);
+  const pathsKovan = delegatesKovan.map(d => `/delegates/kovan/${d.voteDelegateAddress}`);
 
   return {
-    paths,
+    paths: pathsMainnet.concat(pathsKovan),
     fallback: true
   };
 };

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -17,7 +17,6 @@ import DelegateCard from 'components/delegations/DelegateCard';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/utils';
-import { fsCacheDel } from 'lib/fscache';
 
 type Props = {
   delegates: Delegate[];

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -16,6 +16,7 @@ import ResourceBox from 'components/ResourceBox';
 import DelegateCard from 'components/delegations/DelegateCard';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
 import { getNetwork } from 'lib/maker';
+import { fetchJson } from 'lib/utils';
 
 type Props = {
   delegates: Delegate[];
@@ -111,9 +112,10 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
   // fetch delegates at run-time if on any network other than the default
   useEffect(() => {
     if (!isDefaultNetwork()) {
-      fetchDelegates(getNetwork()).then(_setDelegates).catch(setError);
+      fetchJson(`/api/delegates?network=${getNetwork()}`).then(_setDelegates).catch(setError);
     }
   }, []);
+
 
   if (error) {
     return <ErrorPage statusCode={404} title="Error fetching delegates" />;
@@ -132,7 +134,7 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
 
 export const getStaticProps: GetStaticProps = async () => {
   const delegates = await fetchDelegates();
-
+  
   return {
     revalidate: 30, // allow revalidation every 30 seconds
     props: {

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -116,7 +116,6 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
     }
   }, []);
 
-
   if (error) {
     return <ErrorPage statusCode={404} title="Error fetching delegates" />;
   }
@@ -134,7 +133,7 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
 
 export const getStaticProps: GetStaticProps = async () => {
   const delegates = await fetchDelegates();
-  
+
   return {
     revalidate: 30, // allow revalidation every 30 seconds
     props: {

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -17,6 +17,7 @@ import DelegateCard from 'components/delegations/DelegateCard';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/utils';
+import { fsCacheDel } from 'lib/fscache';
 
 type Props = {
   delegates: Delegate[];
@@ -132,6 +133,7 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
 }
 
 export const getStaticProps: GetStaticProps = async () => {
+
   const delegates = await fetchDelegates();
 
   return {

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -15,6 +15,7 @@ import SystemStatsSidebar from 'components/SystemStatsSidebar';
 import ResourceBox from 'components/ResourceBox';
 import DelegateCard from 'components/delegations/DelegateCard';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
+import { getNetwork } from 'lib/maker';
 
 type Props = {
   delegates: Delegate[];
@@ -110,7 +111,7 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
   // fetch delegates at run-time if on any network other than the default
   useEffect(() => {
     if (!isDefaultNetwork()) {
-      fetchDelegates().then(_setDelegates).catch(setError);
+      fetchDelegates(getNetwork()).then(_setDelegates).catch(setError);
     }
   }, []);
 

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -133,7 +133,6 @@ export default function DelegatesPage({ delegates }: Props): JSX.Element {
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-
   const delegates = await fetchDelegates();
 
   return {

--- a/types/delegate.d.ts
+++ b/types/delegate.d.ts
@@ -9,7 +9,7 @@ export type DelegateRepoInformation = {
 };
 
 export type DelegateContractInformation = {
-  delegateAddress: string;
+  address: string;
   voteDelegateAddress: string;
   blockTimestamp: Date;
 };
@@ -17,7 +17,7 @@ export type DelegateContractInformation = {
 export type Delegate = {
   id: string;
   name: string;
-  delegateAddress: string;
+  address: string;
   voteDelegateAddress: string;
   description: string;
   picture: string;


### PR DESCRIPTION

### What does this PR do?

- Fetches kovan delegates from https://github.com/makerdao-dux/voting-delegates
- Fetches kovan and mainnet delegates from serverside paths. Disabling clientside fetching and minimizing the number of requests.
- Remove last voted date 
- ⚠️ Introduces `getMaker(network)` that returns a instance of maker for the specified network. This is usefull to fetch server side kovan information
- Adds styles for tables for markdown rendering as suggested by @LongForWisdom
- Separate FScache into a module, add expiration date
- Fetch delegates through API requests on client side (with the cache included)

### Steps for testing:

1. Go to delegates page in kovan
2. See a recognized delegate and can access to their profile

1. See that http://localhost:3000/api/delegates?network=kovan works
2. See that http://localhost:3000/api/delegates/0xc8829647c8e4131a01354ccac993388568d12d00?network=kovan works
3. See that cache is being regenerated/dumped for delegates API every 30 seconds

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/1152768/125667472-68b7f418-41cb-4fd3-8304-83526b9dc2b6.png)

![image](https://user-images.githubusercontent.com/1152768/125667502-c4d6e078-5dec-4a03-8264-e940b961851b.png)

![image](https://user-images.githubusercontent.com/1152768/125761883-7f8d18d2-8bc6-4a94-829d-699050b8a9de.png)

