### PR TITLE
show vote delegate balance instead of vote proxy balance if user has …

### DIFF
--- a/components/executive/VoteModal.tsx
+++ b/components/executive/VoteModal.tsx
@@ -49,7 +49,7 @@ const VoteModal = ({ close, proposal, currentSlate = [] }: Props): JSX.Element =
 
   const addressLockedMKR =
     voteDelegate?.getVoteDelegateAddress() || voteProxy?.getProxyAddress() || account?.address;
-  const { data: lockedMkr } = useLockedMkr(addressLockedMKR, voteProxy);
+  const { data: lockedMkr } = useLockedMkr(addressLockedMKR, voteProxy, voteDelegate);
 
   const { data: spellData } = useSpellData(proposal.address);
 

--- a/components/executive/Withdraw.tsx
+++ b/components/executive/Withdraw.tsx
@@ -185,7 +185,7 @@ const ModalContent = ({ address, voteProxy, voteDelegate, close, ...props }) => 
 const Withdraw = (props): JSX.Element => {
   const account = useAccountsStore(state => state.currentAccount);
   const [voteProxy, voteDelegate] = useAccountsStore(state =>
-    account ? [state.proxies[account.address], state.voteDelegate] : null
+    account ? [state.proxies[account.address], state.voteDelegate] : [null, null]
   );
 
   const [showDialog, setShowDialog] = useState(false);

--- a/components/executive/Withdraw.tsx
+++ b/components/executive/Withdraw.tsx
@@ -19,7 +19,7 @@ import mixpanel from 'mixpanel-browser';
 import { BoxWithClose } from 'components/BoxWithClose';
 import { useLockedMkr } from 'lib/hooks';
 
-const ModalContent = ({ address, voteProxy, close, ...props }) => {
+const ModalContent = ({ address, voteProxy, voteDelegate, close, ...props }) => {
   invariant(address);
   const [mkrToWithdraw, setMkrToWithdraw] = useState(MKR(0));
   const [txId, setTxId] = useState(null);
@@ -37,7 +37,7 @@ const ModalContent = ({ address, voteProxy, close, ...props }) => {
         .then(val => val?.gt('10e26')) // greater than 100,000,000 MKR
   );
 
-  const { data: lockedMkr } = useLockedMkr(address, voteProxy);
+  const { data: lockedMkr } = useLockedMkr(address, voteProxy, voteDelegate);
 
   const [track, tx] = useTransactionStore(
     state => [state.track, txId ? transactionsSelectors.getTransaction(state, txId) : null],
@@ -184,7 +184,9 @@ const ModalContent = ({ address, voteProxy, close, ...props }) => {
 
 const Withdraw = (props): JSX.Element => {
   const account = useAccountsStore(state => state.currentAccount);
-  const voteProxy = useAccountsStore(state => (account ? state.proxies[account.address] : null));
+  const [voteProxy, voteDelegate] = useAccountsStore(state =>
+    account ? [state.proxies[account.address], state.voteDelegate] : null
+  );
 
   const [showDialog, setShowDialog] = useState(false);
   const bpi = useBreakpointIndex();
@@ -214,6 +216,7 @@ const Withdraw = (props): JSX.Element => {
             sx={{ px: [3, null] }}
             address={account?.address}
             voteProxy={voteProxy}
+            voteDelegate={voteDelegate}
             close={() => setShowDialog(false)}
           />
         </DialogContent>

--- a/lib/hooks/useLockedMkr.ts
+++ b/lib/hooks/useLockedMkr.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import getMaker from 'lib/maker';
 import { CurrencyObject } from 'types/currency';
+import { Delegate } from 'types/delegate';
 
 type LockedMkrData = {
   data?: CurrencyObject;
@@ -8,10 +9,10 @@ type LockedMkrData = {
   error?: Error;
 };
 
-export const useLockedMkr = (address: string, voteProxy?: any): LockedMkrData => {
+export const useLockedMkr = (address: string, voteProxy?: any, voteDelegate?: Delegate): LockedMkrData => {
   const { data, error } = useSWR(address ? ['/user/mkr-locked', address] : null, () =>
     getMaker().then(maker =>
-      voteProxy ? voteProxy.getNumDeposits() : maker.service('chief').getNumDeposits(address)
+      voteProxy && !voteDelegate ? voteProxy.getNumDeposits() : maker.service('chief').getNumDeposits(address)
     )
   );
 

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -96,7 +96,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals: Proposal[] }): JSX
   const loader = useRef<HTMLDivElement>(null);
 
   const address = voteDelegate?.getVoteDelegateAddress() || voteProxy?.getProxyAddress() || account?.address;
-  const { data: lockedMkr } = useLockedMkr(address, voteProxy);
+  const { data: lockedMkr } = useLockedMkr(address, voteProxy, voteDelegate);
 
   const lockedMkrKeyOldChief = oldProxyAddress || account?.address;
   const { data: lockedMkrOldChief } = useSWR(


### PR DESCRIPTION
…both

### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/324/vote-proxy-balance-is-shown-on-executive-page-instead-of-vote-delegate-balance-if-user-has-both

### What does this PR do?

Problem:
A user reported that their vote proxy balance was being shown on the executive page even after they created a vote delegate contract.

Fix:
In the use `useLockedMkr` we now only show the vote proxy balance if the user does *not* have a vote delegate contract. Otherwise we show the vote delegate contract balance (ie maker locked in chief by vote delegate address).

Also updates the `useLockedMkr` hook in the other places it is used.

### Steps for testing:

1. Start with an account that has both a vote proxy & vote delegate contract
2. View the executive page and notice the balance shown is your vote delegate balance

The user who reached out to me offered to do further testing after we implemented a fix, I'll reach out to them since I can't get a vote proxy created on v1 anymore.

### Additional information:

**We should probably align with each other if this is the preferred behavior before merging**

