### PR TITLE
ensure we always remove older polls when deduping polls

### DIFF
--- a/modules/polling/api/parsePollMetadata.ts
+++ b/modules/polling/api/parsePollMetadata.ts
@@ -21,11 +21,12 @@ export async function parsePollsMetadata(pollList): Promise<Poll[]> {
   let numFailedFetches = 0;
   const failedPollIds: number[] = [];
   const polls: Poll[] = [];
-
-  for (const pollGroup of chunk(
-    uniqBy(pollList, p => p.multiHash),
-    20
-  )) {
+  //uniqBy keeps the first occurence of a duplicate, so we sort polls so that the most recent poll is kept in case of a duplicate
+  const dedupedPolls = uniqBy(
+    pollList.sort((a, b) => b.pollId - a.pollId),
+    p => p.multiHash
+  );
+  for (const pollGroup of chunk(dedupedPolls, 20)) {
     // fetch polls in batches, don't fetch a new batch until the current one has resolved
     const pollGroupWithData = await Promise.all(
       pollGroup.map(async (p: PartialPoll) => {


### PR DESCRIPTION
### Link to Clubhouse story
https://app.shortcut.com/dux-makerdao/story/344/better-handle-two-polls-having-the-same-hash
### What does this PR do?
If two polls have the same hash, remove the older poll when deduplicating.  The impetus for this is that one time a poll was submitted with either the start or end date wrong (I forget which), so a new one was submitted and it had the same multihash.  But the frontend would dedupe by deleting the 2nd poll, causing issues.  Since then we've changed the way poll hashes are created to include the entire poll document (including the frontmatter) when creating the hash, so we _shouldn't_ run into this situation again where two polls have the same hash, because changing the start/end date would cause the hash to change.  But better safe than sorry.
### Steps for testing:
On goerli I added a poll so that there are two polls with the same hash (the lower the psm vault fee poll).  The frontend shows the more recently created poll (the one with poll id 3, not 2). You can verify by voting and seeing the poll id in your vote event (e.g. https://goerli.etherscan.io/tx/0x777a16a97a46666eb2285b4b279a769edf6d10f0f010cc53e2c31163d9127673)
