### PR TITLE
Fix polling date filter issue

### DIFF
--- a/modules/executive/components/DateFilter.tsx
+++ b/modules/executive/components/DateFilter.tsx
@@ -43,14 +43,14 @@ export default function DateFilter(props): JSX.Element {
     <FilterButton
       name={() => {
         if (!startDateDisplay && !endDateDisplay) return 'Date Posted';
-        if (!startDateDisplay) return `Date Posted: before ${endDateDisplay}`;
-        if (!endDateDisplay) return `Date Posted: after ${startDateDisplay}`;
-        return `Date Posted: ${startDateDisplay} - ${endDateDisplay}`;
+        if (!startDateDisplay) return `Date Filter: before ${endDateDisplay}`;
+        if (!endDateDisplay) return `Date Filter: after ${startDateDisplay}`;
+        return `Date Filter: ${startDateDisplay} - ${endDateDisplay}`;
       }}
       {...props}
     >
       <Grid gap={2} columns="max-content max-content" sx={{ alignItems: 'baseline' }}>
-        <Text>Executive posted after:</Text>
+        <Text>Posted after:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={startInput}
@@ -59,7 +59,7 @@ export default function DateFilter(props): JSX.Element {
           />
         </Flex>
 
-        <Text>Executive posted before:</Text>
+        <Text>Posted before:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={endInput}

--- a/modules/executive/components/DateFilter.tsx
+++ b/modules/executive/components/DateFilter.tsx
@@ -50,7 +50,7 @@ export default function DateFilter(props): JSX.Element {
       {...props}
     >
       <Grid gap={2} columns="max-content max-content" sx={{ alignItems: 'baseline' }}>
-        <Text>After</Text>
+        <Text>Executive posted after:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={startInput}
@@ -59,7 +59,7 @@ export default function DateFilter(props): JSX.Element {
           />
         </Flex>
 
-        <Text>Before</Text>
+        <Text>Executive posted before:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={endInput}

--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -54,8 +54,8 @@ export async function getPolls(
   const allPolls = await _getAllPolls(network);
   const filteredPolls = allPolls.filter(poll => {
     // check date filters first
-    if (filters.startDate && new Date(poll.startDate).getTime() < filters.startDate.getTime()) return false;
-    if (filters.endDate && new Date(poll.startDate).getTime() > filters.endDate.getTime()) return false;
+    if (filters.startDate && new Date(poll.endDate).getTime() < filters.startDate.getTime()) return false;
+    if (filters.endDate && new Date(poll.endDate).getTime() > filters.endDate.getTime()) return false;
 
     // if no category filters selected, return all, otherwise, check if poll contains category
     return (

--- a/modules/polling/components/DateFilter.tsx
+++ b/modules/polling/components/DateFilter.tsx
@@ -45,7 +45,7 @@ export default function DateFilter(props): JSX.Element {
       {...props}
     >
       <Grid gap={2} columns="max-content max-content" sx={{ alignItems: 'baseline' }}>
-        <Text>Poll expired after:</Text>
+        <Text>Ended after:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={startInput}
@@ -54,7 +54,7 @@ export default function DateFilter(props): JSX.Element {
           />
         </Flex>
 
-        <Text>Poll expired before:</Text>
+        <Text>Ended before:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input ref={endInput} type="date" onChange={e => setEndDate('poll', new Date(e.target.value))} />
         </Flex>

--- a/modules/polling/components/DateFilter.tsx
+++ b/modules/polling/components/DateFilter.tsx
@@ -45,7 +45,7 @@ export default function DateFilter(props): JSX.Element {
       {...props}
     >
       <Grid gap={2} columns="max-content max-content" sx={{ alignItems: 'baseline' }}>
-        <Text>After</Text>
+        <Text>Poll expired after:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input
             ref={startInput}
@@ -54,7 +54,7 @@ export default function DateFilter(props): JSX.Element {
           />
         </Flex>
 
-        <Text>Before</Text>
+        <Text>Poll expired before:</Text>
         <Flex sx={{ alignItems: 'center' }}>
           <Input ref={endInput} type="date" onChange={e => setEndDate('poll', new Date(e.target.value))} />
         </Flex>

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -71,8 +71,8 @@ const PollingOverview = ({ polls, categories }: Props) => {
   const filteredPolls = useMemo(() => {
     return polls.filter(poll => {
       // check date filters first
-      if (start && new Date(poll.startDate).getTime() < start.getTime()) return false;
-      if (end && new Date(poll.startDate).getTime() > end.getTime()) return false;
+      if (start && new Date(poll.endDate).getTime() < start.getTime()) return false;
+      if (end && new Date(poll.endDate).getTime() > end.getTime()) return false;
 
       // if no category filters selected, return all, otherwise, check if poll contains category
       return noCategoriesSelected || poll.categories.some(c => categoryFilter && categoryFilter[c]);


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/551/poll-date-filter-filter-on-end-date-instead-of-creation-date

### What does this PR do?
Changes text and filters in poll page 

### Steps for testing:
Try filters on poll page, see if they make sense
### Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/1152768/143469797-66a04967-9985-47b1-ba2d-cc129311bd50.png)

### Any additional helpful information?:

### Add a GIF:
![](https://media0.giphy.com/media/clxi7gGCUVhIphK5rs/giphy.gif)