### PR TITLE
add hook for mixpanel tracking, use in delegates.tsx

### DIFF
--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -3,12 +3,12 @@
 import React, { useState } from 'react';
 import { Box, Flex, Button, Text, Link as ExternalLink, jsx } from 'theme-ui';
 import Link from 'next/link';
-import mixpanel from 'mixpanel-browser';
 import { getNetwork } from 'lib/maker';
-import { useLockedMkr, useMkrDelegated } from 'lib/hooks';
+import { useLockedMkr, useMkrDelegated, useAnalytics } from 'lib/hooks';
 import { limitString } from 'lib/string';
 import { getEtherscanLink } from 'lib/utils';
 import { DelegateStatusEnum } from 'lib/delegates/constants';
+import { trackingPages } from 'lib/constants';
 import useAccountsStore from 'stores/accounts';
 import { Delegate } from 'types/delegate';
 import {
@@ -33,6 +33,8 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
   const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
 
   const { data: mkrStaked } = useMkrDelegated(address, delegate.voteDelegateAddress);
+
+  const { trackBtnClick } = useAnalytics(trackingPages.DELEGATES);
 
   const showLinkToDetail = delegate.status === DelegateStatusEnum.recognized && !delegate.expired;
 
@@ -142,11 +144,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                 variant="primaryOutline"
                 disabled={!account}
                 onClick={() => {
-                  mixpanel.track('btn-click', {
-                    id: 'openUndelegateModal',
-                    product: 'governance-portal-v2',
-                    page: 'Delegates'
-                  });
+                  trackBtnClick('openUndelegateModal');
                   setShowUndelegateModal(true);
                 }}
                 sx={{ width: '150px', mt: [4, 4, 0, 4, 0] }}
@@ -183,11 +181,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                 variant="primaryLarge"
                 disabled={!account}
                 onClick={() => {
-                  mixpanel.track('btn-click', {
-                    id: 'openDelegateModal',
-                    product: 'governance-portal-v2',
-                    page: 'Delegates'
-                  });
+                  trackBtnClick('openDelegateModal');
                   setShowDelegateModal(true);
                 }}
                 sx={{ width: '150px', mt: [4, 4, 0, 4, 0] }}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -4,13 +4,13 @@ import { config } from './config';
 const analyticsConfig = {
   development: {
     mixpanel: {
-      token: '4ff3f85397ffc3c6b6f0d4120a4ea40a',
+      token: config.MIXPANEL_DEV,
       config: { debug: true, ip: false, api_host: 'https://api.mixpanel.com' }
     }
   },
   production: {
     mixpanel: {
-      token: 'a030d8845e34bfdc11be3d9f3054ad67',
+      token: config.MIXPANEL_PROD,
       config: { ip: false, api_host: 'https://api.mixpanel.com' }
     }
   }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,6 +10,8 @@ type SystemConfig = {
   NODE_ENV: 'development' | 'production' | 'test';
   TESTNET: string;
   GITHUB_TOKEN: string;
+  MIXPANEL_PROD: string;
+  MIXPANEL_DEV: string;
 };
 
 export const config: SystemConfig = {
@@ -23,5 +25,7 @@ export const config: SystemConfig = {
   MONGODB_COMMENTS_DB: process.env.MONGODB_COMMENTS_DB || '',
   NODE_ENV: process.env.NODE_ENV || 'development',
   TESTNET: process.env.TESTNET || '',
-  GITHUB_TOKEN: process.env.GITHUB_TOKEN || ''
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
+  MIXPANEL_PROD: process.env.NEXT_PUBLIC_MIXPANEL_PROD || '',
+  MIXPANEL_DEV: process.env.NEXT_PUBLIC_MIXPANEL_DEV || ''
 };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -60,3 +60,7 @@ export const URL_REGEX = new RegExp(expr);
 
 export const EXEC_PROPOSAL_INDEX =
   'https://raw.githubusercontent.com/makerdao/community/master/governance/votes/active/proposals.json';
+
+export const trackingPages = {
+  DELEGATES: 'Delegates'
+};

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useVotedProposals';
 export * from './useSpellData';
 export * from './useHat';
 export * from './useAllSlates';
+export * from './useAnalytics';

--- a/lib/hooks/useAnalytics.ts
+++ b/lib/hooks/useAnalytics.ts
@@ -1,0 +1,26 @@
+import mixpanel from 'mixpanel-browser';
+const PRODUCT = 'governance-portal-v2';
+
+type MixpanelTrackFunctions = {
+  trackBtnClick: (id: string) => void;
+  trackInputChange: (id: string) => void;
+};
+
+export const useAnalytics = (page: string): MixpanelTrackFunctions => {
+  const trackBtnClick = (id: string): void => {
+    mixpanel.track('btn-click', {
+      id,
+      product: PRODUCT,
+      page
+    });
+  };
+  const trackInputChange = (id: string): void => {
+    mixpanel.track('input-change', {
+      id,
+      product: PRODUCT,
+      page
+    });
+  };
+
+  return { trackBtnClick, trackInputChange };
+};


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/201/mixpanel-configuration

### What does this PR do?

- Adds a custom hook to make mixpanel tracking easier/cleaner.
- Add new API keys to the ENV and remove the old ones from the codebase.

### Steps for testing:

1. Click some buttons
2. Go to mixpanel dashboard and see that your clicks were tracked.

### Screenshots (if relevant):

![Screen Shot 2021-07-29 at 6 03 36 PM](https://user-images.githubusercontent.com/13105602/127580427-2e214f55-aed3-4f51-b4ce-f71200a4aff7.png)

