### PR TITLE
Add jazzicons for shadow delegates

### DIFF
--- a/modules/delegates/components/DelegatePicture.tsx
+++ b/modules/delegates/components/DelegatePicture.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { DelegateStatusEnum } from '../delegates.constants';
-import { Box, Image, jsx } from 'theme-ui';
+import { Box, Flex, Image, jsx } from 'theme-ui';
 import { Jazzicon } from '@ukstv/jazzicon-react';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { Delegate } from '../types';
@@ -8,28 +8,39 @@ import Tooltip from 'modules/app/components/Tooltip';
 import { DelegateParticipationMetrics } from './DelegateParticipationMetrics';
 
 export function DelegatePicture({ delegate }: { delegate: Delegate }): React.ReactElement {
-  const delegatePicture = delegate.picture || '/assets/empty-profile-picture.svg';
-
   const delegateMetrics = (
     <Box sx={{ maxWidth: ['auto', '530px'], width: ['auto', '530px'], display: 'block' }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', flexDirection: ['column', 'row'] }}>
-        <img
-          sx={{ borderRadius: '100%', width: ['150px', '200px'], height: ['150px', '200px'] }}
-          src={delegatePicture}
-        />
+      <Flex
+        sx={{
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexDirection: ['column', 'row']
+        }}
+      >
+        {delegate.picture ? (
+          <img
+            sx={{ borderRadius: '100%', width: ['150px', '200px'], height: ['150px', '200px'] }}
+            src={delegate.picture}
+          />
+        ) : (
+          <Jazzicon
+            address={delegate.address}
+            sx={{ height: ['150px', '200px'], width: ['150px', '200px'] }}
+          />
+        )}
         <Box sx={{ marginLeft: 1, flex: 1 }}>
           <DelegateParticipationMetrics delegate={delegate} />
         </Box>
-      </Box>
+      </Flex>
     </Box>
   );
 
   return (
     <Box sx={{ width: '41px', height: '41px', position: 'relative', minWidth: '41px' }}>
-      <Tooltip label={delegateMetrics}>
-        {delegate.picture ? (
+      {delegate.picture ? (
+        <Tooltip label={delegateMetrics}>
           <Image
-            src={delegatePicture}
+            src={delegate.picture}
             key={delegate.id}
             sx={{
               objectFit: 'cover',
@@ -38,10 +49,10 @@ export function DelegatePicture({ delegate }: { delegate: Delegate }): React.Rea
               maxHeight: '41px'
             }}
           />
-        ) : (
-          <Jazzicon address={delegate.address} sx={{ height: '41px', width: '41px' }} />
-        )}
-      </Tooltip>
+        </Tooltip>
+      ) : (
+        <Jazzicon address={delegate.address} sx={{ height: '41px', width: '41px' }} />
+      )}
       {delegate.status === DelegateStatusEnum.recognized && (
         <Icon
           name={'verified'}

--- a/modules/delegates/components/DelegatePicture.tsx
+++ b/modules/delegates/components/DelegatePicture.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { DelegateStatusEnum } from '../delegates.constants';
 import { Box, Image, jsx } from 'theme-ui';
+import { Jazzicon } from '@ukstv/jazzicon-react';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { Delegate } from '../types';
 import Tooltip from 'modules/app/components/Tooltip';
@@ -26,16 +27,20 @@ export function DelegatePicture({ delegate }: { delegate: Delegate }): React.Rea
   return (
     <Box sx={{ width: '41px', height: '41px', position: 'relative', minWidth: '41px' }}>
       <Tooltip label={delegateMetrics}>
-        <Image
-          src={delegatePicture}
-          key={delegate.id}
-          sx={{
-            objectFit: 'cover',
-            width: '100%',
-            borderRadius: '100%',
-            maxHeight: '41px'
-          }}
-        />
+        {delegate.picture ? (
+          <Image
+            src={delegatePicture}
+            key={delegate.id}
+            sx={{
+              objectFit: 'cover',
+              width: '100%',
+              borderRadius: '100%',
+              maxHeight: '41px'
+            }}
+          />
+        ) : (
+          <Jazzicon address={delegate.address} sx={{ height: '41px', width: '41px' }} />
+        )}
       </Tooltip>
       {delegate.status === DelegateStatusEnum.recognized && (
         <Icon


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/748/add-jazzicons-to-shadow-delegates

### What does this PR do?

Add jazzicons for shadow delegates

### Steps for testing:

1. Go to delegates page
2. See jazzicons for shadow delegates ✨ 

### Screenshots (if relevant):

<img width="807" alt="Screen Shot 2021-11-05 at 12 31 12 PM" src="https://user-images.githubusercontent.com/5225766/140504405-91147ef5-7f29-4190-b2d4-c8028d13a955.png">
<img width="1002" alt="Screen Shot 2021-11-04 at 3 09 24 PM" src="https://user-images.githubusercontent.com/5225766/140504409-7f0cb1b8-7b6d-4985-bc38-063d99899445.png">

### Add a GIF:
![](https://media.giphy.com/media/Qs15s6n1sEQK5CHzN0/giphy.gif)