### PR TITLE
Add mixpanel config check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ _Requires node version >= v11.15.0_
 8. Set `USE_FS_CACHE` to true if you want to use file system cache
 9. Set `GITHUB_TOKEN` to fetch delegates information from GitHub
 10. Set `NEXT_PUBLIC_USE_MOCK` to indicate to use mock data.
+11. Set `NEXT_PUBLIC_MIXPANEL_DEV` to the valid Mixpanel dev environment API key
+12. Set `NEXT_PUBLIC_MIXPANEL_PROD` to the valid Mixpanel prod environment API key
 
 If API keys aren't provided, both Alchemy and Infura will default to the public keys from [ethers.js](https://github.com/ethers-io/ethers.js/). This is probably fine in most cases, performance could just be a bit less consistent as many people are using these.
 

--- a/lib/client/analytics/AnalyticsContext.tsx
+++ b/lib/client/analytics/AnalyticsContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect } from 'react';
 import { CookiesContext } from '../cookies/CookiesContext';
 import { useRouter } from 'next/router';
-import { mixpanelInit } from './mixPanel';
+import { mixpanelInit, mixpanelTokenConfigured } from './mixPanel';
 import mixpanel from 'mixpanel-browser';
 import { ANALYTICS_EVENTS, ANALYTICS_PRODUCT } from './analytics.constants';
 
@@ -32,7 +32,7 @@ export const AnalyticsProvider = ({ children }: { children: React.ReactElement }
 
   // Only track users that accepted analytics
   function launchAnalytics() {
-    if (analyticCookiesEnabled) {
+    if (analyticCookiesEnabled && mixpanelTokenConfigured) {
       mixpanelInit();
 
       // First interaction

--- a/lib/client/analytics/mixPanel.ts
+++ b/lib/client/analytics/mixPanel.ts
@@ -16,6 +16,8 @@ const analyticsConfig = {
   }
 }[config.NODE_ENV];
 
+export const mixpanelTokenConfigured = analyticsConfig?.mixpanel?.token !== '';
+
 export const mixpanelInit = (): void => {
   console.debug(
     `[Mixpanel] Tracking initialized for ${config.NODE_ENV} env using ${analyticsConfig.mixpanel.token}`


### PR DESCRIPTION
### What does this PR do?

Fixes issue where app crashes if `NEXT_PUBLIC_MIXPANEL_DEV` and/or `NEXT_PUBLIC_MIXPANEL_PROD` don't exist in the `.env`

Also adds these configs to the README

### Steps for testing:

On develop branch, attempt to run app without `NEXT_PUBLIC_MIXPANEL_DEV`. App will crash. Then try the same but on this branch. App should not crash.
