### PR TITLE
Check if address is a proxy contract

### DIFF
--- a/lib/abis/voteProxyAbi.json
+++ b/lib/abis/voteProxyAbi.json
@@ -1,0 +1,102 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "gov",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cold",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "freeAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "iou",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "slate", "type": "bytes32" }],
+    "name": "vote",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "free",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "lock",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "hot",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "yays", "type": "address[]" }],
+    "name": "vote",
+    "outputs": [{ "name": "", "type": "bytes32" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "chief",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "_chief", "type": "address" },
+      { "name": "_cold", "type": "address" },
+      { "name": "_hot", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  }
+]

--- a/lib/maker/index.ts
+++ b/lib/maker/index.ts
@@ -97,10 +97,9 @@ async function getMaker(network?: SupportedNetworks): Promise<Maker> {
       log: false,
       multicall: true
     });
-  
+
     makerSingletons[currentNetwork] = instance;
   }
-
 
   return makerSingletons[currentNetwork];
 }

--- a/modules/address/components/AddressDetail.tsx
+++ b/modules/address/components/AddressDetail.tsx
@@ -1,22 +1,34 @@
 /** @jsx jsx */
 import React from 'react';
 import { jsx, Box, Text, Link as ExternalLink, Flex, Heading } from 'theme-ui';
-import { useBreakpointIndex } from '@theme-ui/match-media';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
 import AddressIcon from './AddressIcon';
 import { PollVoteHistoryList } from 'modules/polls/components/PollVoteHistoryList';
-import { AddressAPIStats } from '../types/addressApiResponse';
+import { AddressAPIStats, VoteProxyInfo } from '../types/addressApiResponse';
+import Tooltip from 'components/Tooltip';
 
 type PropTypes = {
   address: string;
   stats: AddressAPIStats;
-  isProxyContract: boolean;
+  voteProxyInfo?: VoteProxyInfo;
 };
 
-export function AddressDetail({ address, stats, isProxyContract }: PropTypes): React.ReactElement {
-  const bpi = useBreakpointIndex();
-
+export function AddressDetail({ address, stats, voteProxyInfo }: PropTypes): React.ReactElement {
+  const tooltipLabel = voteProxyInfo ? (
+    <Box sx={{ p: 2 }}>
+      <Text as="p">
+        <Text sx={{ fontWeight: 'bold' }}>Contract:</Text> {voteProxyInfo.voteProxyAddress}
+      </Text>
+      <Text as="p">
+        <Text sx={{ fontWeight: 'bold' }}>Hot:</Text> {voteProxyInfo.hot}
+      </Text>
+      <Text as="p">
+        <Text sx={{ fontWeight: 'bold' }}>Cold:</Text> {voteProxyInfo.cold}
+      </Text>
+    </Box>
+  ) : null;
   return (
     <Box sx={{ variant: 'cards.primary', p: [0, 0] }}>
       <Box sx={{ p: 3 }}>
@@ -39,12 +51,29 @@ export function AddressDetail({ address, stats, isProxyContract }: PropTypes): R
                 {address}
               </Text>
             </ExternalLink>
-            {isProxyContract && <Text sx={{ color: 'textSecondary', fontSize: [1, 2] }}>Proxy Contract</Text>}
+            {voteProxyInfo && (
+              <Flex>
+                <Text sx={{ color: 'textSecondary', fontSize: [1, 2] }}>Proxy Contract</Text>{' '}
+                <Tooltip label={tooltipLabel}>
+                  <Box>
+                    <Icon name="question" ml={2} mt={'6px'} />
+                  </Box>
+                </Tooltip>{' '}
+              </Flex>
+            )}
           </Flex>
         </Flex>
 
         <Flex sx={{ mt: 3, flexDirection: 'column' }}>
-          <Heading>Polling Vote History</Heading>
+          <Text
+            as="p"
+            sx={{
+              fontSize: 4,
+              fontWeight: 'semiBold'
+            }}
+          >
+            Polling Proposals
+          </Text>
           <PollVoteHistoryList votes={stats.pollVoteHistory} />
         </Flex>
       </Box>

--- a/modules/address/components/AddressDetail.tsx
+++ b/modules/address/components/AddressDetail.tsx
@@ -10,31 +10,37 @@ import { AddressAPIStats } from '../types/addressApiResponse';
 
 type PropTypes = {
   address: string;
-  stats: AddressAPIStats
+  stats: AddressAPIStats;
+  isProxyContract: boolean;
 };
 
-export function AddressDetail({ address, stats }: PropTypes): React.ReactElement {
+export function AddressDetail({ address, stats, isProxyContract }: PropTypes): React.ReactElement {
   const bpi = useBreakpointIndex();
 
   return (
     <Box sx={{ variant: 'cards.primary', p: [0, 0] }}>
       <Box sx={{ p: 3 }}>
         <Flex>
-          <AddressIcon address={address} width='41px' />
-          <Box sx={{ width: '100%' }}>
-            <Box sx={{ ml: 2 }}>
-
-              <ExternalLink
-                title="View on etherescan"
-                href={getEtherscanLink(getNetwork(), address, 'address')}
-                target="_blank"
-              >
-                <Text as="p" sx={{ fontSize: bpi > 0 ? 3 : 1 }}>
-                  {address}
-                </Text>
-              </ExternalLink>
-            </Box>
-          </Box>
+          <AddressIcon address={address} width="41px" />
+          <Flex
+            sx={{
+              ml: 2,
+              width: '100%',
+              flexDirection: 'column',
+              justifyContent: 'center'
+            }}
+          >
+            <ExternalLink
+              title="View on etherescan"
+              href={getEtherscanLink(getNetwork(), address, 'address')}
+              target="_blank"
+            >
+              <Text as="p" sx={{ fontSize: [1, 3] }}>
+                {address}
+              </Text>
+            </ExternalLink>
+            {isProxyContract && <Text sx={{ color: 'textSecondary', fontSize: [1, 2] }}>Proxy Contract</Text>}
+          </Flex>
         </Flex>
 
         <Flex sx={{ mt: 3, flexDirection: 'column' }}>

--- a/modules/address/types/addressApiResponse.d.ts
+++ b/modules/address/types/addressApiResponse.d.ts
@@ -5,9 +5,16 @@ export type AddressAPIStats = {
   pollVoteHistory: PollVoteHistory[];
 };
 
+export type VoteProxyInfo = {
+  voteProxyAddress: string;
+  hot: string;
+  cold: string;
+};
+
 export type AddressApiResponse = {
   isDelegate: boolean;
   isProxyContract: boolean;
+  voteProxyInfo?: VoteProxyInfo;
   delegateInfo?: Delegate;
   address: string;
   stats: AddressAPIStats;

--- a/modules/address/types/addressApiResponse.d.ts
+++ b/modules/address/types/addressApiResponse.d.ts
@@ -1,13 +1,14 @@
 import { PollVoteHistory } from 'modules/polls/types';
 import { Delegate } from 'modules/delegates/types';
 
-export type AddressAPIStats =  {
-  pollVoteHistory: PollVoteHistory[]
-}
+export type AddressAPIStats = {
+  pollVoteHistory: PollVoteHistory[];
+};
 
 export type AddressApiResponse = {
-  isDelegate: boolean,
-  delegateInfo?: Delegate,
-  address: string,
-  stats: AddressAPIStats
-}
+  isDelegate: boolean;
+  isProxyContract: boolean;
+  delegateInfo?: Delegate;
+  address: string;
+  stats: AddressAPIStats;
+};

--- a/modules/polls/api/fetchAddressPollVoteHistory.ts
+++ b/modules/polls/api/fetchAddressPollVoteHistory.ts
@@ -6,38 +6,46 @@ import { PollVoteHistory } from '../types/pollVoteHistory';
 import { getPolls } from './fetchPolls';
 import { fetchPollTally } from './fetchPollTally';
 
-export async function fetchAddressPollVoteHistory(address:string, network: SupportedNetworks): Promise<PollVoteHistory[]> {
+export async function fetchAddressPollVoteHistory(
+  address: string,
+  network: SupportedNetworks
+): Promise<PollVoteHistory[]> {
   const maker = await getMaker(network);
 
   // TODO: This is an innefective way to cross fetch titles and options. We should improve Spock DB to return the titles in the poll votes
   const polls = await getPolls(network);
 
-  const voteHistory = await maker
-    .service('govPolling')
-    .getAllOptionsVotingFor(address);
+  const voteHistory = await maker.service('govPolling').getAllOptionsVotingFor(address);
 
-  const items = await Promise.all(voteHistory
-    .map(async (pollVote: PollVote): Promise<PollVoteHistory|null> => {
-      const poll = polls.find(poll => poll.pollId === pollVote.pollId);
-      // This should not happen but we do it to avoid typescript checks with undefined values. We want to force poll always being something
-      if (!poll) {
-        return null;
+  const items = await Promise.all(
+    voteHistory.map(
+      async (pollVote: PollVote): Promise<PollVoteHistory | null> => {
+        const poll = polls.find(poll => poll.pollId === pollVote.pollId);
+        // This should not happen but we do it to avoid typescript checks with undefined values. We want to force poll always being something
+        if (!poll) {
+          return null;
+        }
+
+        const tally = await fetchPollTally(pollVote.pollId, network);
+
+        const optionValue =
+          poll && poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE
+            ? pollVote.rankedChoiceOption && typeof pollVote.rankedChoiceOption[0] !== 'undefined'
+              ? poll.options[pollVote.rankedChoiceOption[0]]
+              : ''
+            : typeof pollVote.option !== 'undefined'
+            ? poll.options[pollVote.option]
+            : '';
+
+        return {
+          ...pollVote,
+          poll,
+          tally,
+          optionValue: optionValue as string
+        };
       }
-
-      const tally = await fetchPollTally(pollVote.pollId, network);
-
-      const optionValue = poll  && poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE
-        ? (pollVote.rankedChoiceOption && typeof pollVote.rankedChoiceOption[0] !== 'undefined' ?  poll.options[pollVote.rankedChoiceOption[0]]: '' )
-        : (typeof pollVote.option !== 'undefined' ? poll.options[pollVote.option] :  '');
-
-      return {
-        ...pollVote,
-        poll,
-        tally,
-        optionValue: optionValue as string
-      };
-    }));
+    )
+  );
 
   return items.filter(pollVote => !!pollVote) as PollVoteHistory[];
 }
-

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -62,7 +62,7 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
               <AddressDetail
                 address={addressInfo.address}
                 stats={addressInfo.stats}
-                isProxyContract={addressInfo.isProxyContract}
+                voteProxyInfo={addressInfo.voteProxyInfo}
               />
             )}
           </Box>

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -59,7 +59,11 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
               <DelegateDetail delegate={addressInfo.delegateInfo} stats={addressInfo.stats} />
             )}
             {!addressInfo.delegateInfo && (
-              <AddressDetail address={addressInfo.address} stats={addressInfo.stats} />
+              <AddressDetail
+                address={addressInfo.address}
+                stats={addressInfo.stats}
+                isProxyContract={addressInfo.isProxyContract}
+              />
             )}
           </Box>
         </Stack>

--- a/pages/api/address/[address]/index.ts
+++ b/pages/api/address/[address]/index.ts
@@ -1,6 +1,7 @@
 import invariant from 'tiny-invariant';
 import { NextApiRequest, NextApiResponse } from 'next';
-
+import getMaker from 'lib/maker';
+import voteProxyFactoryAbi from 'lib/abis/voteProxyAbi.json';
 import { isSupportedNetwork } from 'lib/maker/index';
 import { DEFAULT_NETWORK } from 'lib/constants';
 import withApiHandler from 'lib/api/withApiHandler';
@@ -13,11 +14,23 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<A
   const address = req.query.address as string;
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
 
+  const maker = await getMaker();
+  const voteProxy = maker.service('smartContract').getContractByAddressAndAbi(address, voteProxyFactoryAbi);
+
+  // TODO: should we check cold for history?
+  let hot;
+  try {
+    hot = await voteProxy.hot();
+  } catch (err) {
+    // console.log(err);
+  }
+
   const delegate = await fetchDelegate(address, network);
-  const pollVoteHistory = await fetchAddressPollVoteHistory(address, network);
+  const pollVoteHistory = await fetchAddressPollVoteHistory(hot ? hot : address, network);
 
   const response: AddressApiResponse = {
     isDelegate: !!delegate,
+    isProxyContract: !!hot,
     delegateInfo: delegate,
     address,
     stats: {


### PR DESCRIPTION
### What does this PR do?

Currently, the vote breakdown lists the proxy address as the voter

If you click the proxy address, there's no history to show (we don't query for it in spock)

This adds a check to see if the address is a proxy contract before fetching history. If it is, it fetches the history for the hot wallet.

We might want to move this logic to spock instead. We should also consider how we want to convey this info in the UI.