### PR TITLE
change repo to makerdao-dux to fetch polls & delegates info

### DIFF
--- a/lib/delegates/getDelegatesRepositoryInfo.ts
+++ b/lib/delegates/getDelegatesRepositoryInfo.ts
@@ -7,8 +7,14 @@ type RepositoryInfo = {
 };
 
 export function getDelegatesRepositoryInformation(network: SupportedNetworks): RepositoryInfo {
-  const repoMainnet = {
-    owner: 'makerdao',
+  // const repoMainnet = {
+  //   owner: 'makerdao',
+  //   repo: 'community',
+  //   page: 'governance/delegates'
+  // };
+
+  const repoMainnetFork = {
+    owner: 'makerdao-dux',
     repo: 'community',
     page: 'governance/delegates'
   };
@@ -19,6 +25,6 @@ export function getDelegatesRepositoryInformation(network: SupportedNetworks): R
     page: 'delegates'
   };
 
-  const delegatesRepositoryInfo = network === SupportedNetworks.MAINNET ? repoMainnet : repoKovan;
+  const delegatesRepositoryInfo = network === SupportedNetworks.MAINNET ? repoMainnetFork : repoKovan;
   return delegatesRepositoryInfo;
 }

--- a/modules/executives/api/fetchExecutives.ts
+++ b/modules/executives/api/fetchExecutives.ts
@@ -21,7 +21,8 @@ export async function getExecutiveProposals(): Promise<CMSProposal[]> {
   
     const proposalIndex = await (await fetch(EXEC_PROPOSAL_INDEX)).json();
   
-    const owner = 'makerdao';
+    // const owner = 'makerdao';
+    const owner = 'makerdao-dux';
     const repo = 'community';
     const path = 'governance/votes';
   


### PR DESCRIPTION
### Link to Clubhouse story
https://app.clubhouse.io/dux-makerdao/story/455/create-our-own-repo-for-portal-markdown-data

### What does this PR do?
Changes the target endpoint for polls and delegates markdown to come from our own fork of the community repo.

### Steps for testing:
1. wait until someone makes a commit to the makerdao/community repo: https://github.com/makerdao/community
2. check our fork to see if it was auto updated: https://github.com/makerdao-dux/community
3. check the preview deployment of this branch to make sure it received the updates: https://governance-portal-v2-git-feature-ch455crea-501174-dux-core-unit.vercel.app/

### Screenshots (if relevant):

### Any additional helpful information?:
I installed this github app to keep the repo up to date, we'll need to make sure it's working correctly for a while before merging this.
https://github.com/wei/pull

### Add a GIF:
![](https://c.tenor.com/5DOkAsngwEsAAAAd/vine-i-cant-believe-youve-done-this.gif)
