### PR TITLE
fix: add ranked label and make image round

### DIFF
--- a/modules/delegates/components/DelegatePicture.tsx
+++ b/modules/delegates/components/DelegatePicture.tsx
@@ -5,7 +5,6 @@ import { Icon } from '@makerdao/dai-ui-icons';
 import { Delegate } from '../types';
 import Tooltip from 'components/Tooltip';
 import { DelegateParticipationMetrics } from './DelegateParticipationMetrics';
-import { CurrentlySupportingExecutive } from 'modules/executives/components/CurrentlySupportingExecutive';
 
 export function DelegatePicture({ delegate }: { delegate: Delegate }): React.ReactElement {
 
@@ -13,13 +12,12 @@ export function DelegatePicture({ delegate }: { delegate: Delegate }): React.Rea
 
 
   const delegateMetrics = (
-    <Box sx={{ display: 'flex'}}>
-      
-      <img width='200px' height='200px' src={delegatePicture} />
-      <Box sx={{ marginLeft: 1 }}>
-        <DelegateParticipationMetrics delegate={delegate} />
-        <CurrentlySupportingExecutive address={delegate.voteDelegateAddress} />
-
+    <Box sx={{ maxWidth: ['auto', '530px'], width: ['auto', '530px'], display: 'block'}}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', flexDirection: ['column', 'row'] }}>
+        <img  sx={{ borderRadius: '100%', width: ['150px', '200px'], height: ['150px', '200px'] }} src={delegatePicture} />
+        <Box sx={{ marginLeft: 1, flex: 1 }}>
+          <DelegateParticipationMetrics delegate={delegate} />
+        </Box>
       </Box>
     </Box>
   );

--- a/modules/executives/components/CurrentlySupportingExecutive.tsx
+++ b/modules/executives/components/CurrentlySupportingExecutive.tsx
@@ -42,7 +42,7 @@ export function CurrentlySupportingExecutive({ address }: { address: string }): 
     supportText ? <Box>
       <Divider my={1} />
       <Flex sx={{ py: 2, justifyContent: 'center', fontSize: [1, 2], color: 'onSecondary' }}>
-        <Text as="p" sx={{ textAlign: 'center', px: [3, 4], mb: 1 }}>
+        <Text as="p" sx={{ textAlign: 'center', px: [3, 4], mb: 1, wordBreak: 'break-word' }}>
           {supportText}
         </Text>
       </Flex>

--- a/modules/polls/components/PollVoteHistoryItem.tsx
+++ b/modules/polls/components/PollVoteHistoryItem.tsx
@@ -103,7 +103,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
             sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'bold', textAlign: ['left', 'right'] }}
             as="p"
           >
-            Voted {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && '(Ranked Choice)'}
+            Option {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && '(Ranked Choice)'}
           </Text>
           <Text
             as="p"

--- a/modules/polls/components/PollVoteHistoryItem.tsx
+++ b/modules/polls/components/PollVoteHistoryItem.tsx
@@ -4,7 +4,7 @@ import Tooltip from 'components/Tooltip';
 import { getNetwork } from 'lib/maker';
 import moment from 'moment';
 import Link from 'next/link';
-import { Box, Text, jsx, Link as ThemeUILink } from 'theme-ui';
+import { Box, Text, jsx, Link as ThemeUILink, Badge } from 'theme-ui';
 import { PollVoteHistory } from '../types/pollVoteHistory';
 import { PollVotePluralityResultsCompact } from './PollVotePluralityResultsCompact';
 import { parseRawPollTally } from '../helpers/parseRawTally';
@@ -62,16 +62,18 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
               </ThemeUILink>
             </Link>
 
-            {vote.poll.discussionLink && (
-              <Box mt={2}>
-                <ThemeUILink title="Discussion" href={vote.poll.discussionLink} target="_blank">
+            <Box mt={2} sx={{ display: 'flex', alignItems: 'center' }}>
+              {vote.poll.discussionLink && (
+                <ThemeUILink title="Discussion" href={vote.poll.discussionLink} target="_blank" sx={{ mr: 2 }}>
                   <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
                     Discussion
                     <Icon ml={2} name="arrowTopRight" size={2} />
                   </Text>
                 </ThemeUILink>
-              </Box>
-            )}
+              )}
+              
+            </Box>
+
           </Box>
         </Tooltip>
       </Box>
@@ -87,6 +89,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
           mt: [2, 0]
         }}
       >
+
         {vote.poll.voteType === POLL_VOTE_TYPE.PLURALITY_VOTE && (
           <Box mr={0} ml={0}>
             <PollVotePluralityResultsCompact vote={vote} />
@@ -115,6 +118,17 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
           >
             {vote.optionValue}
           </Text>
+
+          {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && (
+                <Box >
+                  <Badge
+                    variant="primary"
+                  >
+                    Ranked vote
+                  </Badge>
+                </Box>
+              )}
+
         </Box>
       </Box>
     </Box>

--- a/modules/polls/components/PollVoteHistoryItem.tsx
+++ b/modules/polls/components/PollVoteHistoryItem.tsx
@@ -4,7 +4,7 @@ import Tooltip from 'components/Tooltip';
 import { getNetwork } from 'lib/maker';
 import moment from 'moment';
 import Link from 'next/link';
-import { Box, Text, jsx, Link as ThemeUILink, Badge } from 'theme-ui';
+import { Box, Text, jsx, Link as ThemeUILink } from 'theme-ui';
 import { PollVoteHistory } from '../types/pollVoteHistory';
 import { PollVotePluralityResultsCompact } from './PollVotePluralityResultsCompact';
 import { parseRawPollTally } from '../helpers/parseRawTally';
@@ -71,7 +71,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
                   </Text>
                 </ThemeUILink>
               )}
-              
+
             </Box>
 
           </Box>
@@ -103,7 +103,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
             sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'bold', textAlign: ['left', 'right'] }}
             as="p"
           >
-            Voted
+            Voted {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && '(Ranked Choice)'}
           </Text>
           <Text
             as="p"
@@ -119,15 +119,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
             {vote.optionValue}
           </Text>
 
-          {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && (
-                <Box >
-                  <Badge
-                    variant="primary"
-                  >
-                    Ranked vote
-                  </Badge>
-                </Box>
-              )}
+
 
         </Box>
       </Box>

--- a/modules/polls/components/VotesByAddress.tsx
+++ b/modules/polls/components/VotesByAddress.tsx
@@ -34,7 +34,7 @@ const VotesByAddress = ({ votes, totalMkrParticipation, poll }: Props): JSX.Elem
               Address
             </Text>
             <Text as="th" sx={{ textAlign: 'left', pb: 2 }} variant="caps">
-              Voted
+              Option
             </Text>
             <Text as="th" sx={{ textAlign: 'left', pb: 2 }} variant="caps">
               Voting Power


### PR DESCRIPTION
### what

- It adds the ranked label 
- makes delegate image round and better on phone
![image](https://user-images.githubusercontent.com/1152768/131684898-660283f2-d5a5-429e-9533-06807dd73d30.png)