### PR TITLE
Remove breakdown tooltip + align proxy text

### DIFF
--- a/modules/address/components/AddressDetail.tsx
+++ b/modules/address/components/AddressDetail.tsx
@@ -57,10 +57,10 @@ export function AddressDetail({ address, stats, voteProxyInfo }: PropTypes): Rea
             </ExternalLink>
             {voteProxyInfo && (
               <Flex>
-                <Text sx={{ color: 'textSecondary', fontSize: [1, 2] }}>Proxy Contract</Text>{' '}
+                <Text sx={{ color: 'textSecondary', ml: 2, fontSize: [1, 2] }}>Proxy Contract</Text>{' '}
                 <Tooltip label={tooltipLabel}>
                   <Box>
-                    <Icon name="question" ml={2} mt={'6px'} />
+                    <Icon name="question" ml={2} mt={['2px', '4px']} />
                   </Box>
                 </Tooltip>{' '}
               </Flex>

--- a/modules/polling/components/PollVoteHistoryItem.tsx
+++ b/modules/polling/components/PollVoteHistoryItem.tsx
@@ -1,13 +1,10 @@
 /** @jsx jsx */
-import VoteBreakdown from './VoteBreakdown';
-import Tooltip from 'components/Tooltip';
 import { getNetwork } from 'lib/maker';
 import moment from 'moment';
 import Link from 'next/link';
 import { Box, Text, jsx, Link as ThemeUILink } from 'theme-ui';
 import { PollVoteHistory } from '../types/pollVoteHistory';
 import { PollVotePluralityResultsCompact } from './PollVotePluralityResultsCompact';
-import { parseRawPollTally } from '../helpers/parseRawTally';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { POLL_VOTE_TYPE } from '../polls.constants';
 
@@ -16,14 +13,6 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
 
   const dateFormat = 'MMM DD YYYY HH:mm zz';
   const voteDate = moment(vote.blockTimestamp);
-  const voteBreakdown = (
-    <VoteBreakdown
-      poll={vote.poll}
-      tally={parseRawPollTally(vote.tally, vote.poll)}
-      shownOptions={3}
-      key={vote.pollId}
-    />
-  );
 
   const voteColorStyles = ['secondaryEmphasis', 'primary', 'notice'];
   return (
@@ -40,45 +29,36 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
           mr: [0, 2]
         }}
       >
-        <Tooltip label={voteBreakdown}>
-          <Box>
+        <Text
+          variant="secondary"
+          color="onSecondary"
+          sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'bold' }}
+          as="p"
+        >
+          Voted {voteDate.format(dateFormat)}
+        </Text>
+
+        <Link href={`/polling/${vote.poll.slug}?network=${network}`} passHref>
+          <ThemeUILink variant="nostyle">
             <Text
-              variant="secondary"
-              color="onSecondary"
-              sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'bold' }}
               as="p"
+              sx={{ fontSize: '18px', fontWeight: 'semiBold', color: 'secondaryAlt', mt: 1, mb: 1 }}
             >
-              Voted {voteDate.format(dateFormat)}
+              {vote.poll.title}
             </Text>
+          </ThemeUILink>
+        </Link>
 
-            <Link href={`/polling/${vote.poll.slug}?network=${network}`} passHref>
-              <ThemeUILink variant="nostyle">
-                <Text
-                  as="p"
-                  sx={{ fontSize: '18px', fontWeight: 'semiBold', color: 'secondaryAlt', mt: 1, mb: 1 }}
-                >
-                  {vote.poll.title}
-                </Text>
-              </ThemeUILink>
-            </Link>
-
-            <Box mt={2} sx={{ display: 'flex', alignItems: 'center' }}>
-              {vote.poll.discussionLink && (
-                <ThemeUILink
-                  title="Discussion"
-                  href={vote.poll.discussionLink}
-                  target="_blank"
-                  sx={{ mr: 2 }}
-                >
-                  <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
-                    Discussion
-                    <Icon ml={2} name="arrowTopRight" size={2} />
-                  </Text>
-                </ThemeUILink>
-              )}
-            </Box>
-          </Box>
-        </Tooltip>
+        <Box mt={2} sx={{ display: 'flex', alignItems: 'center' }}>
+          {vote.poll.discussionLink && (
+            <ThemeUILink title="Discussion" href={vote.poll.discussionLink} target="_blank" sx={{ mr: 2 }}>
+              <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
+                Discussion
+                <Icon ml={2} name="arrowTopRight" size={2} />
+              </Text>
+            </ThemeUILink>
+          )}
+        </Box>
       </Box>
 
       <Box
@@ -105,7 +85,7 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
             sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'bold', textAlign: 'right' }}
             as="p"
           >
-            {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE ? 'Voted 1st Choice': 'VOTED OPTION'}
+            {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE ? 'Voted 1st Choice' : 'VOTED OPTION'}
           </Text>
           <Text
             as="p"

--- a/modules/polling/components/PollVoteHistoryList.tsx
+++ b/modules/polling/components/PollVoteHistoryList.tsx
@@ -10,7 +10,10 @@ export function PollVoteHistoryList({ votes }: { votes: PollVoteHistory[] }): Re
       paddingBottom: 3,
       marginBottom: 3,
       borderBottom: '1px solid',
-      borderColor: 'secondary'
+      borderColor: 'secondary',
+      ':last-child': {
+        border: 'none'
+      }
     }
   };
 
@@ -24,7 +27,7 @@ export function PollVoteHistoryList({ votes }: { votes: PollVoteHistory[] }): Re
         ))}
       {votes.length === 0 && (
         <Box mt={1}>
-          <Text>This address has never voted</Text>
+          <Text>No polling vote history found</Text>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/525/change-vote-breakdown-popup-hover-behaviour

https://app.shortcut.com/dux-makerdao/story/532/vertically-align-proxy-contract-label-with-address

### What does this PR do?

Remove breakdown tooltip on vote history item

Aligns proxy contract text for vote history list

### Steps for testing:

Go to `/address/0xd8bba030ae1b52a5e45f5cf05de47dcbb3a1dfc4?network=mainnet`

See that proxy contract text is now aligned and that vote history no longer has a tooltip hover

### Screenshots (if relevant):
<img width="485" alt="Screen Shot 2021-09-16 at 1 55 45 PM" src="https://user-images.githubusercontent.com/5225766/133607867-59afafaa-9159-43fd-a3cc-8808aee5cb5d.png">

### Add a GIF:
![](https://media.giphy.com/media/26FPEEgbycIv6wUYo/giphy.gif)