### PR TITLE
Update spell data loading state

### DIFF
--- a/modules/executive/components/SpellEffectsTab.tsx
+++ b/modules/executive/components/SpellEffectsTab.tsx
@@ -5,6 +5,7 @@ import { Proposal, SpellData } from '../types';
 import { useState } from 'react';
 import { Icon as DaiUIIcon } from '@makerdao/dai-ui-icons';
 
+import Stack from 'modules/app/components/layout/layouts/Stack';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { formatDateWithoutTime } from 'lib/datetime';
 
@@ -61,7 +62,7 @@ export function SpellEffectsTab({
   */
   const [expanded, setExpanded] = useState(false);
 
-  return (
+  return spellData ? (
     <Box>
       <Text
         as="p"
@@ -96,14 +97,11 @@ export function SpellEffectsTab({
               justifyContent: 'space-between'
             }}
           >
-            {spellData?.executiveHash ? (
+            {spellData?.executiveHash && (
               <Text sx={{ mr: 2, fontWeight: 'semiBold', wordBreak: 'break-all' }}>
                 {spellData?.executiveHash}
               </Text>
-            ) : (
-              <SkeletonThemed width="300px" height="15px" />
             )}
-
             <Box sx={{ cursor: 'pointer', ml: 2, minWidth: '99px' }} onClick={() => setExpanded(!expanded)}>
               <Text color={'textMuted'}>
                 What&apos;s this? <DaiUIIcon name={expanded ? 'chevron_up' : 'chevron_down'} size={2} />
@@ -156,22 +154,24 @@ export function SpellEffectsTab({
           </Box>
         )}
         <Box sx={{ width: ['100%', '50%'] }}>
-          <Flex mb={3} mt={[3, 0]}>
-            <CircleIcon name="hourglass" />
-            <Box>
-              <Text
-                as="p"
-                sx={{
-                  fontWeight: 'semiBold'
-                }}
-              >
-                Expiration
-              </Text>
-              <Text as="p" color="textMuted">
-                {formatDateWithoutTime(spellData?.expiration)}
-              </Text>
-            </Box>
-          </Flex>
+          {spellData?.expiration && (
+            <Flex mb={3} mt={[3, 0]}>
+              <CircleIcon name="hourglass" />
+              <Box>
+                <Text
+                  as="p"
+                  sx={{
+                    fontWeight: 'semiBold'
+                  }}
+                >
+                  Expiration
+                </Text>
+                <Text as="p" color="textMuted">
+                  {formatDateWithoutTime(spellData?.expiration)}
+                </Text>
+              </Box>
+            </Flex>
+          )}
           {spellData?.officeHours && (
             <Flex mb={3}>
               <CircleIcon name="clock" />
@@ -193,5 +193,11 @@ export function SpellEffectsTab({
         </Box>
       </Box>
     </Box>
+  ) : (
+    <Stack gap={3}>
+      <SkeletonThemed />
+      <SkeletonThemed />
+      <SkeletonThemed />
+    </Stack>
   );
 }


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/666/improve-loading-animation-for-spell-detail-tab

### What does this PR do?

Updates loading state for spell data

### Steps for testing:

1. Go to spell detail tab for an executive
2. Observe new loading state

### Screenshots (if relevant):
Loading:
<img width="831" alt="Screen Shot 2021-11-03 at 11 51 56 AM" src="https://user-images.githubusercontent.com/5225766/140048179-084c2a1d-3618-4d56-b222-91f492a025ec.png">

Loaded:
<img width="829" alt="Screen Shot 2021-11-03 at 11 52 16 AM" src="https://user-images.githubusercontent.com/5225766/140048210-d1d21df2-998f-45ae-a39c-52baa4b4c817.png">

### Add a GIF:
![](https://giphy.com/clips/studiosoriginals-sleep-tired-sleepy-u2wg2uXJbHzkXkPphr)
