### PR TITLE
Debug sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
     environment:
       SENTRY_ORG: makerdao-dux
       SENTRY_PROJECT: makerdao-dux
+      SENTRY_LOG_LEVEL: debug
     docker:
       - image: makerdaodux/dapptools-node-circleci-docker
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           curl -sL https://sentry.io/get-cli/ | bash
           export SENTRY_RELEASE=$(sentry-cli releases propose-version)
           sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
-          sentry-cli releases set-commits --auto $SENTRY_RELEASE
+          sentry-cli releases set-commits $SENTRY_RELEASE --auto --ignore-missing 
           sentry-cli releases finalize $SENTRY_RELEASE
       - restore_cache:
           keys:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@makerdao/dai": "^0.32.13",
-    "@makerdao/dai-plugin-governance": "^0.14.1-beta9",
+    "@makerdao/dai-plugin-governance": "^0.14.1-beta13",
     "@makerdao/dai-plugin-ledger-web": "^0.9.10",
     "@makerdao/dai-plugin-mcd": "^1.6.35",
     "@makerdao/dai-plugin-trezor-web": "^0.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
     babel-runtime "^6.26.0"
     bignumber.js "^8.1.1"
 
-"@makerdao/dai-plugin-governance@^0.14.1-beta9":
-  version "0.14.1-beta9"
-  resolved "https://registry.yarnpkg.com/@makerdao/dai-plugin-governance/-/dai-plugin-governance-0.14.1-beta9.tgz#0229e52f197831b1e033279ad2530dad33a2f9cd"
-  integrity sha512-deWCdLXkOij5yPZ47OmEB6T5WXMo58hlS06EJ1WumnmWibOcBx8GvvbPp4LjsVkusvGdWoilvMKJTrqgG/0dqA==
+"@makerdao/dai-plugin-governance@^0.14.1-beta13":
+  version "0.14.1-beta13"
+  resolved "https://registry.yarnpkg.com/@makerdao/dai-plugin-governance/-/dai-plugin-governance-0.14.1-beta13.tgz#0e855040323f94da651f792d34dd1f79189f6a4b"
+  integrity sha512-4lH/guO/ZFzYECUlm9/l2hHSWL6c5GBzXvCDUH9K0QNL/wDlnSLVA/mOTwBsqOrrjDSO/Eb7fH8AfWtK92v7JQ==
   dependencies:
     "@makerdao/currency" "0.9.9"
     "@makerdao/services-core" "^0.10.0"


### PR DESCRIPTION
### What does this PR do?
Fix CI.  Sentry was halting ci with this error: "Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it. Otherwise, it means that the commit we are looking for was amended or squashed and cannot be retrieved. Use --ignore-missing flag to skip it and create a new release with the default commits count."

This PR just adds the --ignore-missing flag.

Another option could be to integrate sentry directly with Github.  Not sure if that would prevent this issue, but we do also get this message in CI: "Could not determine any commits to be associated with a repo-based integration. Proceeding to find commits from local git tree."  I don't have owner permissions in the github repo though.
