### PR TITLE
Remove truncation of address on profile page

### DIFF
--- a/components/delegations/DelegateDetail.tsx
+++ b/components/delegations/DelegateDetail.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
-import { jsx, Box, Text, Link as ExternalLink, Divider, Flex } from 'theme-ui';
 import React from 'react';
+import { jsx, Box, Text, Link as ExternalLink, Divider, Flex } from 'theme-ui';
+import { useBreakpointIndex } from '@theme-ui/match-media';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
 import { Delegate } from 'types/delegate';
@@ -12,39 +13,40 @@ type PropTypes = {
 };
 
 export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
+  const bpi = useBreakpointIndex();
   const { voteDelegateAddress } = delegate;
   return (
     <Box sx={{ variant: 'cards.primary', p: [0, 0] }}>
-      <Box sx={{ display: 'flex', p: 3 }}>
-        <DelegatePicture delegate={delegate} key={delegate.id} />
-        <Flex sx={{ justifyContent: 'space-between', width: '100%' }}>
-          <Box sx={{ ml: 2 }}>
-            <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }}>
-              {delegate.name}
-            </Text>
-            <ExternalLink
-              title="View on etherescan"
-              href={getEtherscanLink(getNetwork(), voteDelegateAddress, 'address')}
-              target="_blank"
-            >
-              <Text as="p">
-                {voteDelegateAddress.substr(0, 6)}...
-                {voteDelegateAddress.substr(voteDelegateAddress.length - 5, voteDelegateAddress.length - 1)}
+      <Box sx={{ p: 3 }}>
+        <Flex>
+          <DelegatePicture delegate={delegate} key={delegate.id} />
+          <Box sx={{ width: '100%' }}>
+            <Box sx={{ ml: 2 }}>
+              <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }}>
+                {delegate.name}
+              </Text>
+              <ExternalLink
+                title="View on etherescan"
+                href={getEtherscanLink(getNetwork(), voteDelegateAddress, 'address')}
+                target="_blank"
+              >
+                <Text as="p" sx={{ fontSize: bpi > 0 ? 3 : 1 }}>
+                  {voteDelegateAddress}
+                </Text>
+              </ExternalLink>
+            </Box>
+          </Box>
+        </Flex>
+        {delegate.externalUrl && (
+          <Box sx={{ mt: 2 }}>
+            <ExternalLink title="See external profile" href={delegate.externalUrl} target="_blank">
+              <Text sx={{ fontSize: 1 }}>
+                See external profile
+                <Icon ml={2} name="arrowTopRight" size={2} />
               </Text>
             </ExternalLink>
           </Box>
-
-          {delegate.externalUrl && (
-            <Flex sx={{ alignItems: 'flex-end' }}>
-              <ExternalLink title="See external profile" href={delegate.externalUrl} target="_blank">
-                <Text sx={{ fontSize: 1 }}>
-                  See external profile
-                  <Icon ml={2} name="arrowTopRight" size={2} />
-                </Text>
-              </ExternalLink>
-            </Flex>
-          )}
-        </Flex>
+        )}
       </Box>
       <Box sx={{ p: 3 }}>
         <div


### PR DESCRIPTION
https://app.clubhouse.io/dux-makerdao/story/372/don-t-truncate-middle-of-delegate-address-on-profile-detail-page

Before:
<img width="420" alt="Screen Shot 2021-08-03 at 2 50 13 PM" src="https://user-images.githubusercontent.com/5225766/128018569-615b9170-9fa6-4c5b-84be-72b2312a1e4e.png">
<img width="1497" alt="Screen Shot 2021-08-03 at 2 50 02 PM" src="https://user-images.githubusercontent.com/5225766/128018586-a34fee4f-3feb-4012-b9f2-d55d0e89d9af.png">

After:
<img width="449" alt="Screen Shot 2021-08-03 at 2 48 25 PM" src="https://user-images.githubusercontent.com/5225766/128019033-95ab02ca-c303-495b-b1f4-2c9f4f211808.png">
<img width="987" alt="Screen Shot 2021-08-03 at 2 41 39 PM" src="https://user-images.githubusercontent.com/5225766/128019043-1b7b559d-504b-4fd7-ab71-b3693c45464b.png">
