### PR TITLE
Feat: Allow to send a query parameter to determine the community repo…

### DIFF
--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -23,6 +23,7 @@ import PollWinningOptionBox from './PollWinningOptionBox';
 import { formatDateWithTime } from 'lib/datetime';
 import { usePollTally } from '../hooks/usePollTally';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
+import { useRouter } from 'next/router';
 
 type Props = {
   poll: Poll;
@@ -39,6 +40,8 @@ export default function PollOverviewCard({
   ...props
 }: Props): JSX.Element {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING);
+  const router = useRouter();
+  const branch = router.query.branch;
 
   const network = getNetwork();
   const account = useAccountsStore(state => state.currentAccount);
@@ -66,7 +69,10 @@ export default function PollOverviewCard({
                 <Text as="p" variant="caps" sx={{ color: 'textSecondary', mb: 2 }}>
                   Posted on {formatDateWithTime(poll.startDate)}{' '}
                 </Text>
-                <Link href={`/polling/${poll.slug}?network=${network}`} passHref>
+                <Link
+                  href={`/polling/${poll.slug}?network=${network}${branch ? `&branch=${branch}` : ''}`}
+                  passHref
+                >
                   <InternalLink variant="nostyle">
                     <Text variant="microHeading" sx={{ fontSize: [3, 5] }}>
                       {poll.title}
@@ -74,7 +80,10 @@ export default function PollOverviewCard({
                   </InternalLink>
                 </Link>
               </Box>
-              <Link href={`/polling/${poll.slug}?network=${network}`} passHref>
+              <Link
+                href={`/polling/${poll.slug}?network=${network}${branch ? `&branch=${branch}` : ''}`}
+                passHref
+              >
                 <InternalLink variant="nostyle">
                   <Text
                     sx={{

--- a/modules/polling/types/poll.d.ts
+++ b/modules/polling/types/poll.d.ts
@@ -21,9 +21,9 @@ export type Poll = {
 };
 
 export type PartialPoll = {
-  creator: string;
+  creator?: string;
   pollId: number;
-  blockCreated: number;
+  blockCreated?: number;
   multiHash: string;
   startDate: Date;
   endDate: Date;

--- a/modules/polling/types/poll.d.ts
+++ b/modules/polling/types/poll.d.ts
@@ -21,7 +21,9 @@ export type Poll = {
 };
 
 export type PartialPoll = {
+  creator: string;
   pollId: number;
+  blockCreated: number;
   multiHash: string;
   startDate: Date;
   endDate: Date;

--- a/pages/api/polling/[slug].ts
+++ b/pages/api/polling/[slug].ts
@@ -87,7 +87,8 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
   const slug = req.query.slug as string;
 
-  const poll = await getPoll(slug, network);
+  const branch = req.query.branch as string;
+  const poll = await getPoll(slug, network, branch);
 
   if (!poll) {
     return res.status(404).json('Not found');

--- a/pages/api/polling/all-polls.ts
+++ b/pages/api/polling/all-polls.ts
@@ -131,7 +131,9 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
       : null
   };
 
-  const pollsResponse = await getPolls(filters, network);
+  const branch = req.query.branch as string;
+
+  const pollsResponse = await getPolls(filters, network, branch);
 
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
   res.status(200).json(pollsResponse);

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -36,6 +36,7 @@ import { getPolls } from 'modules/polling/api/fetchPolls';
 import { useAllUserVotes } from 'modules/polling/hooks/useAllUserVotes';
 import { HeadComponent } from 'modules/app/components/layout/Head';
 import { PollsResponse } from 'modules/polling/types/pollsResponse';
+import { useRouter } from 'next/router';
 
 type Props = {
   polls: Poll[];
@@ -304,17 +305,20 @@ export default function PollingOverviewPage({
   const [_categories, _setCategories] = useState<PollCategory[]>();
   const [error, setError] = useState<string>();
 
+  const router = useRouter();
+  const branch = router.query.branch;
+
   // fetch polls at run-time if on any network other than the default
   useEffect(() => {
-    if (!isDefaultNetwork()) {
-      fetchJson(`/api/polling/all-polls?network=${getNetwork()}`)
+    if (!isDefaultNetwork() || branch) {
+      fetchJson(`/api/polling/all-polls?network=${getNetwork()}${branch ? `&branch=${branch}` : ''}`)
         .then((pollsResponse: PollsResponse) => {
           _setPolls(pollsResponse.polls);
           _setCategories(pollsResponse.categories);
         })
         .catch(setError);
     }
-  }, []);
+  }, [branch]);
 
   if (error) {
     return <ErrorPage statusCode={404} title="Error fetching proposals" />;

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -311,17 +311,20 @@ export default function PollPage({ poll: prefetchedPoll }: { poll?: Poll }): JSX
   const [_poll, _setPoll] = useState<Poll>();
   const [error, setError] = useState<string>();
   const { query, isFallback } = useRouter();
+  const branch = query.branch;
 
   // fetch poll contents at run-time if on any network other than the default
   useEffect(() => {
-    if (query['poll-hash'] && (!isDefaultNetwork() || !prefetchedPoll)) {
-      fetchJson(`/api/polling/${query['poll-hash']}?network=${getNetwork()}`)
+    if (query['poll-hash'] && (!isDefaultNetwork() || !prefetchedPoll || branch)) {
+      fetchJson(
+        `/api/polling/${query['poll-hash']}?network=${getNetwork()}${branch ? `&branch=${branch}` : ''}`
+      )
         .then(response => {
           _setPoll(response);
         })
         .catch(setError);
     }
-  }, [query['poll-hash']]);
+  }, [query['poll-hash'], branch]);
 
   if (error || (isDefaultNetwork() && !isFallback && !prefetchedPoll?.multiHash)) {
     return (


### PR DESCRIPTION
Allows to send a query parameter to the governance portal to fetch Polls Metadata from a different branch than master (on the governance community repo). 

This will allow to test new polls or metadata without having to merge into the community repo master branch ( which affects production)

To see a different branch use the following url, replacing "another" for any branch

`/polling/all-polls?branch=another`

## how to test it?


Go to `/polling/QmZmmLNv?network=goerli&branch=dependabot/npm_and_yarn/r2d/theme-ui-0.12.1#poll-detail` 

This is a branch from the community repo, in the url

https://github.com/makerdao/community/branches

