### PR TITLE
Fix/delegate state update create

### DIFF
--- a/pages/delegates/me.tsx
+++ b/pages/delegates/me.tsx
@@ -20,7 +20,11 @@ import TxDisplay from 'components/delegations/modals/TxDisplay';
 
 const CreateDelegate = (): JSX.Element => {
   const bpi = useBreakpointIndex();
-  const [account, voteDelegate] = useAccountsStore(state => [state.currentAccount, state.voteDelegate]);
+  const [account, voteDelegate, setVoteDelegate] = useAccountsStore(state => [
+    state.currentAccount,
+    state.voteDelegate,
+    state.setVoteDelegate
+  ]);
   const address = account?.address;
   const [txId, setTxId] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -36,6 +40,7 @@ const CreateDelegate = (): JSX.Element => {
     const txId = await track(createTxCreator, 'Create delegate contract', {
       mined: txId => {
         transactionsApi.getState().setMessage(txId, 'Delegate contract created');
+        setVoteDelegate(maker.currentAccount().address);
       },
       error: () => {
         transactionsApi.getState().setMessage(txId, 'Delegate contract failed');

--- a/pages/delegates/me.tsx
+++ b/pages/delegates/me.tsx
@@ -59,7 +59,7 @@ const CreateDelegate = (): JSX.Element => {
       <SidebarLayout>
         {!address ? (
           <Text>Connect your wallet to create a delegate contract</Text>
-        ) : voteDelegate ? (
+        ) : voteDelegate && !modalOpen ? (
           <Box>
             <Text>Your delegate contract address:</Text>
             <ExternalLink

--- a/stores/accounts.ts
+++ b/stores/accounts.ts
@@ -29,6 +29,7 @@ type Store = {
   oldProxy: OldVoteProxy;
   // TODO type this
   voteDelegate: any;
+  setVoteDelegate: (address: string) => Promise<void>;
   addAccountsListener: () => Promise<void>;
   disconnectAccount: () => Promise<void>;
 };
@@ -66,13 +67,22 @@ const [useAccountsStore, accountsApi] = create<Store>((set, get) => ({
         getOldProxyStatus(address, maker)
       ]);
 
-      const { voteDelegate } = await maker.service('voteDelegateFactory').getVoteDelegate(address);
+      await get().setVoteDelegate(address);
+
       set({
         currentAccount: account,
         proxies: { ...get().proxies, [address]: hasProxy ? voteProxy : null },
-        oldProxy,
-        voteDelegate
+        oldProxy
       });
+    });
+  },
+
+  setVoteDelegate: async address => {
+    const maker = await getMaker();
+    const { voteDelegate } = await maker.service('voteDelegateFactory').getVoteDelegate(address);
+
+    set({
+      voteDelegate: voteDelegate ?? undefined
     });
   },
 


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/295/create-delegate-modal-hangs-after-signing-tx

-

### What does this PR do?

After a creating a vote delegate, the setter for vote delegate was not being called because it was inside an event listener listening for `accounts/CHANGE`, which is not emitted.

Adds a setter for Vote Delegate that is called after the create delegate transaction is mined.

-

### Steps for testing:

1. Connect a wallet that is not a vote delegate
2. Run through the create process
3. See the confirmation modal with the green check

OR

run the delegates/me.tsx test (not included in this PR)