### PR TITLE
Hide on-chain effects, add comments fetch error handling

### DIFF
--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { GetStaticProps, GetStaticPaths } from 'next';
 import { useRouter } from 'next/router';
 import ErrorPage from 'next/error';
-import useSWR from 'swr';
+import Link from 'next/link';
 import {
   Button,
   Card,
@@ -18,18 +18,25 @@ import {
 } from 'theme-ui';
 import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
-import Link from 'next/link';
+import invariant from 'tiny-invariant';
+import useSWR from 'swr';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import invariant from 'tiny-invariant';
+
+// lib
 import { getExecutiveProposal, getExecutiveProposals } from 'lib/api';
 import { useSpellData, useVotedProposals } from 'lib/hooks';
 import { getNetwork, isDefaultNetwork } from 'lib/maker';
-import { /* fetchJson, parseSpellStateDiff, */ getEtherscanLink, cutMiddle } from 'lib/utils';
+import { getEtherscanLink, cutMiddle } from 'lib/utils';
 import { getStatusText } from 'lib/executive/getStatusText';
+import { useAnalytics } from 'lib/client/analytics/useAnalytics';
+import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
+
+// stores
 import useAccountsStore from 'stores/accounts';
 import { ZERO_ADDRESS } from 'stores/accounts';
-// import OnChainFx from 'components/executive/OnChainFx';
+
+//components
 import Comments from 'components/executive/Comments';
 import VoteModal from 'components/executive/VoteModal';
 import Stack from 'components/layouts/Stack';
@@ -37,10 +44,11 @@ import Tabs from 'components/Tabs';
 import PrimaryLayout from 'components/layouts/Primary';
 import SidebarLayout from 'components/layouts/Sidebar';
 import ResourceBox from 'components/ResourceBox';
+// import OnChainFx from 'components/executive/OnChainFx';
+
+//types
 import { Proposal } from 'types/proposal';
-import { SpellStateDiff } from 'types/spellStateDiff';
-import { useAnalytics } from 'lib/client/analytics/useAnalytics';
-import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
+// import { SpellStateDiff } from 'types/spellStateDiff';
 
 type Props = {
   proposal: Proposal;

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -25,11 +25,11 @@ import invariant from 'tiny-invariant';
 import { getExecutiveProposal, getExecutiveProposals } from 'lib/api';
 import { useSpellData, useVotedProposals } from 'lib/hooks';
 import { getNetwork, isDefaultNetwork } from 'lib/maker';
-import { fetchJson, parseSpellStateDiff, getEtherscanLink, cutMiddle } from 'lib/utils';
+import { /* fetchJson, parseSpellStateDiff, */ getEtherscanLink, cutMiddle } from 'lib/utils';
 import { getStatusText } from 'lib/executive/getStatusText';
 import useAccountsStore from 'stores/accounts';
 import { ZERO_ADDRESS } from 'stores/accounts';
-import OnChainFx from 'components/executive/OnChainFx';
+// import OnChainFx from 'components/executive/OnChainFx';
 import Comments from 'components/executive/Comments';
 import VoteModal from 'components/executive/VoteModal';
 import Stack from 'components/layouts/Stack';
@@ -74,20 +74,21 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
   const account = useAccountsStore(state => state.currentAccount);
   const bpi = useBreakpointIndex();
 
-  const [stateDiff, setStateDiff] = useState<SpellStateDiff>();
-  const [stateDiffError, setStateDiffError] = useState();
+  // ch401: hide until API is fixed
+  // const [stateDiff, setStateDiff] = useState<SpellStateDiff>();
+  // const [stateDiffError, setStateDiffError] = useState();
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const url = `/api/executive/state-diff/${proposal.address}?network=${getNetwork()}`;
-        const _stateDiff = parseSpellStateDiff(await fetchJson(url));
-        setStateDiff(_stateDiff);
-      } catch (error) {
-        setStateDiffError(error);
-      }
-    })();
-  }, []);
+  // useEffect(() => {
+  //   (async () => {
+  //     try {
+  //       const url = `/api/executive/state-diff/${proposal.address}?network=${getNetwork()}`;
+  //       const _stateDiff = parseSpellStateDiff(await fetchJson(url));
+  //       setStateDiff(_stateDiff);
+  //     } catch (error) {
+  //       setStateDiffError(error);
+  //     }
+  //   })();
+  // }, []);
 
   const { data: allSupporters, error: supportersError } = useSWR(
     `/api/executive/supporters?network=${getNetwork()}`
@@ -114,27 +115,28 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
     </div>
   );
 
-  const onChainFxTab = (
-    <div key={3} sx={{ p: [3, 4] }}>
-      <Flex sx={{ mb: 3, overflow: 'auto' }}>
-        For the spell at address
-        <ExternalLink href={getEtherscanLink(getNetwork(), proposal.address, 'address')} target="_blank">
-          <Text sx={{ ml: 2, color: 'accentBlue', ':hover': { color: 'blueLinkHover' } }}>
-            {proposal.address}
-          </Text>
-        </ExternalLink>
-      </Flex>
-      {stateDiff ? (
-        <OnChainFx stateDiff={stateDiff} />
-      ) : stateDiffError ? (
-        <Flex>Unable to fetch on-chain effects at this time</Flex>
-      ) : (
-        <Flex sx={{ alignItems: 'center' }}>
-          loading <Spinner size={20} ml={2} />
-        </Flex>
-      )}
-    </div>
-  );
+  // ch401: hide until API is fixed
+  // const onChainFxTab = (
+  //   <div key={3} sx={{ p: [3, 4] }}>
+  //     <Flex sx={{ mb: 3, overflow: 'auto' }}>
+  //       For the spell at address
+  //       <ExternalLink href={getEtherscanLink(getNetwork(), proposal.address, 'address')} target="_blank">
+  //         <Text sx={{ ml: 2, color: 'accentBlue', ':hover': { color: 'blueLinkHover' } }}>
+  //           {proposal.address}
+  //         </Text>
+  //       </ExternalLink>
+  //     </Flex>
+  //     {stateDiff ? (
+  //       <OnChainFx stateDiff={stateDiff} />
+  //     ) : stateDiffError ? (
+  //       <Flex>Unable to fetch on-chain effects at this time</Flex>
+  //     ) : (
+  //       <Flex sx={{ alignItems: 'center' }}>
+  //         loading <Spinner size={20} ml={2} />
+  //       </Flex>
+  //     )}
+  //   </div>
+  // );
 
   const hasVotedFor =
     votedProposals &&
@@ -187,32 +189,37 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
             <Heading pt={[3, 4]} px={[3, 4]} pb="3" sx={{ fontSize: [5, 6] }}>
               {'title' in proposal ? proposal.title : proposal.address}
             </Heading>
-            {'about' in proposal ? (
-              <Tabs
-                tabListStyles={{ pl: [3, 4] }}
-                tabTitles={[
-                  'Proposal Detail',
-                  'On-Chain Effects',
-                  `Comments ${comments ? `(${comments.length})` : ''}`
-                ]}
-                tabPanels={[
-                  <div
-                    key={1}
-                    sx={{ variant: 'markdown.default', p: [3, 4] }}
-                    dangerouslySetInnerHTML={{ __html: editMarkdown(proposal.content) }}
-                  />,
-                  onChainFxTab,
-                  commentsTab
-                ]}
-                banner={<ProposalTimingBanner proposal={proposal} />}
-              ></Tabs>
-            ) : (
-              <Tabs
-                tabListStyles={{ pl: [3, 4] }}
-                tabTitles={['On-Chain Effects']}
-                tabPanels={[onChainFxTab]}
-              />
-            )}
+            {
+              'about' in proposal ? (
+                <Tabs
+                  tabListStyles={{ pl: [3, 4] }}
+                  tabTitles={[
+                    'Proposal Detail',
+                    // ch401: hide until API is fixed
+                    // 'On-Chain Effects',
+                    `Comments ${comments ? `(${comments.length})` : ''}`
+                  ]}
+                  tabPanels={[
+                    <div
+                      key={1}
+                      sx={{ variant: 'markdown.default', p: [3, 4] }}
+                      dangerouslySetInnerHTML={{ __html: editMarkdown(proposal.content) }}
+                    />,
+                    // onChainFxTab,
+                    commentsTab
+                  ]}
+                  banner={<ProposalTimingBanner proposal={proposal} />}
+                ></Tabs>
+              ) : null
+              // ch401: hide until API is fixed
+              // (
+              // <Tabs
+              //   tabListStyles={{ pl: [3, 4] }}
+              //   tabTitles={['On-Chain Effects']}
+              //   tabPanels={[onChainFxTab]}
+              // />
+              // )
+            }
           </Card>
         </Box>
         <Stack gap={3}>

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -96,7 +96,10 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
 
   const { data: votedProposals } = useVotedProposals();
 
-  const { data: comments } = useSWR(`/api/executive/comments/list/${proposal.address}`);
+  const { data: comments, error: commentsError } = useSWR(
+    `/api/executive/comments/list/${proposal.address}`,
+    { refreshInterval: 60000 }
+  );
 
   const supporters = allSupporters ? allSupporters[proposal.address.toLowerCase()] : null;
 
@@ -109,7 +112,13 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
         <Comments proposal={proposal} comments={comments} />
       ) : (
         <Flex sx={{ alignItems: 'center' }}>
-          loading <Spinner size={20} ml={2} />
+          {commentsError ? (
+            'Unable to fetch comments'
+          ) : (
+            <>
+              Loading <Spinner size={20} ml={2} />
+            </>
+          )}
         </Flex>
       )}
     </div>


### PR DESCRIPTION
### Link to Clubhouse story

https://app.clubhouse.io/dux-makerdao/story/401/error-fetching-on-chain-effects

### What does this PR do?

Hides on-chain effects tab since we know it will error everytime until the (third party) API is updated.

Also adds error handling for the comments tab so that it doesn't perpetually say "loading" if there is an issue fetching comments.

### Steps for testing:

Go to an executive proposal. See that the tab no longer exists.
