### PR TITLE
Remove time from executive posted date

### DIFF
--- a/components/executive/ExecutiveOverviewCard.tsx
+++ b/components/executive/ExecutiveOverviewCard.tsx
@@ -9,7 +9,7 @@ import Bignumber from 'bignumber.js';
 
 import { Proposal } from 'types/proposal';
 import getMaker, { getNetwork } from 'lib/maker';
-import { formatDateWithTime } from 'lib/utils';
+import { formatDateWithTime, formatDateWithoutTime } from 'lib/utils';
 import Stack from '../layouts/Stack';
 import useAccountsStore from 'stores/accounts';
 import VoteModal from './VoteModal';
@@ -83,7 +83,7 @@ export default function ExecutiveOverviewCard({ proposal, spellData, isHat, ...p
           <Stack gap={2}>
             <Flex sx={{ justifyContent: 'space-between', flexDirection: 'row', flexWrap: 'nowrap' }}>
               <Text variant="caps" sx={{ color: 'mutedAlt' }}>
-                posted {formatDateWithTime(proposal.date)}
+                posted {formatDateWithoutTime(proposal.date)}
               </Text>
             </Flex>
             <Box>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -244,6 +244,22 @@ export const formatDateWithTime = dateString => {
   }
 };
 
+export const formatDateWithoutTime = dateString => {
+  if (!dateString) return;
+  const date = new Date(dateString);
+  const options = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  };
+  try {
+    return new Intl.DateTimeFormat('en-US', options).format(date);
+  } catch (err) {
+    console.error(err);
+    return '??';
+  }
+};
+
 export async function initTestchainPolls() {
   const maker = await getMaker();
   const pollingService = maker.service('govPolling');


### PR DESCRIPTION
### What does this PR do?

Fixes issue that was brought up in Rocket Chat (confirmed desired fix with LFW):

Removes timestamp from executive posted date on overview card (instead of showing `0:00 UTC` for all)

### Steps for testing:

1. Go to `/executive`
2. See that the posted date on each card no longer shows the timestamp

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Screenshots (if relevant):

Before:
<img width="742" alt="Screen Shot 2021-07-16 at 1 23 26 PM" src="https://user-images.githubusercontent.com/5225766/125940348-9d5e28c4-d567-48b2-9810-97b12cf017b6.png">

After:
<img width="750" alt="Screen Shot 2021-07-16 at 1 23 56 PM" src="https://user-images.githubusercontent.com/5225766/125940392-f91c8562-c219-42d9-8728-886dd553a5f8.png">


