### PR TITLE
Add delegate actions to delegate detail

### DIFF
--- a/modules/delegates/components/ManageDelegation.tsx
+++ b/modules/delegates/components/ManageDelegation.tsx
@@ -1,0 +1,71 @@
+import { Card, Box, Button, Heading } from 'theme-ui';
+import React, { useState } from 'react';
+import { Delegate } from '../types';
+import useAccountsStore from 'stores/accounts';
+import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constants';
+import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
+import { DelegateModal } from './modals/DelegateModal';
+import { UndelegateModal } from './modals/UndelegateModal';
+import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
+import { useMkrDelegated } from 'modules/mkr/hooks/useMkrDelegated';
+
+export default function ManageDelegation({ delegate }: { delegate: Delegate }): React.ReactElement {
+  const [account] = useAccountsStore(state => [state.currentAccount]);
+  const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.DELEGATE_DETAIL);
+  const [showDelegateModal, setShowDelegateModal] = useState(false);
+  const [showUndelegateModal, setShowUndelegateModal] = useState(false);
+
+  const { mutate: mutateTotalStaked } = useLockedMkr(delegate.voteDelegateAddress);
+  const { mutate: mutateMkrStaked } = useMkrDelegated(account?.address, delegate.voteDelegateAddress);
+
+  return (
+    <Box>
+      <Heading mt={3} mb={2} as="h3" variant="microHeading">
+        Manage Delegation
+      </Heading>
+      <Card variant="compact">
+        <Box>
+          <Button
+            variant="primaryLarge"
+            disabled={!account}
+            onClick={() => {
+              trackButtonClick('openDelegateModal');
+              setShowDelegateModal(true);
+            }}
+            sx={{ width: '100%', height: '45px', mb: [3] }}
+          >
+            Delegate your MKR to this Delegate
+          </Button>
+        </Box>
+
+        <Box>
+          <Button
+            variant="primaryOutline"
+            disabled={!account}
+            onClick={() => {
+              trackButtonClick('openUndelegateModal');
+              setShowUndelegateModal(true);
+            }}
+            sx={{ width: '100%', height: '45px' }}
+          >
+            Undelegate your MKR from this Delegate
+          </Button>
+        </Box>
+      </Card>
+      <DelegateModal
+        delegate={delegate}
+        isOpen={showDelegateModal}
+        onDismiss={() => setShowDelegateModal(false)}
+        mutateTotalStaked={mutateTotalStaked}
+        mutateMkrStaked={mutateMkrStaked}
+      />
+      <UndelegateModal
+        delegate={delegate}
+        isOpen={showUndelegateModal}
+        onDismiss={() => setShowUndelegateModal(false)}
+        mutateTotalStaked={mutateTotalStaked}
+        mutateMkrStaked={mutateMkrStaked}
+      />
+    </Box>
+  );
+}

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -19,6 +19,7 @@ import { AddressApiResponse } from 'modules/address/types/addressApiResponse';
 import { AddressDetail } from 'modules/address/components/AddressDetail';
 import { DelegateDetail } from 'modules/delegates/components';
 import { HeadComponent } from 'modules/app/components/layout/Head';
+import ManageDelegation from 'modules/delegates/components/ManageDelegation';
 
 const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
   const network = getNetwork();
@@ -73,6 +74,9 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
           </Box>
         </Stack>
         <Stack gap={3}>
+          {addressInfo.isDelegate && addressInfo.delegateInfo && (
+            <ManageDelegation delegate={addressInfo.delegateInfo} />
+          )}
           <SystemStatsSidebar
             fields={['polling contract', 'savings rate', 'total dai', 'debt ceiling', 'system surplus']}
           />


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/797/add-delegate-undelegate-buttons-on-delegate-profile-page

### What does this PR do?
Adds delegate quick actions to delegate detail

### Steps for testing:
Go to delegate detail, press buttons, profit
### Screenshots (if relevant):

![image](https://user-images.githubusercontent.com/1152768/143564551-36c3bdb5-01db-49fa-ac0e-0fb0830ebf9c.png)
![image](https://user-images.githubusercontent.com/1152768/143564601-7ae18fee-a326-4c33-b7f8-c91d1dd0ad5a.png)


### Add a GIF:
![](https://media4.giphy.com/media/GwRBmXyEOvFtK/giphy.gif)
