### PR TITLE
Feature/ch441/map executive supporters addresses to delegate

### DIFF
--- a/components/delegations/DelegatesSystemInfo.tsx
+++ b/components/delegations/DelegatesSystemInfo.tsx
@@ -43,7 +43,7 @@ export function DelegatesSystemInfo({
   return (
     <Box className={className}>
       <Heading mt={3} mb={2} as="h3" variant="microHeading">
-        Delegate System Info
+        System Info
       </Heading>
       <Card variant="compact">
         <StackLayout gap={3}>

--- a/pages/api/executive/supporters.ts
+++ b/pages/api/executive/supporters.ts
@@ -5,17 +5,30 @@ import { isSupportedNetwork } from 'lib/maker';
 import { getConnectedMakerObj } from 'lib/api/utils';
 import { DEFAULT_NETWORK } from 'lib/constants';
 import withApiHandler from 'lib/api/withApiHandler';
+import { fetchDelegates } from 'lib/delegates/fetchDelegates';
 
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
   const network = (req.query.network as string) || DEFAULT_NETWORK;
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
   const maker = await getConnectedMakerObj(network);
-  const allSupporters = await maker.service('chief').getVoteTally();
+  const [allSupporters, delegatesResponse] = await Promise.all([
+    maker.service('chief').getVoteTally(),
+    fetchDelegates(network)
+  ]);
 
+  // map delegate addresses to name
+  const delegates = delegatesResponse.delegates.reduce((acc, cur) => {
+    const formattedName = !cur.name || cur.name === '' ? 'Shadow Delegate' : cur.name;
+    acc[cur.voteDelegateAddress] = formattedName;
+    return acc;
+  }, {});
+
+  // handle percent and check address for delegate name
   Object.keys(allSupporters).forEach(spell => {
     allSupporters[spell].forEach(supporter => {
       if (supporter.percent === 'NaN') supporter.percent = '0.00';
+      if (delegates[supporter.address]) supporter.name = delegates[supporter.address];
     });
   });
 

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -141,12 +141,7 @@ const Delegates = ({ delegates, stats, proposals }: Props) => {
               </Box>
             </Card>
           </Box>
-
           {stats && <DelegatesSystemInfo stats={stats} />}
-
-          <SystemStatsSidebar
-            fields={['polling contract', 'savings rate', 'total dai', 'debt ceiling', 'system surplus']}
-          />
           <ResourceBox />
         </Stack>
       </SidebarLayout>

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -28,6 +28,7 @@ import { getExecutiveProposal, getExecutiveProposals } from 'lib/api';
 import { useSpellData, useVotedProposals } from 'lib/hooks';
 import { getNetwork, isDefaultNetwork } from 'lib/maker';
 import { getEtherscanLink, cutMiddle } from 'lib/utils';
+import { limitString } from 'lib/string';
 import { getStatusText } from 'lib/executive/getStatusText';
 import { useAnalytics } from 'lib/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
@@ -283,12 +284,26 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
                         {supporter.percent}% ({new BigNumber(supporter.deposits).toFormat(2)} MKR)
                       </Text>
                       <ExternalLink
-                        href={getEtherscanLink(getNetwork(), supporter.address, 'address')}
+                        href={
+                          supporter.name && supporter.name !== 'Shadow Delegate'
+                            ? `/delegates/${supporter.address}`
+                            : getEtherscanLink(getNetwork(), supporter.address, 'address')
+                        }
                         target="_blank"
                       >
-                        <Text sx={{ color: 'accentBlue', fontSize: 3, ':hover': { color: 'blueLinkHover' } }}>
-                          {cutMiddle(supporter.address)}
-                        </Text>
+                        {supporter.name ? (
+                          <Text
+                            sx={{ color: 'accentBlue', fontSize: 3, ':hover': { color: 'blueLinkHover' } }}
+                          >
+                            {limitString(supporter.name, 28, '...')}
+                          </Text>
+                        ) : (
+                          <Text
+                            sx={{ color: 'accentBlue', fontSize: 3, ':hover': { color: 'blueLinkHover' } }}
+                          >
+                            {cutMiddle(supporter.address)}
+                          </Text>
+                        )}
                       </ExternalLink>
                     </Flex>
                   ))


### PR DESCRIPTION
### Link to Clubhouse story
https://app.clubhouse.io/dux-makerdao/story/441/map-executive-supporters-addresses-to-delegate-contracts

### What does this PR do?
Maps supporters addresses to delegate contract addresses. It displays the name of the delegate instead of the address if a match is found.

It also removes the polling system info from the delegates page.

### Steps for testing:
Go to an executive detail page. See the supporters section has been updated. Test the links.

### Screenshots (if relevant):
<img width="433" alt="Screen Shot 2021-08-24 at 9 55 11 AM" src="https://user-images.githubusercontent.com/5225766/130579020-1ef1578c-4e74-4475-9205-817e5fdb612a.png">

### Add a GIF:
![](https://media.giphy.com/media/tn1cGqW0xWyfm/giphy.gif)