### PR TITLE
add a new string to edit title matcher

### DIFF
--- a/lib/validators/email.ts
+++ b/lib/validators/email.ts
@@ -1,3 +1,4 @@
+// prettier-ignore
 // eslint-disable-next-line
 const rfc2822EmailRegex = /[a-z0-9!#$%&'*+\/=?^_{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9][a-z0-9-]*[a-z0-9]/;
 

--- a/modules/executive/api/parseExecutive.ts
+++ b/modules/executive/api/parseExecutive.ts
@@ -34,13 +34,19 @@ export function parseExecutive(
     return null;
   }
 
-  //remove `Template - [Executive Vote] ` from title
-  const editedTitle = title.replace('Template - [Executive Vote] ', '');
+  //remove `Template - [ ... ] ` from title
+  const editTitle = title => {
+    const vStr = 'Template - [Executive Vote] ';
+    const pStr = 'Template - [Executive Proposal] ';
+    if (title.indexOf(vStr) === 0) return title.replace(vStr, '');
+    if (title.indexOf(pStr) === 0) return title.replace(pStr, '');
+    return title;
+  };
 
   return {
     about: content,
     content: content,
-    title: editedTitle,
+    title: editTitle(title),
     proposalBlurb: summary,
     key: slugify(title),
     address: address,


### PR DESCRIPTION
### What does this PR do?
updates the matcher that remove the "Template - [..." string from proposal titles

### Screenshots (if relevant):
Old:
![Screen Shot 2021-11-19 at 3 17 14 PM](https://user-images.githubusercontent.com/13105602/142698510-30c2aa83-5f16-4cc3-af20-d6230a7ba4c7.png)

New:
![Screen Shot 2021-11-19 at 3 18 04 PM](https://user-images.githubusercontent.com/13105602/142698588-eca9edf3-4221-4131-b3ba-9a3330c37870.png)
