### PR TITLE
Feat/delegates system info

### DIFF
--- a/__tests__/pages/delegates.tsx
+++ b/__tests__/pages/delegates.tsx
@@ -164,10 +164,10 @@ describe('Delegate Create page', () => {
     click(closeUndelegateBtn);
 
     // Voting weights are returned to 0 after undelegating
-    const newTotal = await screen.findByText(/Total MKR delegated/);
+    const newTotal = await screen.getByTestId('total-mkr-delegated');
     const newByYou = await screen.findByText(/MKR delegated by you/);
 
-    expect(newTotal.previousSibling).toHaveTextContent('0.00');
+    expect(newTotal).toHaveTextContent('0.00');
     expect(newByYou.previousSibling).toHaveTextContent('0.00');
   });
 });

--- a/__tests__/pages/delegates.tsx
+++ b/__tests__/pages/delegates.tsx
@@ -11,6 +11,8 @@ import {
 } from '../helpers';
 import { SWRConfig } from 'swr';
 import * as utils from '../../lib/utils';
+import { DelegatesAPIResponse } from 'types/delegatesAPI';
+import { DelegateStatusEnum } from 'lib/delegates/constants';
 
 const NEXT_ACCOUNT = '0x81431b69b1e0e334d4161a13c2955e0f3599381e';
 const DELEGATE_ADDRESS = '0xfcdD2B5501359B70A20e3D79Fd7C41c5155d7d07';
@@ -19,20 +21,31 @@ const MOCK_DELEGATES = [
   {
     address: DEMO_ACCOUNT_TESTS,
     description: 'I AM DELEGATEMAN',
-    expirationDate: '2022-07-08T14:00:24.000Z',
+    expirationDate: new Date('2022-07-08T14:00:24.000Z'),
     expired: false,
     id: '0xc8829647c8e4131a01354ccac993388568d12d00',
-    lastVote: '2021-07-19T23:40:18.158Z',
+    lastVote: new Date('2021-07-19T23:40:18.158Z'),
     name: 'Lee Robinson',
     picture:
       'https://raw.githubusercontent.com/makerdao-dux/voting-delegates/main/delegates/0xc8829647c8e4131a01354ccac993388568d12d00/profile.jpg',
-    status: 'recognized',
-    voteDelegateAddress: DELEGATE_ADDRESS
+    status: DelegateStatusEnum.recognized,
+    voteDelegateAddress: DELEGATE_ADDRESS,
+    mkrDelegated: 0
   }
 ];
 
+const MOCK_API_RESPONSE: DelegatesAPIResponse = {
+  delegates: MOCK_DELEGATES,
+  stats: {
+    total: 0,
+    shadow: 0,
+    recognized: 0,
+    totalMKRDelegated: 0
+  }
+};
+
 const mockGetUsers = jest.spyOn(utils, 'fetchJson');
-mockGetUsers.mockResolvedValue(MOCK_DELEGATES);
+mockGetUsers.mockResolvedValue(MOCK_API_RESPONSE);
 
 jest.mock('@theme-ui/match-media', () => {
   return {
@@ -46,7 +59,7 @@ let maker;
 async function setup(maker) {
   const view = render(
     <SWRConfig value={{ dedupingInterval: 0, refreshInterval: 10 }}>
-      <DelegatesPage delegates={[]} />
+      <DelegatesPage delegates={[]} stats={MOCK_API_RESPONSE.stats}/>
     </SWRConfig>
   );
 

--- a/__tests__/pages/delegates.tsx
+++ b/__tests__/pages/delegates.tsx
@@ -185,7 +185,7 @@ describe('Delegates list page', () => {
     expect(totalShadowDelegatesSystemInfo).toHaveTextContent('0');
     
     const totalMkr = screen.getByTestId('total-mkr-system-info');
-    expect(totalMkr).toHaveTextContent('10.00');
+    expect(totalMkr).toHaveTextContent('10.24');
     
   });
 });

--- a/__tests__/pages/delegates.tsx
+++ b/__tests__/pages/delegates.tsx
@@ -37,10 +37,10 @@ const MOCK_DELEGATES = [
 const MOCK_API_RESPONSE: DelegatesAPIResponse = {
   delegates: MOCK_DELEGATES,
   stats: {
-    total: 0,
+    total: 1,
     shadow: 0,
-    recognized: 0,
-    totalMKRDelegated: 0
+    recognized: 1,
+    totalMKRDelegated: 10.24
   }
 };
 
@@ -70,7 +70,7 @@ async function setup(maker) {
   return view;
 }
 
-describe('Delegate Create page', () => {
+describe('Delegates list page', () => {
   const mkrToDeposit = '3.2';
 
   beforeAll(async () => {
@@ -164,10 +164,28 @@ describe('Delegate Create page', () => {
     click(closeUndelegateBtn);
 
     // Voting weights are returned to 0 after undelegating
-    const newTotal = await screen.getByTestId('total-mkr-delegated');
+    const newTotal = screen.getByTestId('total-mkr-delegated');
     const newByYou = await screen.findByText(/MKR delegated by you/);
 
     expect(newTotal).toHaveTextContent('0.00');
     expect(newByYou.previousSibling).toHaveTextContent('0.00');
+  });
+
+
+  describe('Delegates system info', async () => {
+    await screen.findByText('Delegate System Info');
+    
+    const totalDelegatesSystemInfo = screen.getByTestId('total-delegates-system-info');
+    expect(totalDelegatesSystemInfo).toHaveTextContent('1');
+
+    const totalRecognizedDelegatesSystemInfo = screen.getByTestId('total-recognized-delegates-system-info');
+    expect(totalRecognizedDelegatesSystemInfo).toHaveTextContent('1');
+
+    const totalShadowDelegatesSystemInfo = screen.getByTestId('total-shadow-delegates-system-info');
+    expect(totalShadowDelegatesSystemInfo).toHaveTextContent('0');
+    
+    const totalMkr = screen.getByTestId('total-mkr-system-info');
+    expect(totalMkr).toHaveTextContent('10.00');
+    
   });
 });

--- a/components/MkrLiquiditySidebar.tsx
+++ b/components/MkrLiquiditySidebar.tsx
@@ -48,7 +48,7 @@ async function getMkrLiquidity() {
   ]);
 }
 
-export default function MkrLiquiditySidebar({ ...props }): JSX.Element {
+export default function MkrLiquiditySidebar({ className }: { className?: string }): JSX.Element {
   const { data: nonBalancer } = useSWR('/mkr-liquidity', getMkrLiquidity, { refreshInterval: 60000 });
   const { data: balancer } = useSWR('/mkr-liquidity-balancer', getBalancerMkr, { refreshInterval: 60000 });
   const [aaveV1, aaveV2, uniswap, sushi] = nonBalancer || [];
@@ -78,7 +78,7 @@ export default function MkrLiquiditySidebar({ ...props }): JSX.Element {
   };
 
   return (
-    <Box sx={{ display: ['none', 'block'] }} {...props}>
+    <Box sx={{ display: ['none', 'block'] }} className={className}>
       <Heading as="h3" variant="microHeading" sx={{ mb: 2, mt: 3 }}>
         MKR Liquidity
       </Heading>

--- a/components/ResourceBox.tsx
+++ b/components/ResourceBox.tsx
@@ -2,9 +2,9 @@
 import { Box, Heading, Card, Link as ExternalLink, Flex, Text, jsx } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 
-export default function ResourceBox(props): JSX.Element {
+export default function ResourceBox({ className }: { className?: string }): JSX.Element {
   return (
-    <Box {...props}>
+    <Box className={className}>
       <Heading mt={3} mb={2} as="h3" variant="microHeading">
         Resources
       </Heading>

--- a/components/SystemStatsSidebar.tsx
+++ b/components/SystemStatsSidebar.tsx
@@ -41,7 +41,13 @@ type StatField =
   | 'debt ceiling'
   | 'system surplus';
 
-export default function SystemStatsSidebar({ fields = [], className }: { fields: StatField[], className?: string }): JSX.Element {
+export default function SystemStatsSidebar({
+  fields = [],
+  className
+}: {
+  fields: StatField[];
+  className?: string;
+}): JSX.Element {
   const { data } = useSWR<[CurrencyObject, BigNumber, CurrencyObject, CurrencyObject, CurrencyObject]>(
     '/system-stats-sidebar',
     getSystemStats
@@ -168,26 +174,26 @@ export default function SystemStatsSidebar({ fields = [], className }: { fields:
 
   return (
     <Box sx={{ display: ['none', 'block'] }} className={className}>
-        <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between', mb: 2, mt: 3 }}>
-          <Heading as="h3" variant="microHeading">
-            System Info
-          </Heading>
-          <ExternalLink
-            href="https://daistats.com/"
-            target="_blank"
-            sx={{ color: 'accentBlue', fontSize: 3, ':hover': { color: 'blueLinkHover' } }}
-          >
-            <Flex sx={{ alignItems: 'center' }}>
-              <Text>
-                See more
-                <Icon ml={2} name="arrowTopRight" size={2} />
-              </Text>
-            </Flex>
-          </ExternalLink>
-        </Flex>
-        <Card variant="compact">
-          <Stack gap={3}>{fields.map(field => statsMap[field](field))}</Stack>
-        </Card>
-      </Box>
+      <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between', mb: 2, mt: 3 }}>
+        <Heading as="h3" variant="microHeading">
+          System Info
+        </Heading>
+        <ExternalLink
+          href="https://daistats.com/"
+          target="_blank"
+          sx={{ color: 'accentBlue', fontSize: 3, ':hover': { color: 'blueLinkHover' } }}
+        >
+          <Flex sx={{ alignItems: 'center' }}>
+            <Text>
+              See more
+              <Icon ml={2} name="arrowTopRight" size={2} />
+            </Text>
+          </Flex>
+        </ExternalLink>
+      </Flex>
+      <Card variant="compact">
+        <Stack gap={3}>{fields.map(field => statsMap[field](field))}</Stack>
+      </Card>
+    </Box>
   );
 }

--- a/components/SystemStatsSidebar.tsx
+++ b/components/SystemStatsSidebar.tsx
@@ -41,7 +41,7 @@ type StatField =
   | 'debt ceiling'
   | 'system surplus';
 
-export default function SystemStatsSidebar({ fields = [], ...props }: { fields: StatField[] }): JSX.Element {
+export default function SystemStatsSidebar({ fields = [], className }: { fields: StatField[], className?: string }): JSX.Element {
   const { data } = useSWR<[CurrencyObject, BigNumber, CurrencyObject, CurrencyObject, CurrencyObject]>(
     '/system-stats-sidebar',
     getSystemStats
@@ -167,9 +167,8 @@ export default function SystemStatsSidebar({ fields = [], ...props }: { fields: 
   };
 
   return (
-    <>
-      <Box sx={{ display: ['none', 'block'] }} {...props}>
-        <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between', mb: 2, mt: 4 }}>
+    <Box sx={{ display: ['none', 'block'] }} className={className}>
+        <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between', mb: 2, mt: 3 }}>
           <Heading as="h3" variant="microHeading">
             System Info
           </Heading>
@@ -190,6 +189,5 @@ export default function SystemStatsSidebar({ fields = [], ...props }: { fields: 
           <Stack gap={3}>{fields.map(field => statsMap[field](field))}</Stack>
         </Card>
       </Box>
-    </>
   );
 }

--- a/components/delegations/DelegateCard.tsx
+++ b/components/delegations/DelegateCard.tsx
@@ -204,7 +204,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
             }}
           >
             <Box sx={{ mb: [3, 3, 0, 3, 0], width: '200px' }}>
-              <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }}>
+              <Text as="p" variant="microHeading" sx={{ fontSize: [3, 5] }} data-testid="total-mkr-delegated">
                 {totalStaked ? totalStaked.toBigNumber().toFormat(2) : '0.00'}
               </Text>
               <Text as="p" variant="secondary" color="onSecondary" sx={{ fontSize: [2, 3] }}>

--- a/components/delegations/DelegatesSystemInfo.tsx
+++ b/components/delegations/DelegatesSystemInfo.tsx
@@ -10,19 +10,24 @@ export function DelegatesSystemInfo({ stats }: { stats: DelegatesAPIStats }): Re
   const { data: delegateFactoryAddress } = useSWR<string>('/delegate-factory-address', () =>
     getMaker().then(maker => maker.service('smartContract').getContract('VOTE_DELEGATE_FACTORY').address)
   );
-  const statsItems = [{
-    title: 'Total delegates',
-    value: stats.total
-  }, {
-    title: 'Recognized delegates',
-    value: stats.recognized
-  }, {
-    title: 'Shadow delegates',
-    value: stats.shadow
-  }, {
-    title: 'Total MKR delegated',
-    value: stats.totalMKRDelegated
-  }];
+  const statsItems = [
+    {
+      title: 'Total delegates',
+      value: stats.total
+    },
+    {
+      title: 'Recognized delegates',
+      value: stats.recognized
+    },
+    {
+      title: 'Shadow delegates',
+      value: stats.shadow
+    },
+    {
+      title: 'Total MKR delegated',
+      value: stats.totalMKRDelegated
+    }
+  ];
 
   return (
     <Box>
@@ -34,7 +39,10 @@ export function DelegatesSystemInfo({ stats }: { stats: DelegatesAPIStats }): Re
           <Flex sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
             <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Delegate Factory</Text>
             {delegateFactoryAddress ? (
-              <ThemeUILink href={getEtherscanLink(getNetwork(), delegateFactoryAddress, 'address')} target="_blank">
+              <ThemeUILink
+                href={getEtherscanLink(getNetwork(), delegateFactoryAddress, 'address')}
+                target="_blank"
+              >
                 <Text>{formatAddress(delegateFactoryAddress)}</Text>
               </ThemeUILink>
             ) : (

--- a/components/delegations/DelegatesSystemInfo.tsx
+++ b/components/delegations/DelegatesSystemInfo.tsx
@@ -1,0 +1,58 @@
+import StackLayout from 'components/layouts/Stack';
+import SkeletonThemed from 'components/SkeletonThemed';
+import getMaker, { getNetwork } from 'lib/maker';
+import { formatAddress, getEtherscanLink } from 'lib/utils';
+import useSWR from 'swr';
+import { Box, Card, Flex, Heading, Link as ThemeUILink, Text } from 'theme-ui';
+import { DelegatesAPIStats } from 'types/delegatesAPI';
+
+export function DelegatesSystemInfo({ stats }: { stats: DelegatesAPIStats }): React.ReactElement {
+  const { data: delegateFactoryAddress } = useSWR<string>('/delegate-factory-address', () =>
+    getMaker().then(maker => maker.service('smartContract').getContract('VOTE_DELEGATE_FACTORY').address)
+  );
+  const statsItems = [{
+    title: 'Total delegates',
+    value: stats.total
+  }, {
+    title: 'Recognized delegates',
+    value: stats.recognized
+  }, {
+    title: 'Shadow delegates',
+    value: stats.shadow
+  }, {
+    title: 'Total MKR delegated',
+    value: stats.totalMKRDelegated
+  }];
+
+  return (
+    <Box>
+      <Heading mt={3} mb={2} as="h3" variant="microHeading">
+        Delegate System Info
+      </Heading>
+      <Card variant="compact">
+        <StackLayout gap={3}>
+          <Flex sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+            <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Delegate Factory</Text>
+            {delegateFactoryAddress ? (
+              <ThemeUILink href={getEtherscanLink(getNetwork(), delegateFactoryAddress, 'address')} target="_blank">
+                <Text>{formatAddress(delegateFactoryAddress)}</Text>
+              </ThemeUILink>
+            ) : (
+              <Box sx={{ width: 6 }}>
+                <SkeletonThemed />
+              </Box>
+            )}
+          </Flex>
+          {statsItems.map(item => (
+            <Flex key={item.title} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+              <Text sx={{ fontSize: 3, color: 'textSecondary' }}>{item.title}</Text>
+              <Text variant="h2" sx={{ fontSize: 3 }}>
+                {item.value}
+              </Text>
+            </Flex>
+          ))}
+        </StackLayout>
+      </Card>
+    </Box>
+  );
+}

--- a/components/delegations/DelegatesSystemInfo.tsx
+++ b/components/delegations/DelegatesSystemInfo.tsx
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import StackLayout from 'components/layouts/Stack';
 import SkeletonThemed from 'components/SkeletonThemed';
 import getMaker, { getNetwork } from 'lib/maker';
@@ -6,31 +7,35 @@ import useSWR from 'swr';
 import { Box, Card, Flex, Heading, Link as ThemeUILink, Text } from 'theme-ui';
 import { DelegatesAPIStats } from 'types/delegatesAPI';
 
-export function DelegatesSystemInfo({ stats }: { stats: DelegatesAPIStats }): React.ReactElement {
+export function DelegatesSystemInfo({ stats, className }: { stats: DelegatesAPIStats, className?: string }): React.ReactElement {
   const { data: delegateFactoryAddress } = useSWR<string>('/delegate-factory-address', () =>
     getMaker().then(maker => maker.service('smartContract').getContract('VOTE_DELEGATE_FACTORY').address)
   );
   const statsItems = [
     {
       title: 'Total delegates',
+      id: 'total-delegates-system-info',
       value: stats.total
     },
     {
       title: 'Recognized delegates',
+      id: 'total-recognized-delegates-system-info',
       value: stats.recognized
     },
     {
       title: 'Shadow delegates',
+      id: 'total-shadow-delegates-system-info',
       value: stats.shadow
     },
     {
       title: 'Total MKR delegated',
-      value: stats.totalMKRDelegated
+      id: 'total-mkr-system-info', 
+      value: (new BigNumber(stats.totalMKRDelegated)).toFormat(2)
     }
   ];
 
   return (
-    <Box>
+    <Box className={className}>
       <Heading mt={3} mb={2} as="h3" variant="microHeading">
         Delegate System Info
       </Heading>
@@ -52,9 +57,9 @@ export function DelegatesSystemInfo({ stats }: { stats: DelegatesAPIStats }): Re
             )}
           </Flex>
           {statsItems.map(item => (
-            <Flex key={item.title} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+            <Flex key={item.id} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
               <Text sx={{ fontSize: 3, color: 'textSecondary' }}>{item.title}</Text>
-              <Text variant="h2" sx={{ fontSize: 3 }}>
+              <Text variant="h2" sx={{ fontSize: 3 }} data-testid={item.id}>
                 {item.value}
               </Text>
             </Flex>

--- a/components/delegations/DelegatesSystemInfo.tsx
+++ b/components/delegations/DelegatesSystemInfo.tsx
@@ -7,7 +7,13 @@ import useSWR from 'swr';
 import { Box, Card, Flex, Heading, Link as ThemeUILink, Text } from 'theme-ui';
 import { DelegatesAPIStats } from 'types/delegatesAPI';
 
-export function DelegatesSystemInfo({ stats, className }: { stats: DelegatesAPIStats, className?: string }): React.ReactElement {
+export function DelegatesSystemInfo({
+  stats,
+  className
+}: {
+  stats: DelegatesAPIStats;
+  className?: string;
+}): React.ReactElement {
   const { data: delegateFactoryAddress } = useSWR<string>('/delegate-factory-address', () =>
     getMaker().then(maker => maker.service('smartContract').getContract('VOTE_DELEGATE_FACTORY').address)
   );
@@ -29,8 +35,8 @@ export function DelegatesSystemInfo({ stats, className }: { stats: DelegatesAPIS
     },
     {
       title: 'Total MKR delegated',
-      id: 'total-mkr-system-info', 
-      value: (new BigNumber(stats.totalMKRDelegated)).toFormat(2)
+      id: 'total-mkr-system-info',
+      value: new BigNumber(stats.totalMKRDelegated).toFormat(2)
     }
   ];
 

--- a/lib/delegates/fetchChainDelegates.ts
+++ b/lib/delegates/fetchChainDelegates.ts
@@ -9,9 +9,17 @@ export async function fetchChainDelegates(
 
   const delegates = await maker.service('voteDelegate').getAllDelegates();
 
-  return delegates.map(d => ({
+  const mkrStaked = await Promise.all(delegates.map(async delegate => {
+
+    // Get MKR delegated to each contract
+    const mkr = await maker.service('chief').getNumDeposits(delegate.voteDelegate);
+    return mkr.toNumber();
+  }));
+
+  return delegates.map((d, index) => ({
     ...d,
     address: d.delegate,
-    voteDelegateAddress: d.voteDelegate
+    voteDelegateAddress: d.voteDelegate,
+    mkrDelegated: mkrStaked[index]
   }));
 }

--- a/lib/delegates/fetchChainDelegates.ts
+++ b/lib/delegates/fetchChainDelegates.ts
@@ -9,12 +9,13 @@ export async function fetchChainDelegates(
 
   const delegates = await maker.service('voteDelegate').getAllDelegates();
 
-  const mkrStaked = await Promise.all(delegates.map(async delegate => {
-
-    // Get MKR delegated to each contract
-    const mkr = await maker.service('chief').getNumDeposits(delegate.voteDelegate);
-    return mkr.toNumber();
-  }));
+  const mkrStaked = await Promise.all(
+    delegates.map(async delegate => {
+      // Get MKR delegated to each contract
+      const mkr = await maker.service('chief').getNumDeposits(delegate.voteDelegate);
+      return mkr.toNumber();
+    })
+  );
 
   return delegates.map((d, index) => ({
     ...d,

--- a/lib/delegates/fetchDelegates.ts
+++ b/lib/delegates/fetchDelegates.ts
@@ -81,7 +81,7 @@ export async function fetchDelegates(network?: SupportedNetworks): Promise<Deleg
       recognized: delegates.filter(d => d.status === DelegateStatusEnum.recognized).length,
       totalMKRDelegated: delegates.reduce((prev, next) => prev + next.mkrDelegated, 0)
     }
-  };
+  }; 
 
   return delegatesResponse;
 }

--- a/lib/delegates/fetchDelegates.ts
+++ b/lib/delegates/fetchDelegates.ts
@@ -81,7 +81,7 @@ export async function fetchDelegates(network?: SupportedNetworks): Promise<Deleg
       recognized: delegates.filter(d => d.status === DelegateStatusEnum.recognized).length,
       totalMKRDelegated: delegates.reduce((prev, next) => prev + next.mkrDelegated, 0)
     }
-  }; 
+  };
 
   return delegatesResponse;
 }

--- a/pages/api/delegates/index.ts
+++ b/pages/api/delegates/index.ts
@@ -5,13 +5,14 @@ import { isSupportedNetwork } from 'lib/maker/index';
 import { DEFAULT_NETWORK } from 'lib/constants';
 import withApiHandler from 'lib/api/withApiHandler';
 import { fetchDelegates } from 'lib/delegates/fetchDelegates';
+import { DelegatesAPIResponse } from 'types/delegatesAPI';
 
-export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<DelegatesAPIResponse>) => {
   const network = (req.query.network as string) || DEFAULT_NETWORK;
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
-  // const maker = await getConnectedMakerObj(network);
   const delegates = await fetchDelegates(network);
+  
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
   res.status(200).json(delegates);
 });

--- a/pages/api/delegates/index.ts
+++ b/pages/api/delegates/index.ts
@@ -12,7 +12,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<D
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
   const delegates = await fetchDelegates(network);
-  
+
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
   res.status(200).json(delegates);
 });

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -40,9 +40,7 @@ const Delegates = ({ delegates, stats }: Props) => {
       marginBottom: 2
     }
   };
-  const [voteDelegate] = useAccountsStore(state => [
-    state.voteDelegate
-  ]);
+  const [voteDelegate] = useAccountsStore(state => [state.voteDelegate]);
 
   const isOwner = d =>
     d.voteDelegateAddress.toLowerCase() === voteDelegate?.getVoteDelegateAddress().toLowerCase();
@@ -65,7 +63,6 @@ const Delegates = ({ delegates, stats }: Props) => {
 
       <SidebarLayout>
         <Box>
-         
           {delegates && delegates.length === 0 && <Text>No delegates found</Text>}
           {recognizedDelegates.length > 0 && (
             <Box sx={styles.delegateGroup}>
@@ -162,10 +159,12 @@ export default function DelegatesPage({ delegates, stats }: Props): JSX.Element 
   // fetch delegates at run-time if on any network other than the default
   useEffect(() => {
     if (!isDefaultNetwork()) {
-      fetchJson(`/api/delegates?network=${getNetwork()}`).then((response: DelegatesAPIResponse) => {
-        _setDelegates(response.delegates);
-        _setStats(response.stats);
-      }).catch(setError);
+      fetchJson(`/api/delegates?network=${getNetwork()}`)
+        .then((response: DelegatesAPIResponse) => {
+          _setDelegates(response.delegates);
+          _setStats(response.stats);
+        })
+        .catch(setError);
     }
   }, []);
 
@@ -181,7 +180,12 @@ export default function DelegatesPage({ delegates, stats }: Props): JSX.Element 
     );
   }
 
-  return <Delegates delegates={isDefaultNetwork() ? delegates : (_delegates as Delegate[])} stats={isDefaultNetwork() ? stats : (_stats as DelegatesAPIStats)}  />;
+  return (
+    <Delegates
+      delegates={isDefaultNetwork() ? delegates : (_delegates as Delegate[])}
+      stats={isDefaultNetwork() ? stats : (_stats as DelegatesAPIStats)}
+    />
+  );
 }
 
 export const getStaticProps: GetStaticProps = async () => {

--- a/types/delegate.d.ts
+++ b/types/delegate.d.ts
@@ -14,6 +14,7 @@ export type DelegateContractInformation = {
   address: string;
   voteDelegateAddress: string;
   blockTimestamp: Date;
+  mkrDelegated: number;
 };
 
 export type Delegate = {
@@ -30,4 +31,5 @@ export type Delegate = {
   externalUrl?: string;
   combinedParticipation?: string;
   communication?: string;
+  mkrDelegated: number;
 };

--- a/types/delegatesAPI.d.ts
+++ b/types/delegatesAPI.d.ts
@@ -1,17 +1,17 @@
 import { Delegate } from './delegate';
 
 export type DelegatesAPIStats = {
-  total: number,
-  shadow: number,
-  recognized: number,
-  totalMKRDelegated: number
-}
+  total: number;
+  shadow: number;
+  recognized: number;
+  totalMKRDelegated: number;
+};
 
 export type DelegatesAPIResponse = {
-  delegates: Delegate[],
-  stats: DelegatesAPIStats,
+  delegates: Delegate[];
+  stats: DelegatesAPIStats;
   pagination?: {
-    page: number,
-    pageSize: number,
-  }
-}
+    page: number;
+    pageSize: number;
+  };
+};

--- a/types/delegatesAPI.d.ts
+++ b/types/delegatesAPI.d.ts
@@ -1,0 +1,17 @@
+import { Delegate } from './delegate';
+
+export type DelegatesAPIStats = {
+  total: number,
+  shadow: number,
+  recognized: number,
+  totalMKRDelegated: number
+}
+
+export type DelegatesAPIResponse = {
+  delegates: Delegate[],
+  stats: DelegatesAPIStats,
+  pagination?: {
+    page: number,
+    pageSize: number,
+  }
+}


### PR DESCRIPTION
### Link to Clubhouse story
https://app.clubhouse.io/dux-makerdao/story/373/add-delegate-info-to-sidebar

### What does this PR do?

- Modifies API to add stats response
```
"stats":{"total":17,"shadow":16,"recognized":1,"totalMKRDelegated":9.5939}}
```
- Brings stats from the server side to the delegates system component
- Adds the delegates system info in the delegates page

### Steps for testing:
- Go to delegates page and see the component
- Load /api/delegates to get stats
-
### Screenshots (if relevant):


![image](https://user-images.githubusercontent.com/1152768/128041777-9e1f9b6c-135b-4a3e-a744-72084444936d.png)

### Add a GIF:
![](https://media4.giphy.com/media/2E6OYt2yphlWTGZeYK/giphy.gif?cid=ecf05e4783a762f5569de5a1910f82d9daa0247aab5bfe04&rid=giphy.gif&ct=g)