### PR TITLE
move 'see external profile' to right side

### DIFF
--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -17,33 +17,34 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
     <Box sx={{ variant: 'cards.primary', p: [0, 0] }}>
       <Box sx={{ display: 'flex', p: 3 }}>
         <DelegatePicture delegate={delegate} key={delegate.id} />
-
-        <Box sx={{ ml: 2 }}>
-          <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }}>
-            {delegate.name}
-          </Text>
-          <ExternalLink
-            title="View on etherescan"
-            href={getEtherscanLink(getNetwork(), voteDelegateAddress, 'address')}
-            target="_blank"
-          >
-            <Text as="p">
-              {voteDelegateAddress.substr(0, 6)}...
-              {voteDelegateAddress.substr(voteDelegateAddress.length - 5, voteDelegateAddress.length - 1)}
+        <Flex sx={{ justifyContent: 'space-between', width: '100%' }}>
+          <Box sx={{ ml: 2 }}>
+            <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }}>
+              {delegate.name}
             </Text>
-          </ExternalLink>
-        </Box>
-
-        {delegate.externalUrl && (
-          <Flex sx={{ alignItems: 'flex-end' }}>
-            <ExternalLink title="See external profile" href={delegate.externalUrl} target="_blank">
-              <Text sx={{ fontSize: 1 }}>
-                See external profile
-                <Icon ml={2} name="arrowTopRight" size={2} />
+            <ExternalLink
+              title="View on etherescan"
+              href={getEtherscanLink(getNetwork(), voteDelegateAddress, 'address')}
+              target="_blank"
+            >
+              <Text as="p">
+                {voteDelegateAddress.substr(0, 6)}...
+                {voteDelegateAddress.substr(voteDelegateAddress.length - 5, voteDelegateAddress.length - 1)}
               </Text>
             </ExternalLink>
-          </Flex>
-        )}
+          </Box>
+
+          {delegate.externalUrl && (
+            <Flex sx={{ alignItems: 'flex-end' }}>
+              <ExternalLink title="See external profile" href={delegate.externalUrl} target="_blank">
+                <Text sx={{ fontSize: 1 }}>
+                  See external profile
+                  <Icon ml={2} name="arrowTopRight" size={2} />
+                </Text>
+              </ExternalLink>
+            </Flex>
+          )}
+        </Flex>
       </Box>
       <Box sx={{ p: 3 }}>
         <div


### PR DESCRIPTION
### Link to Clubhouse story
https://app.clubhouse.io/dux-makerdao/story/369/fix-spacing-for-see-external-profile-on-delegate-page
### What does this PR do?
Fix spacing of 'see external profile'
<img width="397" alt="Screen Shot 2021-08-02 at 1 33 01 PM" src="https://user-images.githubusercontent.com/3388550/127921073-f748afed-74fb-4bbd-8217-f3d3a6012593.png">
<img width="961" alt="Screen Shot 2021-08-02 at 1 32 43 PM" src="https://user-images.githubusercontent.com/3388550/127921079-18234d13-05a4-4763-be76-492ca0409a89.png">
