### PR TITLE
Add last voted to delegate detail

### DIFF
--- a/modules/delegates/components/DelegateCard.tsx
+++ b/modules/delegates/components/DelegateCard.tsx
@@ -8,16 +8,9 @@ import { useLockedMkr, useMkrDelegated } from 'lib/hooks';
 import { limitString } from 'lib/string';
 import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
 import { useAnalytics } from 'lib/client/analytics/useAnalytics';
-import { DelegateStatusEnum } from '../delegates.constants';
 import useAccountsStore from 'stores/accounts';
 import { Delegate } from '../types';
-import {
-  DelegatePicture,
-  DelegateModal,
-  UndelegateModal,
-  // DelegateLastVoted,
-  DelegateContractExpiration
-} from 'modules/delegates/components';
+import { DelegatePicture, DelegateModal, UndelegateModal } from 'modules/delegates/components';
 import Tooltip from 'components/Tooltip';
 import { CurrentlySupportingExecutive } from 'modules/executive/components/CurrentlySupportingExecutive';
 

--- a/modules/delegates/components/DelegateContractExpiration.tsx
+++ b/modules/delegates/components/DelegateContractExpiration.tsx
@@ -1,22 +1,13 @@
 /** @jsx jsx */
 
 import { Delegate } from '../types';
-import { Box, Text, jsx } from 'theme-ui';
+import { Text, Flex, jsx } from 'theme-ui';
 import React from 'react';
 import Icon from 'components/Icon';
 import moment from 'moment';
 
 export function DelegateContractExpiration({ delegate }: { delegate: Delegate }): React.ReactElement {
   const styles = {
-    itemWrapper: {
-      display: 'flex',
-      alignItems: 'center'
-    },
-    dateIcon: {
-      display: 'flex',
-      alignContent: 'center',
-      marginRight: 1
-    },
     expiredIcon: {
       fill: 'error',
       stroke: 'error'
@@ -31,17 +22,26 @@ export function DelegateContractExpiration({ delegate }: { delegate: Delegate })
   const expiryDate = moment(delegate.expirationDate);
 
   return (
-    <Box sx={styles.itemWrapper}>
-      <Box sx={styles.dateIcon}>
-        <Icon name="calendarcross" sx={delegate.expired ? styles.expiredIcon : styles.activeIcon} />
-      </Box>
+    <Flex
+      sx={{
+        alignItems: 'center'
+      }}
+    >
       <Text
         variant="secondary"
         color="onSecondary"
-        sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'semiBold', ml: 1 }}
+        sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'semiBold', mr: 2 }}
       >
         {delegate.expired ? 'CONTRACT DELEGATION EXPIRED' : ` EXPIRES ${expiryDate.format(dateFormat)}`}
       </Text>
-    </Box>
+      <Flex
+        sx={{
+          alignContent: 'center',
+          marginRight: 1
+        }}
+      >
+        <Icon name="calendarcross" sx={delegate.expired ? styles.expiredIcon : styles.activeIcon} />
+      </Flex>
+    </Flex>
   );
 }

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -1,19 +1,21 @@
 /** @jsx jsx */
 import React from 'react';
 import { jsx, Box, Text, Link as ExternalLink, Flex } from 'theme-ui';
-import { useBreakpointIndex } from '@theme-ui/match-media';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
-import { Delegate } from '../types';
-import { DelegatePicture } from './DelegatePicture';
-import { DelegateContractExpiration } from './DelegateContractExpiration';
-import { DelegateCredentials } from './DelegateCredentials';
-import { Icon } from '@makerdao/dai-ui-icons';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
 import Tabs from 'components/Tabs';
-import { DelegateVoteHistory } from './DelegateVoteHistory';
-import { DelegateParticipationMetrics } from './DelegateParticipationMetrics';
-import { DelegateStatusEnum } from '../delegates.constants';
+import {
+  DelegatePicture,
+  DelegateContractExpiration,
+  DelegateLastVoted,
+  DelegateCredentials,
+  DelegateVoteHistory,
+  DelegateParticipationMetrics
+} from 'modules/delegates/components';
+import { Delegate } from 'modules/delegates/types';
+import { DelegateStatusEnum } from 'modules/delegates/delegates.constants';
 
 type PropTypes = {
   delegate: Delegate;
@@ -45,6 +47,8 @@ export function DelegateDetail({ delegate, stats }: PropTypes): React.ReactEleme
     </Box>
   ].filter(i => !!i);
 
+  const lastVote = stats.pollVoteHistory.sort((a, b) => (a.blockTimestamp > b.blockTimestamp ? -1 : 1))[0];
+
   return (
     <Box sx={{ variant: 'cards.primary', p: [0, 0] }}>
       <Box sx={{ p: [3, 4], pb: 3 }}>
@@ -75,13 +79,11 @@ export function DelegateDetail({ delegate, stats }: PropTypes): React.ReactEleme
               </Box>
             </Flex>
           </Box>
-          <Box mt={[3, 0]}>
+          <Flex sx={{ mt: [3, 0], flexDirection: 'column', alignItems: ['flex-start', 'flex-end'] }}>
+            <DelegateLastVoted delegate={delegate} date={lastVote.blockTimestamp} />
             <DelegateContractExpiration delegate={delegate} />
-          </Box>
+          </Flex>
         </Flex>
-        {/* <Box sx={{ mr: 3 }}>
-          <DelegateLastVoted delegate={delegate} />
-        </Box> */}
       </Box>
 
       <Tabs tabListStyles={{ pl: [3, 4] }} tabTitles={tabTitles} tabPanels={tabPanels}></Tabs>

--- a/modules/delegates/components/DelegateLastVoted.tsx
+++ b/modules/delegates/components/DelegateLastVoted.tsx
@@ -1,50 +1,53 @@
 /** @jsx jsx */
 
 import { Delegate } from '../types';
-import { Box, Text, jsx } from 'theme-ui';
+import { Text, Flex, jsx } from 'theme-ui';
 import React from 'react';
 import Icon from 'components/Icon';
 import moment from 'moment';
 
-export function DelegateLastVoted({ delegate }: { delegate: Delegate }): React.ReactElement {
+export function DelegateLastVoted({
+  delegate,
+  date
+}: {
+  delegate: Delegate;
+  date: string;
+}): React.ReactElement {
   const styles = {
-    itemWrapper: {
-      display: 'flex',
-      alignItems: 'center',
-      mb: 1
-    },
-    dateIcon: {
-      display: 'flex',
-      alignContent: 'center',
-      marginRight: 1
-    },
-
     expiredCalendar: {
-      fill: 'primary',
-      stroke: 'primary'
-    },
-
-    activeCalendar: {
       fill: '#D8E0E3',
       stroke: '#D8E0E3'
+    },
+    activeCalendar: {
+      fill: 'primary',
+      stroke: 'primary'
     }
   };
 
   const dateFormat = 'MMM DD YYYY HH:mm zz';
-  const lastVoteDate = moment(delegate.lastVote);
+  const lastVoteDate = moment(date);
 
   return (
-    <Box sx={styles.itemWrapper}>
-      <Box sx={styles.dateIcon}>
-        <Icon name="calendar" sx={delegate.expired ? styles.expiredCalendar : styles.activeCalendar} />
-      </Box>
+    <Flex
+      sx={{
+        mb: 1
+      }}
+    >
       <Text
         variant="secondary"
         color={delegate.expired ? '#D8E0E3' : 'onSecondary'}
-        sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'semiBold', ml: 1 }}
+        sx={{ textTransform: 'uppercase', fontSize: 1, fontWeight: 'semiBold', mr: 2 }}
       >
         LAST VOTED {lastVoteDate.format(dateFormat)}
       </Text>
-    </Box>
+      <Flex
+        sx={{
+          alignContent: 'center',
+          mr: 1
+        }}
+      >
+        <Icon name="calendar" sx={delegate.expired ? styles.expiredCalendar : styles.activeCalendar} />
+      </Flex>
+    </Flex>
   );
 }

--- a/modules/delegates/components/index.ts
+++ b/modules/delegates/components/index.ts
@@ -12,3 +12,6 @@ export * from './DelegateDetail';
 export * from './DelegateLastVoted';
 export * from './DelegatePicture';
 export * from './DelegatesSystemInfo';
+export * from './DelegateCredentials';
+export * from './DelegateVoteHistory';
+export * from './DelegateParticipationMetrics';


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/276/add-last-voted-value-to-delegate-list-card

### What does this PR do?

Adds last voted data to delegate detail view

### Steps for testing:

Go to delegate detail

See the last voted data

### Screenshots (if relevant):

<img width="776" alt="Screen Shot 2021-09-20 at 2 21 10 PM" src="https://user-images.githubusercontent.com/5225766/134001410-d973e5fc-5b96-44b2-8c7f-97be275e35a7.png">
<img width="368" alt="Screen Shot 2021-09-20 at 2 21 21 PM" src="https://user-images.githubusercontent.com/5225766/134001414-c48ff809-52db-465c-bc4b-32d57d404817.png">

### Add a GIF:
![](https://media.giphy.com/media/l2SpWPGLYJK94yY00/giphy.gif)