### PR TITLE
Delegate list updates

### DIFF
--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -33,7 +33,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
 
   const { data: mkrStaked } = useMkrDelegated(address, delegate.voteDelegateAddress);
 
-  const showLinkToDetail = delegate.status === DelegateStatusEnum.active && !delegate.expired;
+  const showLinkToDetail = delegate.status === DelegateStatusEnum.recognized && !delegate.expired;
 
   const isOwner =
     delegate.voteDelegateAddress.toLowerCase() === voteDelegate?.getVoteDelegateAddress().toLowerCase();

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import { Box, Flex, Button, Text, Link as ExternalLink, jsx } from 'theme-ui';
 import Link from 'next/link';
-
 import { getNetwork } from 'lib/maker';
 import { useLockedMkr, useMkrDelegated } from 'lib/hooks';
 import { limitString } from 'lib/string';

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -27,7 +27,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
   const network = getNetwork();
   const [showDelegateModal, setShowDelegateModal] = useState(false);
   const [showUndelegateModal, setShowUndelegateModal] = useState(false);
-  const account = useAccountsStore(state => state.currentAccount);
+  const [account, voteDelegate] = useAccountsStore(state => [state.currentAccount, state.voteDelegate]);
   const address = account?.address;
 
   const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
@@ -36,8 +36,11 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
 
   const showLinkToDetail = delegate.status === DelegateStatusEnum.active && !delegate.expired;
 
+  const isOwner =
+    delegate.voteDelegateAddress.toLowerCase() === voteDelegate?.getVoteDelegateAddress().toLowerCase();
+
   return (
-    <Box sx={{ variant: 'cards.primary' }}>
+    <Box sx={{ variant: isOwner ? 'cards.emphasized' : 'cards.primary' }}>
       <Flex
         sx={{
           flexDirection: ['column', 'column', 'row', 'column', 'row']

--- a/components/delegations/DelegatePicture.tsx
+++ b/components/delegations/DelegatePicture.tsx
@@ -13,7 +13,7 @@ export function DelegatePicture({ delegate }: { delegate: Delegate }): React.Rea
           borderRadius: '100%'
         }}
       />
-      {delegate.status === DelegateStatusEnum.active && (
+      {delegate.status === DelegateStatusEnum.recognized && (
         <Image
           src="/assets/verified-check.svg"
           sx={{

--- a/lib/common/shuffleArray.ts
+++ b/lib/common/shuffleArray.ts
@@ -1,0 +1,8 @@
+export const shuffleArray = <Type>(array: Type[]): Type[] => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+
+  return array;
+};

--- a/lib/delegates/constants.ts
+++ b/lib/delegates/constants.ts
@@ -1,5 +1,5 @@
 export enum DelegateStatusEnum {
-  active = 'active',
+  recognized = 'recognized',
   expired = 'expired',
-  unrecognized = 'unrecognized'
+  shadow = 'shadow'
 }

--- a/lib/delegates/fetchDelegates.ts
+++ b/lib/delegates/fetchDelegates.ts
@@ -17,7 +17,7 @@ function mergeDelegateInfo(
   return {
     voteDelegateAddress: onChainDelegate.voteDelegateAddress,
     address: onChainDelegate.address,
-    status: githubDelegate ? DelegateStatusEnum.active : DelegateStatusEnum.unrecognized,
+    status: githubDelegate ? DelegateStatusEnum.recognized : DelegateStatusEnum.shadow,
     expired: isExpired,
     expirationDate: expirationDate.toDate(),
     description: githubDelegate?.description || '',

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -68,6 +68,11 @@ export default {
     tight: {
       variant: 'cards.primary',
       p: [2, 2]
+    },
+    emphasized: {
+      variant: 'cards.primary',
+      border: '1px solid',
+      borderColor: 'onSecondary'
     }
   },
   modal: {

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -18,6 +18,7 @@ import { DelegateCard } from 'components/delegations';
 import PageLoadingPlaceholder from 'components/PageLoadingPlaceholder';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/utils';
+import useAccountsStore from 'stores/accounts';
 
 type Props = {
   delegates: Delegate[];
@@ -29,14 +30,16 @@ const Delegates = ({ delegates }: Props) => {
       marginBottom: 2
     }
   };
-
+  const voteDelegate = useAccountsStore(state => state.voteDelegate);
+  const isOwner = d =>
+    d.voteDelegateAddress.toLowerCase() === voteDelegate?.getVoteDelegateAddress().toLowerCase();
   const expiredDelegates = delegates.filter(delegate => delegate.expired === true);
-  const activeDelegates = shuffleArray(
-    delegates.filter(delegate => delegate.status === DelegateStatusEnum.active && !delegate.expired)
-  );
-  const unrecognizedDelegates = shuffleArray(
-    delegates.filter(delegate => delegate.status === DelegateStatusEnum.unrecognized && !delegate.expired)
-  );
+  const recognizedDelegates = shuffleArray(
+    delegates.filter(delegate => delegate.status === DelegateStatusEnum.recognized && !delegate.expired)
+  ).sort(d => (isOwner(d) ? -1 : 0));
+  const shadowDelegates = shuffleArray(
+    delegates.filter(delegate => delegate.status === DelegateStatusEnum.shadow && !delegate.expired)
+  ).sort(d => (isOwner(d) ? -1 : 0));
 
   return (
     <PrimaryLayout shortenFooter={true} sx={{ maxWidth: [null, null, null, 'page', 'dashboard'] }}>
@@ -47,14 +50,14 @@ const Delegates = ({ delegates }: Props) => {
       <SidebarLayout>
         <Box>
           {delegates && delegates.length === 0 && <Text>No delegates found</Text>}
-          {activeDelegates.length > 0 && (
+          {recognizedDelegates.length > 0 && (
             <Box sx={styles.delegateGroup}>
               <Heading mb={3} mt={4} as="h4">
                 Recognized delegates
               </Heading>
 
               <Box>
-                {activeDelegates.map(delegate => (
+                {recognizedDelegates.map(delegate => (
                   <Box key={delegate.id} sx={{ mb: 4 }}>
                     <DelegateCard delegate={delegate} />
                   </Box>
@@ -63,14 +66,14 @@ const Delegates = ({ delegates }: Props) => {
             </Box>
           )}
 
-          {unrecognizedDelegates.length > 0 && (
+          {shadowDelegates.length > 0 && (
             <Box sx={styles.delegateGroup}>
               <Heading mb={3} mt={4} as="h4">
                 Shadow Delegates
               </Heading>
 
               <Box>
-                {unrecognizedDelegates.map(delegate => (
+                {shadowDelegates.map(delegate => (
                   <Box key={delegate.id} sx={{ mb: 4 }}>
                     <DelegateCard delegate={delegate} />
                   </Box>

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -7,6 +7,7 @@ import ErrorPage from 'next/error';
 import { isDefaultNetwork } from 'lib/maker';
 import { fetchDelegates } from 'lib/delegates/fetchDelegates';
 import { DelegateStatusEnum } from 'lib/delegates/constants';
+import { shuffleArray } from 'lib/common/shuffleArray';
 import { Delegate } from 'types/delegate';
 import PrimaryLayout from 'components/layouts/Primary';
 import SidebarLayout from 'components/layouts/Sidebar';
@@ -30,11 +31,11 @@ const Delegates = ({ delegates }: Props) => {
   };
 
   const expiredDelegates = delegates.filter(delegate => delegate.expired === true);
-  const activeDelegates = delegates.filter(
-    delegate => delegate.status === DelegateStatusEnum.active && !delegate.expired
+  const activeDelegates = shuffleArray(
+    delegates.filter(delegate => delegate.status === DelegateStatusEnum.active && !delegate.expired)
   );
-  const unrecognizedDelegates = delegates.filter(
-    delegate => delegate.status === DelegateStatusEnum.unrecognized && !delegate.expired
+  const unrecognizedDelegates = shuffleArray(
+    delegates.filter(delegate => delegate.status === DelegateStatusEnum.unrecognized && !delegate.expired)
   );
 
   return (

--- a/types/delegate.d.ts
+++ b/types/delegate.d.ts
@@ -1,4 +1,4 @@
-export type DelegateStatus = 'active' | 'expired' | 'unrecognized';
+export type DelegateStatus = 'recognized' | 'expired' | 'shadow';
 
 export type DelegateRepoInformation = {
   voteDelegateAddress: string;


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/326/randomize-order-of-delegates
https://app.clubhouse.io/dux-makerdao/story/327/emphasize-border-of-delegate-card-if-owner

### What does this PR do?

Adds emphasis to a delegate card if the connected account is the owner

Randomizes the order of the recognized and shadow delegates sections

### Steps for testing:

1. Go to `/delegates` with a user that owns a delegate contract
2. Ensure that border shows emphasis
3. Ensure the order of the delegates in each section is randomized each time the page loads

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Screenshots (if relevant):

<img width="1001" alt="Screen Shot 2021-07-21 at 2 44 00 PM" src="https://user-images.githubusercontent.com/5225766/126490438-588d466e-c434-425c-aee9-67a8a2fb3b18.png">

### Additional information:

<!-- Any other information and context that is important to this PR -->

-

### Random GIF:

![](https://media.giphy.com/media/l41Ys1fQky5raqvMQ/giphy.gif)
