### PR TITLE
hide scrollbar in exec supporters

### DIFF
--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -256,7 +256,16 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
               Supporters
             </Heading>
             <Card variant="compact" p={3} sx={{ height: '237px' }}>
-              <Box sx={{ overflowY: 'auto', height: '100%' }}>
+              <Box
+                sx={{
+                  overflowY: 'scroll',
+                  height: '100%',
+                  '::-webkit-scrollbar': {
+                    display: 'none'
+                  },
+                  scrollbarWidth: 'none'
+                }}
+              >
                 {supporters ? (
                   supporters.map(supporter => (
                     <Flex


### PR DESCRIPTION
### Screenshots (if relevant):
Before:
<img width="410" alt="Screen Shot 2021-09-14 at 7 20 39 PM" src="https://user-images.githubusercontent.com/3388550/133375358-7b08a312-4828-45da-897a-06e94f9beedb.png">
After:
<img width="415" alt="Screen Shot 2021-09-14 at 7 21 37 PM" src="https://user-images.githubusercontent.com/3388550/133375362-77b93ea6-6e75-432e-903e-f98fc866c76f.png">


