### PR TITLE
Fix exec status issue and refactor into helper

### DIFF
--- a/components/executive/ExecutiveOverviewCard.tsx
+++ b/components/executive/ExecutiveOverviewCard.tsx
@@ -10,7 +10,7 @@ import mixpanel from 'mixpanel-browser';
 import { getNetwork } from 'lib/maker';
 import { formatDateWithTime } from 'lib/utils';
 import { useVotedProposals } from 'lib/hooks';
-import { SPELL_SCHEDULED_DATE_OVERRIDES } from 'lib/constants';
+import { getStatusText } from 'lib/executive/getStatusText';
 import useAccountsStore from 'stores/accounts';
 import { ZERO_ADDRESS } from 'stores/accounts';
 import Stack from 'components/layouts/Stack';
@@ -179,30 +179,9 @@ export default function ExecutiveOverviewCard({ proposal, spellData, isHat, ...p
         )}
         <Divider my={0} />
         <Flex p={3} sx={{ justifyContent: 'center' }}>
-          {proposal.address === ZERO_ADDRESS ? (
-            <Text sx={{ fontSize: [2, 3], color: 'onSecondary' }}>
-              This proposal surpased the 80,000 MKR threshold on {formatDateWithTime(1607704862000)} – the new
-              chief has been activated!
-            </Text>
-          ) : spellData && spellData.hasBeenScheduled ? (
-            <Text sx={{ fontSize: [2, 3], color: 'onSecondary' }}>
-              Passed on {formatDateWithTime(spellData.datePassed)}.{' '}
-              {typeof spellData.dateExecuted === 'string' ? (
-                <>Executed on {formatDateWithTime(spellData.dateExecuted)}.</>
-              ) : (
-                <>
-                  Available for execution on{' '}
-                  {SPELL_SCHEDULED_DATE_OVERRIDES[proposal.address] ||
-                    formatDateWithTime(spellData.nextCastTime || spellData.eta)}
-                  .
-                </>
-              )}
-            </Text>
-          ) : (
-            <Text sx={{ fontSize: [2, 3], color: 'onSecondary' }}>
-              This proposal has not yet passed and is not available for execution.
-            </Text>
-          )}
+          <Text sx={{ fontSize: [2, 3], color: 'onSecondary' }}>
+            {getStatusText(proposal.address, spellData)}
+          </Text>
         </Flex>
       </Card>
     </Link>

--- a/lib/executive/getStatusText.ts
+++ b/lib/executive/getStatusText.ts
@@ -1,0 +1,29 @@
+import { formatDateWithTime } from 'lib/utils';
+import { SPELL_SCHEDULED_DATE_OVERRIDES } from 'lib/constants';
+import { SpellData } from 'types/spellData';
+import { ZERO_ADDRESS } from 'stores/accounts';
+
+export const getStatusText = (proposalAddress: string, spellData?: SpellData): string => {
+  if (!spellData) return 'Fetching status...';
+
+  if (proposalAddress === ZERO_ADDRESS) {
+    return `This proposal surpased the 80,000 MKR threshold on ${formatDateWithTime(1607704862000)} – the new
+    chief has been activated!`;
+  }
+
+  if (spellData.hasBeenScheduled || spellData.dateExecuted) {
+    if (typeof spellData.dateExecuted === 'string') {
+      return `Passed on ${formatDateWithTime(spellData.datePassed)}. Executed on ${formatDateWithTime(
+        spellData.dateExecuted
+      )}.`;
+    } else {
+      return `Passed on ${formatDateWithTime(spellData.datePassed)}. Available for execution on
+      ${
+        SPELL_SCHEDULED_DATE_OVERRIDES[proposalAddress] ||
+        formatDateWithTime(spellData.nextCastTime || spellData.eta)
+      }
+      .`;
+    }
+  }
+  return 'This proposal has not yet passed and is not available for execution.';
+};


### PR DESCRIPTION
### Link to Clubhouse story

n/a

### What does this PR do?

Fixes an issue where we weren't showing that an executive had been previously executed.

Refactors status logic that was being used in multiple places into a single helper.

### Steps for testing:

1. Go to `/executive`
2. Scroll down to the Dec 11 exec (governing proposal)
3. Verify it now shows when it was executed


### Screenshots (if relevant):

Before:
<img width="802" alt="Screen Shot 2021-07-15 at 12 27 16 PM" src="https://user-images.githubusercontent.com/5225766/125773956-4ce0fb42-0557-4969-a0c9-cbda82e107e2.png">

After:
<img width="803" alt="Screen Shot 2021-07-15 at 12 10 57 PM" src="https://user-images.githubusercontent.com/5225766/125773974-dd5e138a-ed6b-4b7b-bf06-d1d77ffc4f63.png">

### Random GIF:

![](https://media.giphy.com/media/rdma0nDFZMR32/giphy.gif)
