### PR TITLE
Delegate modal alert

### DIFF
--- a/components/executive/Withdraw.tsx
+++ b/components/executive/Withdraw.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { useState } from 'react';
-import { Button, Flex, Text, Box, jsx, Alert } from 'theme-ui';
+import { Button, Flex, Text, Box, jsx, Alert, Link } from 'theme-ui';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import shallow from 'zustand/shallow';
@@ -20,7 +20,7 @@ import { useLockedMkr } from 'lib/hooks';
 import { useAnalytics } from 'lib/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
 
-const ModalContent = ({ address, voteProxy, voteDelegate, close, ...props }) => {
+const ModalContent = ({ address, voteProxy, close, ...props }) => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.EXECUTIVE);
 
   invariant(address);
@@ -40,8 +40,7 @@ const ModalContent = ({ address, voteProxy, voteDelegate, close, ...props }) => 
         .then(val => val?.gt('10e26')) // greater than 100,000,000 MKR
   );
 
-  const { data: lockedMkr } = useLockedMkr(address, voteProxy, voteDelegate);
-
+  const { data: lockedMkr } = useLockedMkr(address, voteProxy);
   const [track, tx] = useTransactionStore(
     state => [state.track, txId ? transactionsSelectors.getTransaction(state, txId) : null],
     shallow
@@ -179,13 +178,10 @@ const ModalContent = ({ address, voteProxy, voteDelegate, close, ...props }) => 
 
 const Withdraw = (props): JSX.Element => {
   const account = useAccountsStore(state => state.currentAccount);
-  const [voteProxy, voteDelegate] = useAccountsStore(state =>
-    account ? [state.proxies[account.address], state.voteDelegate] : [null, null]
-  );
+  const voteProxy = useAccountsStore(state => (account ? state.proxies[account.address] : null));
 
   const [showDialog, setShowDialog] = useState(false);
   const bpi = useBreakpointIndex();
-
   return (
     <>
       <DialogOverlay
@@ -211,19 +207,27 @@ const Withdraw = (props): JSX.Element => {
             sx={{ px: [3, null] }}
             address={account?.address}
             voteProxy={voteProxy}
-            voteDelegate={voteDelegate}
             close={() => setShowDialog(false)}
           />
         </DialogContent>
       </DialogOverlay>
-      <Button
-        variant="mutedOutline"
-        onClick={() => setShowDialog(true)}
-        {...props}
-        data-testid="withdraw-button"
-      >
-        Withdraw
-      </Button>
+      {props.link ? (
+        <Link
+          onClick={() => setShowDialog(true)}
+          sx={{ textDecoration: 'underline', cursor: 'pointer', color: 'inherit' }}
+        >
+          {props.link}
+        </Link>
+      ) : (
+        <Button
+          variant="mutedOutline"
+          onClick={() => setShowDialog(true)}
+          {...props}
+          data-testid="withdraw-button"
+        >
+          Withdraw
+        </Button>
+      )}
     </>
   );
 };

--- a/components/executive/Withdraw.tsx
+++ b/components/executive/Withdraw.tsx
@@ -19,12 +19,13 @@ import { BoxWithClose } from 'components/BoxWithClose';
 import { useLockedMkr } from 'lib/hooks';
 import { useAnalytics } from 'lib/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'lib/client/analytics/analytics.constants';
+import BigNumber from 'bignumber.js';
 
 const ModalContent = ({ address, voteProxy, close, ...props }) => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.EXECUTIVE);
 
   invariant(address);
-  const [mkrToWithdraw, setMkrToWithdraw] = useState(MKR(0));
+  const [mkrToWithdraw, setMkrToWithdraw] = useState(new BigNumber(0));
   const [txId, setTxId] = useState(null);
 
   const { data: allowanceOk } = useSWR<CurrencyObject>(
@@ -104,7 +105,7 @@ const ModalContent = ({ address, voteProxy, close, ...props }) => {
         )}
         <Button
           sx={{ flexDirection: 'column', width: '100%', alignItems: 'center', mt: 3 }}
-          disabled={mkrToWithdraw.eq(0) || mkrToWithdraw.gt(lockedMkr)}
+          disabled={mkrToWithdraw.eq(0) || !lockedMkr || mkrToWithdraw.gt(lockedMkr.toBigNumber())}
           onClick={async () => {
             trackButtonClick('withdrawMkr');
             const maker = await getMaker();

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -27,9 +27,6 @@ export default {
     ornament: '#000',
     skeletonColor: '#EEE',
     skeletonHighlightColor: '#F5F5F5',
-    info: '#fbd16f',
-    infoAlt: '#fff8eb',
-    onInfo: '#826417',
     modes: {
       dark: {
         primary: '#1DC1AE',
@@ -146,15 +143,6 @@ export default {
     nostyle: {
       textDecoration: 'none',
       color: 'inherit'
-    }
-  },
-  alerts: {
-    ...theme.alerts,
-    information: {
-      variant: 'alerts.primary',
-      borderColor: 'info',
-      bg: 'infoAlt',
-      color: 'onInfo'
     }
   },
   buttons: {

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -27,6 +27,9 @@ export default {
     ornament: '#000',
     skeletonColor: '#EEE',
     skeletonHighlightColor: '#F5F5F5',
+    info: '#fbd16f',
+    infoAlt: '#fff8eb',
+    onInfo: '#826417',
     modes: {
       dark: {
         primary: '#1DC1AE',
@@ -143,6 +146,15 @@ export default {
     nostyle: {
       textDecoration: 'none',
       color: 'inherit'
+    }
+  },
+  alerts: {
+    ...theme.alerts,
+    information: {
+      variant: 'alerts.primary',
+      borderColor: 'info',
+      bg: 'infoAlt',
+      color: 'onInfo'
     }
   },
   buttons: {

--- a/modules/delegates/components/modals/DelegateModal.tsx
+++ b/modules/delegates/components/modals/DelegateModal.tsx
@@ -132,6 +132,7 @@ export const DelegateModal = ({ isOpen, onDismiss, delegate }: Props): JSX.Eleme
                           balance={mkrBalance?.toBigNumber()}
                           buttonLabel="Delegate MKR"
                           onClick={() => setConfirmStep(true)}
+                          showAlert={true}
                         />
                       )
                     ) : (

--- a/modules/delegates/components/modals/InputDelegateMkr.tsx
+++ b/modules/delegates/components/modals/InputDelegateMkr.tsx
@@ -50,10 +50,10 @@ export function InputDelegateMkr({
           {buttonLabel}
         </Button>
       </Box>
-      {showAlert && lockedMkr && lockedMkr.gt(0.00) && balance && balance.gt(0) && (
-        <Alert variant="information" sx={{ fontWeight: 'normal'}}>
+      {showAlert && lockedMkr && lockedMkr.gt(0) && balance && balance.gt(0) && (
+        <Alert variant="notice" sx={{ fontWeight: 'normal'}}>
           <Text>
-            {`You have ${lockedMkr.toBigNumber().toFormat(2)} additional MKR locked in the voting contract. `}
+            {`You have ${lockedMkr.toBigNumber().toFormat(6)} additional MKR locked in the voting contract. `}
             <Link href={accountVoteDelegate ? '/account' : '/executive'} sx={{ color: 'inherit', textDecoration: 'underline' }}>{'Withdraw MKR'}</Link>{' to deposit it into a delegate contract.'}
           </Text>
         </Alert>)

--- a/modules/delegates/components/modals/InputDelegateMkr.tsx
+++ b/modules/delegates/components/modals/InputDelegateMkr.tsx
@@ -46,7 +46,7 @@ export function InputDelegateMkr({
       <Text sx={{ color: 'secondaryEmphasis', mt: 3 }}>{description}</Text>
       <Box sx={{ mt: 3, width: '20rem' }}>
         <MKRInput value={value} onChange={handleChange} balance={balance} />
-        <Button onClick={onClick} sx={{ width: '100%', my: 3 }} disabled={!value || value.eq(0)}>
+        <Button onClick={onClick} sx={{ width: '100%', my: 3 }} disabled={!value || !balance || value.eq(0) || value.gt(balance)}>
           {buttonLabel}
         </Button>
       </Box>

--- a/modules/delegates/components/modals/InputDelegateMkr.tsx
+++ b/modules/delegates/components/modals/InputDelegateMkr.tsx
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js';
 import { useState } from 'react';
 import useAccountsStore from 'stores/accounts';
 import { useLockedMkr } from 'lib/hooks';
+import Withdraw from 'components/executive/Withdraw';
 
 type Props = {
   title: string;
@@ -26,10 +27,9 @@ export function InputDelegateMkr({
   showAlert
 }: Props): React.ReactElement {
   const [value, setValue] = useState(new BigNumber(0));
-  console.log({showAlert});
   const currentAccount = useAccountsStore(state =>state.currentAccount);
-  const [voteProxy, accountVoteDelegate] = useAccountsStore(state =>
-    currentAccount ? [state.proxies[currentAccount.address], state.voteDelegate] : [null, null]
+  const voteProxy = useAccountsStore(state =>
+    currentAccount ? state.proxies[currentAccount.address] : null
   );
   const { data: lockedMkr } = useLockedMkr(currentAccount?.address, voteProxy);
   function handleChange(val: BigNumber): void {
@@ -54,14 +54,17 @@ export function InputDelegateMkr({
         <Alert variant="notice" sx={{ fontWeight: 'normal'}}>
           <Text>
             {`You have ${lockedMkr.toBigNumber().toFormat(6)} additional MKR locked in the voting contract. `}
-            <Link href={accountVoteDelegate ? '/account' : '/executive'} sx={{ color: 'inherit', textDecoration: 'underline' }}>{'Withdraw MKR'}</Link>{' to deposit it into a delegate contract.'}
+            <Withdraw link={'Withdraw MKR'}/>
+            {' to deposit it into a delegate contract.'}
           </Text>
         </Alert>)
       }
       {showAlert && lockedMkr && lockedMkr.gt(0.00) && balance && balance.eq(0) && (
         <Alert variant="notice" sx={{ fontWeight: 'normal'}}>
           <Text>
-            {'You must '}<Link href={accountVoteDelegate ? '/account' : '/executive'} sx={{ color: 'inherit', textDecoration: 'underline' }}>{'withdraw MKR'}</Link>{' from the voting contract before you can delegate it.'}
+            {'You must '}
+            <Withdraw link={'withdraw your MKR'}/>
+            {' from the voting contract before delegating it.'}
           </Text>
         </Alert>)
       }

--- a/modules/delegates/components/modals/InputDelegateMkr.tsx
+++ b/modules/delegates/components/modals/InputDelegateMkr.tsx
@@ -1,7 +1,10 @@
 import { Button, Box, Flex, Text } from '@theme-ui/components';
+import { Alert, Link } from 'theme-ui';
 import { MKRInput } from 'components/MKRInput';
 import BigNumber from 'bignumber.js';
 import { useState } from 'react';
+import useAccountsStore from 'stores/accounts';
+import { useLockedMkr } from 'lib/hooks';
 
 type Props = {
   title: string;
@@ -10,6 +13,7 @@ type Props = {
   balance?: BigNumber;
   buttonLabel: string;
   onClick: () => void;
+  showAlert: boolean;
 };
 
 export function InputDelegateMkr({
@@ -18,15 +22,20 @@ export function InputDelegateMkr({
   onChange,
   balance,
   buttonLabel,
-  onClick
+  onClick,
+  showAlert
 }: Props): React.ReactElement {
   const [value, setValue] = useState(new BigNumber(0));
-
+  console.log({showAlert});
+  const currentAccount = useAccountsStore(state =>state.currentAccount);
+  const [voteProxy, accountVoteDelegate] = useAccountsStore(state =>
+    currentAccount ? [state.proxies[currentAccount.address], state.voteDelegate] : [null, null]
+  );
+  const { data: lockedMkr } = useLockedMkr(currentAccount?.address, voteProxy);
   function handleChange(val: BigNumber): void {
     setValue(val);
     onChange(val);
   }
-
   return (
     <Flex
       sx={{ flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center' }}
@@ -37,10 +46,25 @@ export function InputDelegateMkr({
       <Text sx={{ color: 'secondaryEmphasis', mt: 3 }}>{description}</Text>
       <Box sx={{ mt: 3, width: '20rem' }}>
         <MKRInput value={value} onChange={handleChange} balance={balance} />
-        <Button onClick={onClick} sx={{ width: '100%', mt: 3 }} disabled={!value || value.eq(0)}>
+        <Button onClick={onClick} sx={{ width: '100%', my: 3 }} disabled={!value || value.eq(0)}>
           {buttonLabel}
         </Button>
       </Box>
+      {showAlert && lockedMkr && lockedMkr.gt(0.00) && balance && balance.gt(0) && (
+        <Alert variant="information" sx={{ fontWeight: 'normal'}}>
+          <Text>
+            {`You have ${lockedMkr.toBigNumber().toFormat(2)} additional MKR locked in the voting contract. `}
+            <Link href={accountVoteDelegate ? '/account' : '/executive'} sx={{ color: 'inherit', textDecoration: 'underline' }}>{'Withdraw MKR'}</Link>{' to deposit it into a delegate contract.'}
+          </Text>
+        </Alert>)
+      }
+      {showAlert && lockedMkr && lockedMkr.gt(0.00) && balance && balance.eq(0) && (
+        <Alert variant="notice" sx={{ fontWeight: 'normal'}}>
+          <Text>
+            {'You must '}<Link href={accountVoteDelegate ? '/account' : '/executive'} sx={{ color: 'inherit', textDecoration: 'underline' }}>{'withdraw MKR'}</Link>{' from the voting contract before you can delegate it.'}
+          </Text>
+        </Alert>)
+      }
     </Flex>
   );
 }

--- a/modules/delegates/components/modals/UndelegateModal.tsx
+++ b/modules/delegates/components/modals/UndelegateModal.tsx
@@ -114,6 +114,7 @@ export const UndelegateModal = ({ isOpen, onDismiss, delegate }: Props): JSX.Ele
                         balance={mkrStaked.toBigNumber()}
                         buttonLabel="Undelegate MKR"
                         onClick={freeMkr}
+                        showAlert={false}
                       />
                     ) : (
                       <ApprovalContent


### PR DESCRIPTION
### Link to Clubhouse story
https://app.shortcut.com/dux-makerdao/story/371/alert-users-they-need-to-withdraw-mkr-from-chief-to-delegate-it
### What does this PR do?
Allows a user to easily withdraw MKR from chief before depositing into a delegate contract.
Also two bug fixes:
1. Show the correct MKR balance in the chief withdrawal modal for users with a delegate contract.
1. disable button when inputting a number larger than your MKR balance in delegate deposit and chief withdraw modals.

started adding a new yellow-colored alert, but instead just using the orange 'notice' one.
### Steps for testing:

### Screenshots (if relevant):
<img width="639" alt="Screen Shot 2021-09-22 at 1 10 55 PM" src="https://user-images.githubusercontent.com/3388550/134433843-2f844d66-4652-44ed-b3a2-08f6900c72d6.png">
<img width="640" alt="Screen Shot 2021-09-22 at 1 11 00 PM" src="https://user-images.githubusercontent.com/3388550/134433831-e1d4605a-496b-43c2-ab70-aa73e52ac8c1.png">
<img width="598" alt="Screen Shot 2021-09-22 at 1 13 49 PM" src="https://user-images.githubusercontent.com/3388550/134434081-9701e430-28d9-450c-a614-aebc26483087.png">

### Add a GIF:
