### PR TITLE
Show percentage of MKR delegated

### DIFF
--- a/modules/delegates/components/DelegatesSystemInfo.tsx
+++ b/modules/delegates/components/DelegatesSystemInfo.tsx
@@ -53,12 +53,14 @@ export function DelegatesSystemInfo({
     {
       title: 'Percent of MKR delegated',
       id: 'percent-mkr-system-info',
-      value: totalMKR
-        ? `${new BigNumber(stats.totalMKRDelegated)
-            .dividedBy(totalMKR.toBigNumber())
-            .multipliedBy(100)
-            .toFormat(2)}%`
-        : '0'
+      value: totalMKR ? (
+        `${new BigNumber(stats.totalMKRDelegated)
+          .dividedBy(totalMKR.toBigNumber())
+          .multipliedBy(100)
+          .toFormat(2)}%`
+      ) : (
+        <SkeletonThemed width={'100px'} height={'15px'} />
+      )
     }
   ];
 

--- a/modules/delegates/components/DelegatesSystemInfo.tsx
+++ b/modules/delegates/components/DelegatesSystemInfo.tsx
@@ -6,6 +6,8 @@ import { formatAddress, getEtherscanLink } from 'lib/utils';
 import useSWR from 'swr';
 import { Box, Card, Flex, Heading, Link as ThemeUILink, Text } from 'theme-ui';
 import { DelegatesAPIStats } from '../types';
+import { useEffect } from 'react';
+import { useTotalMKR } from 'modules/mkr/hooks/useTotalMkr';
 
 export function DelegatesSystemInfo({
   stats,
@@ -24,6 +26,9 @@ export function DelegatesSystemInfo({
       refreshInterval: 0
     }
   );
+
+  const { data: totalMKR } = useTotalMKR();
+
   const statsItems = [
     {
       title: 'Total delegates',
@@ -44,6 +49,16 @@ export function DelegatesSystemInfo({
       title: 'Total MKR delegated',
       id: 'total-mkr-system-info',
       value: new BigNumber(stats.totalMKRDelegated).toFormat(2)
+    },
+    {
+      title: 'Percent of MKR delegated',
+      id: 'percent-mkr-system-info',
+      value: totalMKR
+        ? `${new BigNumber(stats.totalMKRDelegated)
+            .dividedBy(totalMKR.toBigNumber())
+            .multipliedBy(100)
+            .toFormat(2)}%`
+        : '0'
     }
   ];
 

--- a/modules/mkr/hooks/useTotalMkr.ts
+++ b/modules/mkr/hooks/useTotalMkr.ts
@@ -1,0 +1,28 @@
+// Returns the total supply of MKR
+
+import getMaker, { getNetwork } from 'lib/maker';
+import useSWR from 'swr';
+import { CurrencyObject } from 'types/currency';
+
+export const useTotalMKR = (): {
+  data: CurrencyObject;
+} => {
+  const { data } = useSWR(
+    '/total-mkr-supply',
+    async () => {
+      const maker = await getMaker(getNetwork());
+
+      const total = await maker.service('token').getToken('MKR').totalSupply();
+
+      return total;
+    },
+    {
+      revalidateOnMount: true,
+      revalidateOnFocus: false
+    }
+  );
+
+  return {
+    data
+  };
+};


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/536/add-of-total-mkr-tokens-delegated-to-delegates-system-info
### What does this PR do?
shows percent of total supply of MKR delegated
### Steps for testing:
go to delegates page and see the %

### Screenshots (if relevant):

![image](https://user-images.githubusercontent.com/1152768/143591820-9eb818cc-8ad9-4bae-ab3b-375a8c4d0163.png)


### Any additional helpful information?:

### Add a GIF:
![](https://media3.giphy.com/media/iGLEtJA9pPH1acTOra/giphy-downsized-medium.gif)