### PR TITLE
Fix/685

### DIFF
--- a/modules/polling/api/__tests__/parsePollMetadata.spec.ts
+++ b/modules/polling/api/__tests__/parsePollMetadata.spec.ts
@@ -1,82 +1,85 @@
-import { Poll } from "../../types";
-import { sortPolls } from "../parsePollMetadata"
+import { Poll } from '../../types';
+import { sortPolls } from '../parsePollMetadata';
 
 describe('Parse poll metadata', () => {
-    const polls: Poll[] = [{
-        categories: ['a'],
-        content: '',
-        discussionLink: '',
-        endDate: new Date(2011,10,30),
-        multiHash: '',
-        options: {},
-        pollId: 1,
-        startDate: new Date(2011,10,30),
-        slug: '',
-        summary: '',
-        title: '2011,10,30',
-        voteType: 'Plurality Voting',
-        ctx: {} as any
-    }, 
+  const polls: Poll[] = [
     {
-        categories: ['a'],
-        content: '',
-        discussionLink: '',
-        endDate: new Date(2011,10,30),
-        multiHash: '',
-        options: {},
-        pollId: 2,
-        startDate: new Date(2011,10,31),
-        slug: '',
-        summary: '',
-        title: '2011,10,31',
-        voteType: 'Plurality Voting',
-        ctx: {} as any
-    },{
-        categories: ['a'],
-        content: '',
-        discussionLink: '',
-        endDate: new Date(2021,10,31),
-        multiHash: '',
-        options: {},
-        pollId: 3,
-        startDate: new Date(2021,10,31),
-        slug: '',
-        summary: '',
-        title: '2021,10,31',
-        voteType: 'Plurality Voting',
-        ctx: {} as any
-    }, 
+      categories: ['a'],
+      content: '',
+      discussionLink: '',
+      endDate: new Date(2011, 10, 30),
+      multiHash: '',
+      options: {},
+      pollId: 1,
+      startDate: new Date(2011, 10, 30),
+      slug: '',
+      summary: '',
+      title: '2011,10,30',
+      voteType: 'Plurality Voting',
+      ctx: {} as any
+    },
     {
-        categories: ['a'],
-        content: '',
-        discussionLink: '',
-        endDate: new Date(2021,11,31),
-        multiHash: '',
-        options: {},
-        pollId: 4,
-        startDate: new Date(2021,11,31),
-        slug: '',
-        summary: '',
-        title: '2021,11,31',
-        voteType: 'Plurality Voting',
-        ctx: {} as any
-    }];
+      categories: ['a'],
+      content: '',
+      discussionLink: '',
+      endDate: new Date(2011, 10, 30),
+      multiHash: '',
+      options: {},
+      pollId: 2,
+      startDate: new Date(2011, 10, 31),
+      slug: '',
+      summary: '',
+      title: '2011,10,31',
+      voteType: 'Plurality Voting',
+      ctx: {} as any
+    },
+    {
+      categories: ['a'],
+      content: '',
+      discussionLink: '',
+      endDate: new Date(2021, 10, 31),
+      multiHash: '',
+      options: {},
+      pollId: 3,
+      startDate: new Date(2021, 10, 31),
+      slug: '',
+      summary: '',
+      title: '2021,10,31',
+      voteType: 'Plurality Voting',
+      ctx: {} as any
+    },
+    {
+      categories: ['a'],
+      content: '',
+      discussionLink: '',
+      endDate: new Date(2021, 11, 31),
+      multiHash: '',
+      options: {},
+      pollId: 4,
+      startDate: new Date(2021, 11, 31),
+      slug: '',
+      summary: '',
+      title: '2021,11,31',
+      voteType: 'Plurality Voting',
+      ctx: {} as any
+    }
+  ];
 
-    test('The first poll is the one ending sooner', () => {
-        const results = sortPolls(polls);
+  test('The first poll is the one ending sooner', () => {
+    const results = sortPolls(polls);
 
-        expect(results[0].pollId).toEqual(2);
-    });
+    expect(results[0].pollId).toEqual(2);
+  });
 
-    test('The second poll is the one with the same date as 1 but different start date', () => {
-        const results = sortPolls(polls);
+  test('The second poll is the one with the same date as 1 but different start date', () => {
+    const results = sortPolls(polls);
 
-        expect(results[1].pollId).toEqual(1);
-    });
+    expect(results[1].pollId).toEqual(1);
+  });
 
-    test('The 4 poll is the one ending later', () => {
-        const results = sortPolls(polls);
+  test('The 4 poll is the one ending later', () => {
+    const results = sortPolls(polls);
 
-        expect(results[3].pollId).toEqual(4);
-    });
-})
+    expect(results[3].pollId).toEqual(4);
+  });
+});

--- a/modules/polling/api/__tests__/parsePollMetadata.spec.ts
+++ b/modules/polling/api/__tests__/parsePollMetadata.spec.ts
@@ -1,0 +1,82 @@
+import { Poll } from "../../types";
+import { sortPolls } from "../parsePollMetadata"
+
+describe('Parse poll metadata', () => {
+    const polls: Poll[] = [{
+        categories: ['a'],
+        content: '',
+        discussionLink: '',
+        endDate: new Date(2011,10,30),
+        multiHash: '',
+        options: {},
+        pollId: 1,
+        startDate: new Date(2011,10,30),
+        slug: '',
+        summary: '',
+        title: '2011,10,30',
+        voteType: 'Plurality Voting',
+        ctx: {} as any
+    }, 
+    {
+        categories: ['a'],
+        content: '',
+        discussionLink: '',
+        endDate: new Date(2011,10,30),
+        multiHash: '',
+        options: {},
+        pollId: 2,
+        startDate: new Date(2011,10,31),
+        slug: '',
+        summary: '',
+        title: '2011,10,31',
+        voteType: 'Plurality Voting',
+        ctx: {} as any
+    },{
+        categories: ['a'],
+        content: '',
+        discussionLink: '',
+        endDate: new Date(2021,10,31),
+        multiHash: '',
+        options: {},
+        pollId: 3,
+        startDate: new Date(2021,10,31),
+        slug: '',
+        summary: '',
+        title: '2021,10,31',
+        voteType: 'Plurality Voting',
+        ctx: {} as any
+    }, 
+    {
+        categories: ['a'],
+        content: '',
+        discussionLink: '',
+        endDate: new Date(2021,11,31),
+        multiHash: '',
+        options: {},
+        pollId: 4,
+        startDate: new Date(2021,11,31),
+        slug: '',
+        summary: '',
+        title: '2021,11,31',
+        voteType: 'Plurality Voting',
+        ctx: {} as any
+    }];
+
+    test('The first poll is the one ending sooner', () => {
+        const results = sortPolls(polls);
+
+        expect(results[0].pollId).toEqual(2);
+    });
+
+    test('The second poll is the one with the same date as 1 but different start date', () => {
+        const results = sortPolls(polls);
+
+        expect(results[1].pollId).toEqual(1);
+    });
+
+    test('The 4 poll is the one ending later', () => {
+        const results = sortPolls(polls);
+
+        expect(results[3].pollId).toEqual(4);
+    });
+})

--- a/modules/polling/api/parsePollMetadata.ts
+++ b/modules/polling/api/parsePollMetadata.ts
@@ -13,11 +13,9 @@ export function sortPolls(pollList: Poll[]): Poll[] {
     // Sort by more recent first if they end at the same time
     const sortedByStartDate = a.startDate.getTime() < b.startDate.getTime() ? 1 : -1;
 
-    return dateEndDiff < 0 ? - 1 : 
-      (dateEndDiff > 0 ? 1 : sortedByStartDate);
+    return dateEndDiff < 0 ? -1 : dateEndDiff > 0 ? 1 : sortedByStartDate;
   });
 }
-
 
 export async function parsePollsMetadata(pollList): Promise<Poll[]> {
   let numFailedFetches = 0;


### PR DESCRIPTION
### Link to Clubhouse story
https://app.shortcut.com/dux-makerdao/story/685/poll-ordering-by-recent-post
### What does this PR do?
Changes sort order  of polls, incase different polls end at the same date, also order by start date

### Steps for testing:
Go to polls page
### Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/1152768/139063190-f7597342-5bf5-404c-b632-e2e91d0cc976.png)
