### PR TITLE
Fix/poll filters

### DIFF
--- a/__tests__/components/polling/QuickVote.tsx
+++ b/__tests__/components/polling/QuickVote.tsx
@@ -1,9 +1,12 @@
 import { act, screen } from '@testing-library/react';
 import mockPolls from '../../../mocks/polls.json';
+import mockCategories from '../../../mocks/categories.json';
 import { accountsApi } from '../../../stores/accounts';
 import { connectAccount, createTestPolls, renderWithAccountSelect as render } from '../../helpers';
 import getMaker from '../../../lib/maker';
 import PollingOverviewPage from '../../../pages/polling';
+import { Poll } from '../../../types/poll';
+import { PollCategory } from '../../../types/pollCategory';
 
 let maker;
 
@@ -23,7 +26,7 @@ describe('QuickVote', () => {
 
   beforeEach(async () => {
     accountsApi.setState({ currentAccount: undefined });
-    const view = render(<PollingOverviewPage polls={mockPolls as any} />);
+    render(<PollingOverviewPage categories={mockCategories as PollCategory[]} polls={mockPolls as Poll[]} />);
 
     await act(async () => {
       await connectAccount();

--- a/__tests__/components/polling/RankedChoiceSelect.tsx
+++ b/__tests__/components/polling/RankedChoiceSelect.tsx
@@ -1,9 +1,12 @@
 import { act, screen } from '@testing-library/react';
 import mockPolls from '../../../mocks/polls.json';
+import mockCategories from '../../../mocks/categories.json';
 import { accountsApi } from '../../../stores/accounts';
 import { connectAccount, createTestPolls, renderWithAccountSelect as render } from '../../helpers';
 import getMaker from '../../../lib/maker';
 import PollingOverviewPage from '../../../pages/polling';
+import { Poll } from '../../../types/poll';
+import { PollCategory } from '../../../types/pollCategory';
 
 let maker;
 
@@ -21,7 +24,7 @@ describe('RankedChoiceSelect', () => {
 
   beforeEach(async () => {
     accountsApi.setState({ currentAccount: undefined });
-    const view = render(<PollingOverviewPage polls={mockPolls as any} />);
+    render(<PollingOverviewPage categories={mockCategories as PollCategory[]} polls={mockPolls as Poll[]} />);
     await act(async () => {
       await connectAccount();
     });
@@ -33,11 +36,11 @@ describe('RankedChoiceSelect', () => {
 
     expect(select).toBeInTheDocument();
     expect(options.length).toBe(7);
-    expect(await screen.findByText('0')).toBeInTheDocument();
-    expect(await screen.findByText('0.25')).toBeInTheDocument();
-    expect(await screen.findByText('0.5')).toBeInTheDocument();
-    expect(await screen.findByText('1')).toBeInTheDocument();
-    expect(await screen.findByText('2')).toBeInTheDocument();
-    expect(await screen.findByText('4')).toBeInTheDocument();
+    expect(await screen.findByText('0', { selector: 'li' })).toBeInTheDocument();
+    expect(await screen.findByText('0.25', { selector: 'li' })).toBeInTheDocument();
+    expect(await screen.findByText('0.5', { selector: 'li' })).toBeInTheDocument();
+    expect(await screen.findByText('1', { selector: 'li' })).toBeInTheDocument();
+    expect(await screen.findByText('2', { selector: 'li' })).toBeInTheDocument();
+    expect(await screen.findByText('4', { selector: 'li' })).toBeInTheDocument();
   });
 });

--- a/__tests__/components/polling/SingleSelect.tsx
+++ b/__tests__/components/polling/SingleSelect.tsx
@@ -1,9 +1,12 @@
 import { act, screen } from '@testing-library/react';
 import mockPolls from '../../../mocks/polls.json';
+import mockCategories from '../../../mocks/categories.json';
 import { accountsApi } from '../../../stores/accounts';
 import { connectAccount, createTestPolls, renderWithAccountSelect as render } from '../../helpers';
 import getMaker from '../../../lib/maker';
 import PollingOverviewPage from '../../../pages/polling';
+import { Poll } from '../../../types/poll';
+import { PollCategory } from '../../../types/pollCategory';
 
 let maker;
 
@@ -20,7 +23,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   accountsApi.setState({ currentAccount: undefined });
-  const view = render(<PollingOverviewPage polls={mockPolls as any} />);
+  render(<PollingOverviewPage categories={mockCategories as PollCategory[]} polls={mockPolls as Poll[]} />);
   await act(async () => {
     await connectAccount();
   });

--- a/__tests__/pages/polling.tsx
+++ b/__tests__/pages/polling.tsx
@@ -9,7 +9,10 @@ import { formatAddress } from 'lib/utils';
 import PollingOverviewPage from '../../pages/polling';
 import getMaker from '../../lib/maker';
 import mockPolls from '../../mocks/polls.json';
+import mockCategories from '../../mocks/categories.json';
 import { accountsApi } from '../../stores/accounts';
+import { Poll } from '../../types/poll';
+import { PollCategory } from '../../types/pollCategory';
 
 let maker;
 
@@ -29,7 +32,7 @@ describe('Polling', () => {
 
   beforeEach(async () => {
     accountsApi.setState({ currentAccount: undefined });
-    const view = render(<PollingOverviewPage polls={mockPolls as any} />);
+    render(<PollingOverviewPage categories={mockCategories as PollCategory[]} polls={mockPolls as Poll[]} />);
     await act(async () => {
       await connectAccount();
     });

--- a/components/polling/CategoryFilter.tsx
+++ b/components/polling/CategoryFilter.tsx
@@ -1,10 +1,15 @@
-import { Flex, Checkbox, Label } from 'theme-ui';
+import { Flex, Checkbox, Label, Text } from 'theme-ui';
 import shallow from 'zustand/shallow';
-
+import { PollCategory } from 'types/pollCategory';
 import FilterButton from '../FilterButton';
 import useUiFiltersStore from 'stores/uiFilters';
 
-export default function CategoryFilter({ categories, ...props }: { categories: string[] }) {
+export default function CategoryFilter({
+  categories,
+  ...props
+}: {
+  categories: PollCategory[];
+}): JSX.Element {
   const [categoryFilter, setCategoryFilter] = useUiFiltersStore(
     state => [state.pollFilters.categoryFilter, state.setCategoryFilter],
     shallow
@@ -14,14 +19,19 @@ export default function CategoryFilter({ categories, ...props }: { categories: s
     <FilterButton name={() => 'Poll Type'} {...props}>
       <Flex sx={{ flexDirection: 'column' }}>
         {categories.map(category => (
-          <Flex key={category || 'undefined'}>
+          <Flex key={category.name}>
             <Label sx={{ py: 1, fontSize: 2, alignItems: 'center' }}>
               <Checkbox
                 sx={{ width: 3, height: 3 }}
                 checked={categoryFilter?.category}
-                onChange={event => setCategoryFilter({ ...categoryFilter, [category]: event.target.checked })}
+                onChange={event =>
+                  setCategoryFilter({ ...categoryFilter, [category.name]: event.target.checked })
+                }
               />
-              {category}
+              <Flex sx={{ justifyContent: 'space-between', width: '100%' }}>
+                <Text>{category.name}</Text>
+                <Text sx={{ color: 'muted', ml: 3 }}>{category.count}</Text>
+              </Flex>
             </Label>
           </Flex>
         ))}

--- a/components/polling/CategoryFilter.tsx
+++ b/components/polling/CategoryFilter.tsx
@@ -18,7 +18,7 @@ export default function CategoryFilter({ categories, ...props }: { categories: s
             <Label sx={{ py: 1, fontSize: 2, alignItems: 'center' }}>
               <Checkbox
                 sx={{ width: 3, height: 3 }}
-                checked={categoryFilter?.[category] === undefined || categoryFilter[category]}
+                checked={categoryFilter?.category}
                 onChange={event => setCategoryFilter({ ...categoryFilter, [category]: event.target.checked })}
               />
               {category}

--- a/lib/polling/getCategories.ts
+++ b/lib/polling/getCategories.ts
@@ -3,6 +3,7 @@ import { PollCategory } from 'types/pollCategory';
 
 export const getCategories = (polls: Poll[]): PollCategory[] => {
   const categoryMap = polls.reduce((acc, cur) => {
+    if (!cur.categories) return acc;
     cur.categories.forEach(c => {
       if (acc[c]) {
         acc[c] += 1;

--- a/lib/polling/getCategories.ts
+++ b/lib/polling/getCategories.ts
@@ -1,0 +1,21 @@
+import { Poll } from 'types/poll';
+import { PollCategory } from 'types/pollCategory';
+
+export const getCategories = (polls: Poll[]): PollCategory[] => {
+  const categoryMap = polls.reduce((acc, cur) => {
+    cur.categories.forEach(c => {
+      if (acc[c]) {
+        acc[c] += 1;
+      } else {
+        acc[c] = 1;
+      }
+    });
+    return acc;
+  }, {});
+
+  const allCategories = Object.keys(categoryMap)
+    .sort((a, b) => (a > b ? 1 : -1))
+    .map(c => ({ name: c, count: categoryMap[c] }));
+
+  return allCategories || [];
+};

--- a/mocks/categories.json
+++ b/mocks/categories.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "test category a",
+    "count": 3
+  },
+  {
+    "name": "test category b",
+    "count": 11
+  }
+]

--- a/mocks/polls.json
+++ b/mocks/polls.json
@@ -12,15 +12,20 @@
     "summary": "The Inclusion Poll will run from June 8 to June 11 and will determine whether the proposal at hand will proceed to next week's Governance Poll.",
     "title": "MIP14: Inclusion Poll for Protocol DAI Transfer",
     "options": {
-      "1": 0,
-      "2": 0.25,
-      "3": 0.5,
-      "4": 1,
-      "5": 2,
-      "6": 4
+      "1": "0",
+      "2": "0.25",
+      "3": "0.5",
+      "4": "1",
+      "5": "2",
+      "6": "4"
     },
     "discussionLink": "https://forum.makerdao.com/t/2462",
-    "voteType": "Ranked Choice IRV"
+    "voteType": "Ranked Choice IRV",
+    "categories": ["test1", "test2"],
+    "ctx": {
+      "prev": null,
+      "next": null
+    }
   },
   {
     "creator": "0xf563f100df419ccde59bfbe0692fc4c5bfe01706",
@@ -39,6 +44,11 @@
       "2": "No"
     },
     "discussionLink": "https://forum.makerdao.com/t/2664",
-    "voteType": "Plurality Voting"
+    "voteType": "Plurality Voting",
+    "categories": ["test2", "test3"],
+    "ctx": {
+      "prev": null,
+      "next": null
+    }
   }
 ]

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -37,10 +37,10 @@ import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
 
 type Props = {
   polls: Poll[];
-  allCategories: PollCategory[];
+  categories: PollCategory[];
 };
 
-const PollingOverview = ({ polls, allCategories }: Props) => {
+const PollingOverview = ({ polls, categories }: Props) => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING_REVIEW);
   const [
     startDate,
@@ -68,11 +68,11 @@ const PollingOverview = ({ polls, allCategories }: Props) => {
   const loader = useRef<HTMLDivElement>(null);
   const bpi = useBreakpointIndex();
 
-  const filteredPolls = useMemo(() => {
-    const start = startDate && new Date(startDate);
-    const end = endDate && new Date(endDate);
-    const noCategoriesSelected = categoryFilter === null || Object.values(categoryFilter).every(c => !c);
+  const noCategoriesSelected = categoryFilter === null || Object.values(categoryFilter).every(c => !c);
+  const start = startDate && new Date(startDate);
+  const end = endDate && new Date(endDate);
 
+  const filteredPolls = useMemo(() => {
     return polls.filter(poll => {
       // check date filters first
       if (start && new Date(poll.startDate).getTime() < start.getTime()) return false;
@@ -150,7 +150,7 @@ const PollingOverview = ({ polls, allCategories }: Props) => {
           <Heading variant="microHeading" mr={3}>
             Filters
           </Heading>
-          <CategoryFilter categories={allCategories} />
+          <CategoryFilter categories={categories} />
           <DateFilter sx={{ ml: 3 }} />
         </Flex>
         <SidebarLayout>
@@ -281,10 +281,10 @@ const PollingOverview = ({ polls, allCategories }: Props) => {
 
 export default function PollingOverviewPage({
   polls: prefetchedPolls,
-  allCategories: prefetchedCategories
+  categories: prefetchedCategories
 }: Props): JSX.Element {
   const [_polls, _setPolls] = useState<Poll[]>();
-  const [_allCategories, _setAllCategories] = useState<PollCategory[]>();
+  const [_categories, _setCategories] = useState<PollCategory[]>();
   const [error, setError] = useState<string>();
 
   // fetch polls at run-time if on any network other than the default
@@ -293,7 +293,7 @@ export default function PollingOverviewPage({
       getPolls()
         .then(polls => {
           _setPolls(polls);
-          _setAllCategories(getCategories(polls));
+          _setCategories(getCategories(polls));
         })
         .catch(setError);
     }
@@ -303,7 +303,7 @@ export default function PollingOverviewPage({
     return <ErrorPage statusCode={404} title="Error fetching proposals" />;
   }
 
-  if (!isDefaultNetwork() && (!_polls || !_allCategories))
+  if (!isDefaultNetwork() && (!_polls || !_categories))
     return (
       <PrimaryLayout shortenFooter={true}>
         <PageLoadingPlaceholder />
@@ -313,7 +313,7 @@ export default function PollingOverviewPage({
   return (
     <PollingOverview
       polls={isDefaultNetwork() ? prefetchedPolls : (_polls as Poll[])}
-      allCategories={isDefaultNetwork() ? prefetchedCategories : (_allCategories as PollCategory[])}
+      categories={isDefaultNetwork() ? prefetchedCategories : (_categories as PollCategory[])}
     />
   );
 }
@@ -321,13 +321,13 @@ export default function PollingOverviewPage({
 export const getStaticProps: GetStaticProps = async () => {
   // fetch polls at build-time if on the default network
   const polls = await getPolls();
-  const allCategories = getCategories(polls);
+  const categories = getCategories(polls);
 
   return {
     revalidate: 30, // allow revalidation every 30 seconds
     props: {
       polls,
-      allCategories
+      categories
     }
   };
 };

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -71,15 +71,17 @@ const PollingOverview = ({ polls }: Props) => {
     }
   }, []);
 
+  const allCategories = Array.from(new Set(polls.map(poll => poll.categories).flat()));
   const filteredPolls = useMemo(() => {
     const start = startDate && new Date(startDate);
     const end = endDate && new Date(endDate);
+    const noFiltersSelected = categoryFilter === null || Object.values(categoryFilter).every(c => !c);
+    const categoryExists = (category, poll) => poll.categories.some(c => c === category);
     return polls.filter(poll => {
       if (start && new Date(poll.startDate).getTime() < start.getTime()) return false;
       if (end && new Date(poll.startDate).getTime() > end.getTime()) return false;
-      return categoryFilter === null // if categoryFilter is null, no filters have been set yet
-        ? true
-        : !poll.categories.some(category => categoryFilter[category] === false);
+      // if no filters selected, return all
+      return noFiltersSelected || poll.categories.some(c => categoryFilter && categoryFilter[c]);
     });
   }, [polls, startDate, endDate, categoryFilter]);
 
@@ -150,7 +152,7 @@ const PollingOverview = ({ polls }: Props) => {
           <Heading variant="microHeading" mr={3}>
             Filters
           </Heading>
-          <CategoryFilter categories={Array.from(new Set(polls.map(poll => poll.categories).flat()))} />
+          <CategoryFilter categories={allCategories} />
           <DateFilter sx={{ ml: 3 }} />
         </Flex>
         <SidebarLayout>

--- a/types/poll.d.ts
+++ b/types/poll.d.ts
@@ -7,8 +7,8 @@ export type Poll = {
   pollId: number;
   summary: string;
   options: Record<any, any>;
-  endDate: string;
-  startDate: string;
+  endDate: Date;
+  startDate: Date;
   discussionLink: string | null;
   voteType: VoteTypes;
   categories: string[];

--- a/types/poll.d.ts
+++ b/types/poll.d.ts
@@ -6,9 +6,9 @@ export type Poll = {
   content: string;
   pollId: number;
   summary: string;
-  options: { [optionId: string]: string };
-  endDate: Date;
-  startDate: Date;
+  options: Record<any, any>;
+  endDate: string;
+  startDate: string;
   discussionLink: string | null;
   voteType: VoteTypes;
   categories: string[];

--- a/types/pollCategory.ts
+++ b/types/pollCategory.ts
@@ -1,0 +1,4 @@
+export type PollCategory = {
+  name: string;
+  count: number;
+};


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/41/add-an-unselect-all-button-to-the-poll-type-dropdown-for-better-usability-improve-usability-by-defaulting-to-all-unchecked

### What does this PR do?

Updates filters to only filter once a category has been selected

Fixes issue where categories were not showing up correctly

Adds number of posts next to filter category

Determines categories serverside when pre-fetching polls

### Steps for testing:

Go to https://governance-portal-v2-pkd0gv74s-dux-core-unit.vercel.app/polling?network=mainnet and tests the "Poll Type" filters

### Screenshots (if relevant):
Before:
<img width="462" alt="Screen Shot 2021-08-04 at 1 16 41 PM" src="https://user-images.githubusercontent.com/5225766/128172429-77a8f9a7-800f-4921-baa2-75d31ce76979.png">

After:
<img width="877" alt="Screen Shot 2021-08-04 at 10 41 28 AM" src="https://user-images.githubusercontent.com/5225766/128172444-b640c907-48ca-4c02-8ec2-df199e3a02e9.png">

### Any additional helpful information?:

### Add a GIF:
![](https://media.giphy.com/media/l1smkUd9t1zrjeHcbp/giphy.gif)