### PR TITLE
Bug/ch339/param issue 404 on poll urls

### DIFF
--- a/__tests__/lib/api.ts
+++ b/__tests__/lib/api.ts
@@ -51,7 +51,6 @@ describe('API', () => {
   test('parseExecutive', async () => {
     const parsedExec = parseExecutive(Exec1, { testnet: ['x'] }, 'x');
 
-    console.log(parsedExec);
     expect(
       !!parsedExec.about &&
         !!parsedExec.content &&
@@ -76,16 +75,25 @@ describe('API', () => {
 });
 
 test('parseExecutive', async () => {
-  const parsedExec = parseExecutive(Exec1, {'testnet': ['x']}, 'x');
-  expect(!!parsedExec.about && !!parsedExec.content && !!parsedExec.title && !!parsedExec.proposalBlurb && !!parsedExec.key && !!parsedExec.address && !!parsedExec.date && !!parsedExec.active).toBe(true);
+  const parsedExec = parseExecutive(Exec1, { testnet: ['x'] }, 'x');
+  expect(
+    !!parsedExec.about &&
+      !!parsedExec.content &&
+      !!parsedExec.title &&
+      !!parsedExec.proposalBlurb &&
+      !!parsedExec.key &&
+      !!parsedExec.address &&
+      !!parsedExec.date &&
+      !!parsedExec.active
+  ).toBe(true);
 });
 
 test('parseExecutive removes execs with invalid dates', async () => {
-  const parsedExec = parseExecutive(Exec2, {'testnet': ['x']}, 'x');
+  const parsedExec = parseExecutive(Exec2, { testnet: ['x'] }, 'x');
   expect(parsedExec).toBe(null);
 });
 
 test('parseExecutive removes execs with invalid address', async () => {
-  const parsedExec = parseExecutive(Exec3, {'testnet': ['x']}, 'x');
+  const parsedExec = parseExecutive(Exec3, { testnet: ['x'] }, 'x');
   expect(parsedExec).toBe(null);
 });

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -303,7 +303,7 @@ export default {
         textDecoration: 'none',
         ':hover': { color: 'blueLinkHover' }
       },
-      '& > :first-child': {
+      '& > :first-of-type': {
         mt: 0
       },
       table: {

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -298,7 +298,7 @@ export default function PollPage({
 
   // fetch poll contents at run-time if on any network other than the default
   useEffect(() => {
-    if ((!isDefaultNetwork() && query['poll-hash']) || !prefetchedPoll) {
+    if (query['poll-hash'] && (!isDefaultNetwork() || !prefetchedPoll)) {
       getPoll(query['poll-hash'] as string)
         .then(_setPoll)
         .catch(setError);


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/339/param-issue-404-on-poll-urls

### What does this PR do?

Fix issue where poll-hash route 404s if you navigate there directly

The issue was that we were initially calling `getPoll` with an undefined slug. This set an error in the component and then never updated once we actually refetched with a slug id.

Additionally fixed a console warning that `:first-of-type` is a better selector to use than `:first-child` for server rendering.

### Steps for testing:

On `develop`, on kovan network, try to load a poll detail page directly.  You will see a 404.

On this branch, attempt the same. No 404.
