### PR TITLE
Feature/sc 661/add visual for how many mkr needed to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   install:
     docker:
       - image: circleci/node:14.17.3
+    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   install:
     docker:
       - image: circleci/node:14.17.3
-    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -17,17 +17,18 @@ import Stack from 'modules/app/components/layout/layouts/Stack';
 import VoteModal from './VoteModal';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constants';
+import { useMkrOnHat } from 'modules/executive/hooks/useMkrOnHat';
 
 type Props = {
   proposal: Proposal;
-  spellData?: SpellData;
   isHat: boolean;
+  spellData?: SpellData;
 };
 
-export default function ExecutiveOverviewCard({ proposal, spellData, isHat, ...props }: Props): JSX.Element {
+export default function ExecutiveOverviewCard({ proposal, isHat, spellData, ...props }: Props): JSX.Element {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.EXECUTIVE);
-
   const account = useAccountsStore(state => state.currentAccount);
+  const { data: mkrOnHat } = useMkrOnHat();
   const [voting, setVoting] = useState(false);
   const { data: votedProposals } = useVotedProposals();
   const network = getNetwork();
@@ -178,7 +179,7 @@ export default function ExecutiveOverviewCard({ proposal, spellData, isHat, ...p
         <Divider my={0} />
         <Flex sx={{ py: 2, justifyContent: 'center', fontSize: [1, 2], color: 'onSecondary' }}>
           <Text as="p" sx={{ textAlign: 'center', px: [3, 4], mb: 1, wordBreak: 'break-word' }}>
-            {getStatusText(proposal.address, spellData)}
+            {getStatusText({ proposalAddress: proposal.address, spellData, mkrOnHat })}
           </Text>
         </Flex>
       </Card>

--- a/modules/executive/helpers/getStatusText.ts
+++ b/modules/executive/helpers/getStatusText.ts
@@ -1,4 +1,5 @@
 import { formatDateWithTime } from 'lib/datetime';
+import { isBefore } from 'date-fns';
 import { SPELL_SCHEDULED_DATE_OVERRIDES } from 'lib/constants';
 import { SpellData } from '../types/spellData';
 import { ZERO_ADDRESS } from 'stores/accounts';
@@ -11,6 +12,7 @@ export const getStatusText = (proposalAddress: string, spellData?: SpellData): s
     chief has been activated!`;
   }
 
+  // check if scheduled or has been executed
   if (spellData.hasBeenScheduled || spellData.dateExecuted) {
     if (typeof spellData.dateExecuted === 'string') {
       return `Passed on ${formatDateWithTime(spellData.datePassed)}. Executed on ${formatDateWithTime(
@@ -25,5 +27,15 @@ export const getStatusText = (proposalAddress: string, spellData?: SpellData): s
       .`;
     }
   }
+
+  // hasn't been scheduled or executed, check if expired
+  const isExpired = spellData.expiration ? isBefore(new Date(spellData.expiration), new Date()) : false;
+  if (isExpired) {
+    return `This proposal expired at ${formatDateWithTime(
+      spellData.expiration
+    )} and can no longer be exectuted.`;
+  }
+
+  // hasn't been scheduled, executed, hasn't expired, must be active and not passed yet
   return 'This proposal has not yet passed and is not available for execution.';
 };

--- a/modules/executive/hooks/useMkrOnHat.ts
+++ b/modules/executive/hooks/useMkrOnHat.ts
@@ -1,0 +1,28 @@
+import getMaker from 'lib/maker';
+import useSWR from 'swr';
+import { CurrencyObject } from 'types/currency';
+
+type MkrOnHatResponse = {
+  data?: CurrencyObject;
+  loading: boolean;
+  error: Error;
+};
+
+export const useMkrOnHat = (): MkrOnHatResponse => {
+  const { data, error } = useSWR<CurrencyObject>(
+    '/executive/mkr-on-hat',
+    async () => {
+      const maker = await getMaker();
+      const hat = await maker.service('chief').getHat();
+      return maker.service('chief').getApprovalCount(hat);
+    },
+    // refresh every 5 mins
+    { refreshInterval: 300000 }
+  );
+
+  return {
+    data,
+    loading: !error && !data,
+    error
+  };
+};

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -14,6 +14,7 @@ import invariant from 'tiny-invariant';
 import { getExecutiveProposal, getExecutiveProposals } from 'modules/executive/api/fetchExecutives';
 import { useSpellData } from 'modules/executive/hooks/useSpellData';
 import { useVotedProposals } from 'modules/executive/hooks/useVotedProposals';
+import { useMkrOnHat } from 'modules/executive/hooks/useMkrOnHat';
 import { getNetwork, isDefaultNetwork } from 'lib/maker';
 import { cutMiddle, limitString } from 'lib/string';
 import { getStatusText } from 'modules/executive/helpers/getStatusText';
@@ -38,6 +39,7 @@ import { SpellEffectsTab } from 'modules/executive/components/SpellEffectsTab';
 
 //types
 import { CMSProposal, Proposal, SpellData } from 'modules/executive/types';
+import { CurrencyObject } from 'types/currency';
 
 type Props = {
   proposal: Proposal;
@@ -50,17 +52,21 @@ const editMarkdown = content => {
 
 const ProposalTimingBanner = ({
   proposal,
-  spellData
+  spellData,
+  mkrOnHat
 }: {
   proposal: CMSProposal;
   spellData?: SpellData;
+  mkrOnHat?: CurrencyObject;
 }): JSX.Element => {
   if (spellData || proposal.address === ZERO_ADDRESS)
     return (
       <>
         <Divider my={1} />
         <Flex sx={{ py: 2, justifyContent: 'center', fontSize: [1, 2], color: 'onSecondary' }}>
-          <Text sx={{ textAlign: 'center', px: [3, 4] }}>{getStatusText(proposal.address, spellData)}</Text>
+          <Text sx={{ textAlign: 'center', px: [3, 4] }}>
+            {getStatusText({ proposalAddress: proposal.address, spellData, mkrOnHat })}
+          </Text>
         </Flex>
         <Divider sx={{ mt: 1 }} />
       </>
@@ -81,6 +87,7 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
   );
 
   const { data: votedProposals } = useVotedProposals();
+  const { data: mkrOnHat } = useMkrOnHat();
 
   const { data: comments, error: commentsError } = useSWR(
     `/api/executive/comments/list/${proposal.address}`,
@@ -202,7 +209,9 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
                   </div>,
                   commentsTab
                 ]}
-                banner={<ProposalTimingBanner proposal={proposal} spellData={spellData} />}
+                banner={
+                  <ProposalTimingBanner proposal={proposal} spellData={spellData} mkrOnHat={mkrOnHat} />
+                }
               ></Tabs>
             ) : (
               <Tabs


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/661/add-visual-for-how-many-mkr-needed-to-pass-vote-for-executives

### What does this PR do?

Adds additional status information including if exec has expired or how much additional MKR is needed to pass

### Steps for testing:

1. Go to exec page, see new statuses (hard to recreate the additional MKR one if you don't have an exec that is active and hasn't passed)

### Screenshots (if relevant):
<img width="829" alt="Screen Shot 2021-11-02 at 1 20 45 PM" src="https://user-images.githubusercontent.com/5225766/139852363-8cc5eff9-3d31-43c3-a2d5-7caaaf15673c.png">
<img width="829" alt="Screen Shot 2021-11-01 at 2 44 07 PM" src="https://user-images.githubusercontent.com/5225766/139852377-e63186ab-b436-4a18-be43-05c532579a80.png">

### Add a GIF:
![](https://media.giphy.com/media/hFtVHPDcrVubS/giphy.gif)