### PR TITLE
Fix/poll order by enddate

### DIFF
--- a/components/Footer/LongFooter.tsx
+++ b/components/Footer/LongFooter.tsx
@@ -188,7 +188,11 @@ export default function LongFooter({ locale = 'en' }: { locale?: string }): Reac
             <ThemeUILink sx={{ color: 'text' }} href="https://t.me/makerdaoOfficial" title="Telegram">
               <Icon name="telegram" />
             </ThemeUILink>
-            <ThemeUILink sx={{ color: 'text' }} href="https://chat.makerdao.com/" title="MakerDAO official chat">
+            <ThemeUILink
+              sx={{ color: 'text' }}
+              href="https://chat.makerdao.com/"
+              title="MakerDAO official chat"
+            >
               <Icon name="rocket_chat" />
             </ThemeUILink>
             <ThemeUILink sx={{ color: 'text' }} href="https://www.youtube.com/MakerDAO" title="Youtube">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -184,8 +184,10 @@ export async function parsePollsMetadata(pollList): Promise<Poll[]> {
 
   return (
     polls
-      // newest to oldest
-      .sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime())
+      // closest to expiration shown first
+      .sort((a, b) =>
+        Date.now() - new Date(a.endDate).getTime() < Date.now() - new Date(b.endDate).getTime() ? 1 : -1
+      )
   );
 }
 


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/169/order-polls-by-expiration-instead-of-creation-date

### What does this PR do?

Changes poll sorting to sort polls closest to expiring on the top

### Steps for testing:

Use this URL and view polls, closest to expiration should be at the top

https://governance-portal-v2-2759i1b6k-dux-core-unit.vercel.app/

