### PR TITLE
Feature/sc 667/make own shadow delegate contract more prominent

### DIFF
--- a/modules/delegates/components/DelegateCard.tsx
+++ b/modules/delegates/components/DelegateCard.tsx
@@ -94,7 +94,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                         sx={{
                           display: 'inline-flex',
                           backgroundColor: 'tagColorSevenBg',
-                          borderRadius: '12px',
+                          borderRadius: 'roundish',
                           padding: '3px 6px',
                           alignItems: 'center',
                           color: 'tagColorSeven',

--- a/modules/delegates/components/DelegateCard.tsx
+++ b/modules/delegates/components/DelegateCard.tsx
@@ -83,11 +83,28 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                 <DelegatePicture delegate={delegate} />
 
                 <Box sx={{ ml: 2 }}>
-                  <Box>
+                  <Flex sx={{ alignItems: 'center' }}>
                     <Text as="p" variant="microHeading" sx={{ fontSize: [3, 4] }}>
-                      {delegate.name ? limitString(delegate.name, 43, '...') : 'Unknown'}
+                      {delegate.name
+                        ? limitString(delegate.name, isOwner ? 23 : 43, '...')
+                        : limitString('Unknown', isOwner ? 12 : 43, '...')}
                     </Text>
-                  </Box>
+                    {isOwner && (
+                      <Flex
+                        sx={{
+                          display: 'inline-flex',
+                          backgroundColor: 'tagColorSevenBg',
+                          borderRadius: '12px',
+                          padding: '3px 6px',
+                          alignItems: 'center',
+                          color: 'tagColorSeven',
+                          ml: 2
+                        }}
+                      >
+                        <Text sx={{ fontSize: 1 }}>Owner</Text>
+                      </Flex>
+                    )}
+                  </Flex>
                   <Text>
                     {delegate.voteDelegateAddress.substr(0, 6)}...
                     {delegate.voteDelegateAddress.substr(
@@ -113,7 +130,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                   sx={{ borderColor: 'text', color: 'text' }}
                   variant="outline"
                 >
-                  View Profile Details
+                  {`View ${isOwner ? 'Your' : 'Profile'} Details`}
                 </Button>
               </a>
             </Link>


### PR DESCRIPTION
### Link to Clubhouse story

https://app.shortcut.com/dux-makerdao/story/667/make-own-shadow-delegate-contract-more-prominent-on-delegates-page

### What does this PR do?

Adds an owner badge to delegates if the connected wallet is an owner

### Steps for testing:

1. Go to delegates page
2. Connect to a wallet that owns a delegate contract
3. See badge ✨ 

### Screenshots (if relevant):

<img width="1001" alt="Screen Shot 2021-11-05 at 2 46 30 PM" src="https://user-images.githubusercontent.com/5225766/140522106-e752b5b7-50cd-4702-be64-da94780b490d.png">
<img width="805" alt="Screen Shot 2021-11-05 at 2 46 59 PM" src="https://user-images.githubusercontent.com/5225766/140522118-7d69725d-04e6-4458-9013-2a98f5d47695.png">
<img width="983" alt="Screen Shot 2021-11-05 at 2 51 39 PM" src="https://user-images.githubusercontent.com/5225766/140522122-5de8ad55-2969-4d99-9660-6529549e636c.png">

### Add a GIF:
![](https://media.giphy.com/media/ZidmSZIH8mM1i/giphy.gif)
