### PR TITLE
feat: Represent link to external profile

### DIFF
--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -34,17 +34,16 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
           </ExternalLink>
         </Box>
 
-        {delegate.externalUrl && <Flex sx={{ alignItems: 'flex-end' }}>
-          <ExternalLink
-            title="See external profile"
-            href={delegate.externalUrl}
-            target="_blank" >
-              <Text sx={{ fontSize: 1}}>
+        {delegate.externalUrl && (
+          <Flex sx={{ alignItems: 'flex-end' }}>
+            <ExternalLink title="See external profile" href={delegate.externalUrl} target="_blank">
+              <Text sx={{ fontSize: 1 }}>
                 See external profile
                 <Icon ml={2} name="arrowTopRight" size={2} />
               </Text>
-              </ExternalLink>
-          </Flex>}
+            </ExternalLink>
+          </Flex>
+        )}
       </Box>
       <Box sx={{ p: 3 }}>
         <div

--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
-import { jsx, Box, Text, Link as ExternalLink, Divider } from 'theme-ui';
+import { jsx, Box, Text, Link as ExternalLink, Divider, Flex } from 'theme-ui';
 import React from 'react';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
 import { Delegate } from 'types/delegate';
 import { DelegatePicture, DelegateContractExpiration, DelegateLastVoted } from 'components/delegations';
+import { Icon } from '@makerdao/dai-ui-icons';
 
 type PropTypes = {
   delegate: Delegate;
@@ -32,6 +33,18 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
             </Text>
           </ExternalLink>
         </Box>
+
+        {delegate.externalUrl && <Flex sx={{ alignItems: 'flex-end' }}>
+          <ExternalLink
+            title="See external profile"
+            href={delegate.externalUrl}
+            target="_blank" >
+              <Text sx={{ fontSize: 1}}>
+                See external profile
+                <Icon ml={2} name="arrowTopRight" size={2} />
+              </Text>
+              </ExternalLink>
+          </Flex>}
       </Box>
       <Box sx={{ p: 3 }}>
         <div

--- a/lib/delegates/fetchDelegates.ts
+++ b/lib/delegates/fetchDelegates.ts
@@ -24,6 +24,7 @@ function mergeDelegateInfo(
     name: githubDelegate?.name || '',
     picture: githubDelegate?.picture || '',
     id: onChainDelegate.voteDelegateAddress,
+    externalUrl: githubDelegate?.externalUrl,
     lastVote: new Date() // TODO: See where to get this info
   };
 }

--- a/types/delegate.d.ts
+++ b/types/delegate.d.ts
@@ -25,4 +25,5 @@ export type Delegate = {
   expired: boolean;
   lastVote: Date;
   expirationDate: Date;
+  externalUrl?: string;
 };


### PR DESCRIPTION


### What does this PR do?
Links to the external URL provided by the delegates page. 

![image](https://user-images.githubusercontent.com/1152768/126180003-c4047b55-2177-4c13-8845-0d144b627fe6.png)


### Steps for testing:

1. Go to delegates detail and see the link to the external profile
2. It should pick the information from here https://github.com/makerdao-dux/voting-delegates/tree/main/delegates/0xc8829647c8e4131a01354ccac993388568d12d00
