### PR TITLE
fetch delegator data in API

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -60,6 +60,8 @@ export default {
     tagColorFifteenBg: '#FFFBEF',
     tagColorSixteen: '#FF8237',
     tagColorSixteenBg: '#FFFBEF',
+    bull: '#1AAB9B',
+    bear: '#F77249',
     modes: {
       dark: {
         primary: '#1DC1AE',
@@ -117,7 +119,9 @@ export default {
         tagColorFifteen: '#FF8237',
         tagColorFifteenBg: '#121212',
         tagColorSixteen: '#FF8237',
-        tagColorSixteenBg: '#121212'
+        tagColorSixteenBg: '#121212',
+        bull: '#1AAB9B',
+        bear: '#F77249'
       }
     }
   },
@@ -282,6 +286,13 @@ export default {
       ...theme.text.caps,
       fontSize: 1,
       fontWeight: 600,
+      color: 'textSecondary',
+      letterSpacing: '0.05em'
+    },
+    smallCaps: {
+      ...theme.text.caps,
+      fontSize: 1,
+      fontWeight: 'body',
       color: 'textSecondary',
       letterSpacing: '0.05em'
     },
@@ -1094,6 +1105,61 @@ export default {
             strokeWidth="0.6"
           />
         </g>
+      )
+    },
+    decrease: {
+      viewBox: '0 0 8 7',
+      path: (
+        <g>
+          <path
+            d="M6.97438 1.90227C7.19442 1.90227 7.3728 2.08065 7.3728 2.30069L7.3728 6.68329L6.57597 6.68329L6.57597 2.30069C6.57597 2.08065 6.75434 1.90227 6.97438 1.90227Z"
+            fill="currentColor"
+          />
+          <path
+            d="M2.59178 6.28487C2.59178 6.06483 2.77016 5.88645 2.9902 5.88645L7.3728 5.88645L7.3728 6.68329L2.9902 6.68329C2.77016 6.68329 2.59178 6.50491 2.59178 6.28487Z"
+            fill="currentColor"
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M6.85769 6.16818C6.7021 6.32377 6.44983 6.32377 6.29424 6.16818L1.1148 0.988736C0.959209 0.833144 0.959209 0.58088 1.1148 0.425288C1.27039 0.269695 1.52266 0.269695 1.67825 0.425288L6.85769 5.60473C7.01328 5.76032 7.01328 6.01258 6.85769 6.16818Z"
+            fill="currentColor"
+          />
+        </g>
+      )
+    },
+    increase: {
+      viewBox: '0 0 8 8',
+      path: (
+        <g>
+          <path
+            d="M2.59178 1.14842C2.59178 0.928378 2.77016 0.75 2.9902 0.75H7.3728V1.54684H2.9902C2.77016 1.54684 2.59178 1.36846 2.59178 1.14842Z"
+            fill="currentColor"
+          />
+          <path
+            d="M6.97438 5.53102C6.75434 5.53102 6.57597 5.35264 6.57597 5.1326L6.57597 0.75L7.3728 0.75V5.1326C7.3728 5.35264 7.19442 5.53102 6.97438 5.53102Z"
+            fill="currentColor"
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M6.85769 1.26511C7.01328 1.4207 7.01328 1.67297 6.85769 1.82856L1.67825 7.008C1.52266 7.16359 1.27039 7.16359 1.1148 7.008C0.95921 6.85241 0.95921 6.60014 1.1148 6.44455L6.29424 1.26511C6.44983 1.10952 6.7021 1.10952 6.85769 1.26511Z"
+            fill="currentColor"
+          />
+        </g>
+      )
+    },
+    minus: {
+      viewBox: '0 0 6 3',
+      path: <path d="M5.6463 2.125V0.851562H0.521296V2.125H5.6463Z" fill="currentColor" />
+    },
+    plus: {
+      viewBox: '0 0 9 9',
+      path: (
+        <path
+          d="M4.66192 5.35938H8.06036V4.20312H4.66192V0.804688H3.50567V4.20312H0.107233V5.35938H3.50567V8.75781H4.66192V5.35938Z"
+          fill="currentColor"
+        />
       )
     }
   }

--- a/modules/delegates/api/fetchDelegationHistory.ts
+++ b/modules/delegates/api/fetchDelegationHistory.ts
@@ -33,5 +33,7 @@ export async function fetchDelegationHistory(
     []
   );
 
-  return delegators.sort((a, b) => (a.lockAmount > b.lockAmount ? -1 : 1));
+  return delegators.sort((a, b) =>
+    utils.parseEther(a.lockAmount).gt(utils.parseEther(b.lockAmount)) ? -1 : 1
+  );
 }

--- a/modules/delegates/api/fetchDelegationHistory.ts
+++ b/modules/delegates/api/fetchDelegationHistory.ts
@@ -1,0 +1,33 @@
+import BigNumber from 'bignumber.js';
+import { utils } from 'ethers';
+import { format, parse } from 'date-fns';
+import { SupportedNetworks } from 'lib/constants';
+import { DelegationHistory, MKRLockedDelegateAPIResponse } from '../types';
+import getMaker from 'lib/maker';
+
+export async function fetchDelegationHistory(
+  address: string,
+  network: SupportedNetworks
+): Promise<DelegationHistory[]> {
+  const maker = await getMaker(network);
+  const addressData: MKRLockedDelegateAPIResponse[] = await maker
+    .service('voteDelegate')
+    .getMkrLockedDelegate(address);
+
+  const delegatorsR = addressData.reduce((acc, { fromAddress, lockAmount }) => {
+    const currSum = acc[fromAddress]?.lockAmount
+      ? utils.parseEther(acc[fromAddress]?.lockAmount)
+      : utils.parseEther('0');
+
+    acc[fromAddress] = { lockAmount: utils.formatEther(currSum.add(utils.parseEther(lockAmount))) };
+    return acc;
+  }, {});
+
+  //TODO do this in the reducer
+  const delegators: DelegationHistory[] = [];
+  for (const x in delegatorsR) {
+    delegators.push({ address: x, ...delegatorsR[x] });
+  }
+
+  return delegators.sort((a, b) => (a.lockAmount > b.lockAmount ? -1 : 1));
+}

--- a/modules/delegates/api/fetchMKRWeightHistory.ts
+++ b/modules/delegates/api/fetchMKRWeightHistory.ts
@@ -4,14 +4,7 @@ import { MKRWeightHisory } from '../types/mkrWeight';
 import getMaker from 'lib/maker';
 import { format, parse } from 'date-fns';
 import BigNumber from 'bignumber.js';
-
-type MKRLockedDelegate = {
-  fromAddress: string;
-  lockAmount: string;
-  blockNumber: number;
-  blockTimestamp: string;
-  lockTotal: string;
-};
+import { MKRLockedDelegateAPIResponse } from '../types';
 
 export async function fetchDelegatesMKRWeightHistory(
   address: string,
@@ -20,7 +13,9 @@ export async function fetchDelegatesMKRWeightHistory(
   network: SupportedNetworks
 ): Promise<MKRWeightHisory[]> {
   const maker = await getMaker(network);
-  const addressData: MKRLockedDelegate[] = await maker.service('voteDelegate').getMkrLockedDelegate(address);
+  const addressData: MKRLockedDelegateAPIResponse[] = await maker
+    .service('voteDelegate')
+    .getMkrLockedDelegate(address);
 
   // We need to fill all the data for the interval
   // If we get last month, we need to add all the missing days

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -20,13 +20,12 @@ import { fetchJson } from 'lib/fetchJson';
 import { PollingParticipationOverview } from 'modules/polling/components/PollingParticipationOverview';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
 import LastVoted from 'modules/polling/components/LastVoted';
-import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 
 type PropTypes = {
   delegate: Delegate;
 };
 
-export function DelegateDetail({ delegate, delegatedFrom }: PropTypes): React.ReactElement {
+export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
   const { voteDelegateAddress } = delegate;
   const { data: statsData } = useSWR<AddressAPIStats>(
     `/api/address/${delegate.voteDelegateAddress}/stats?network=${getNetwork()}`,
@@ -37,7 +36,6 @@ export function DelegateDetail({ delegate, delegatedFrom }: PropTypes): React.Re
       revalidateOnMount: true
     }
   );
-  const { data: totalStaked, mutate: mutateTotalStaked } = useLockedMkr(delegate.voteDelegateAddress);
 
   const tabTitles = [
     delegate.status === DelegateStatusEnum.recognized ? 'Delegate Credentials' : null,
@@ -63,7 +61,7 @@ export function DelegateDetail({ delegate, delegatedFrom }: PropTypes): React.Re
       {statsData && <PollingParticipationOverview votes={statsData.pollVoteHistory} />}
     </Box>,
     <Box key="delegate-vote-history">
-      <DelegateVoteHistory delegate={delegate} delegatedFrom={delegatedFrom} totalStaked={totalStaked} />
+      <DelegateVoteHistory delegate={delegate} />
     </Box>
   ].filter(i => !!i);
 

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -20,12 +20,13 @@ import { fetchJson } from 'lib/fetchJson';
 import { PollingParticipationOverview } from 'modules/polling/components/PollingParticipationOverview';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
 import LastVoted from 'modules/polling/components/LastVoted';
+import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 
 type PropTypes = {
   delegate: Delegate;
 };
 
-export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
+export function DelegateDetail({ delegate, delegatedFrom }: PropTypes): React.ReactElement {
   const { voteDelegateAddress } = delegate;
   const { data: statsData } = useSWR<AddressAPIStats>(
     `/api/address/${delegate.voteDelegateAddress}/stats?network=${getNetwork()}`,
@@ -36,6 +37,7 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
       revalidateOnMount: true
     }
   );
+  const { data: totalStaked, mutate: mutateTotalStaked } = useLockedMkr(delegate.voteDelegateAddress);
 
   const tabTitles = [
     delegate.status === DelegateStatusEnum.recognized ? 'Delegate Credentials' : null,
@@ -61,7 +63,7 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
       {statsData && <PollingParticipationOverview votes={statsData.pollVoteHistory} />}
     </Box>,
     <Box key="delegate-vote-history">
-      <DelegateVoteHistory delegate={delegate} />
+      <DelegateVoteHistory delegate={delegate} delegatedFrom={delegatedFrom} totalStaked={totalStaked} />
     </Box>
   ].filter(i => !!i);
 

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Text, Link as ExternalLink, Flex, Divider, Heading } from 'theme-ui';
+import { Box, Text, Link as ExternalLink, Flex, Divider } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
@@ -66,11 +66,13 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
       )}
       {delegate.status === DelegateStatusEnum.recognized && <Divider />}
       {delegators && delegators?.length > 0 && (
-        <Box sx={{ pl: [3, 4], pr: [3, 4], py: [3, 4] }}>
-          <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
-        </Box>
+        <>
+          <Box sx={{ pl: [3, 4], pr: [3, 4], py: [3, 4] }}>
+            <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
+          </Box>
+          <Divider />
+        </>
       )}
-      {delegate.status === DelegateStatusEnum.recognized && <Divider />}
       <Box sx={{ pl: [3, 4], pr: [3, 4], pb: [3, 4] }}>
         <DelegateMKRChart delegate={delegate} />
       </Box>

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Text, Link as ExternalLink, Flex, Divider } from 'theme-ui';
+import { Box, Text, Link as ExternalLink, Flex, Divider, Heading } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { getNetwork } from 'lib/maker';
 import { getEtherscanLink } from 'lib/utils';
@@ -20,6 +20,9 @@ import { fetchJson } from 'lib/fetchJson';
 import { PollingParticipationOverview } from 'modules/polling/components/PollingParticipationOverview';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
 import LastVoted from 'modules/polling/components/LastVoted';
+import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
+import DelegatedByAddress from 'modules/delegates/components/DelegatedByAddress';
+import { DelegationHistory } from 'modules/delegates/types';
 
 type PropTypes = {
   delegate: Delegate;
@@ -36,6 +39,14 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
       revalidateOnMount: true
     }
   );
+  const { data: delegators } = useSWR<DelegationHistory[]>(
+    `/api/delegates/delegation-history/${delegate.voteDelegateAddress}?network=${getNetwork()}`,
+    fetchJson,
+    {
+      revalidateOnMount: true
+    }
+  );
+  const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
 
   const tabTitles = [
     delegate.status === DelegateStatusEnum.recognized ? 'Delegate Credentials' : null,
@@ -52,6 +63,12 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
     <Box key="delegate-participation-metrics">
       {delegate.status === DelegateStatusEnum.recognized && (
         <DelegateParticipationMetrics delegate={delegate} />
+      )}
+      {delegate.status === DelegateStatusEnum.recognized && <Divider />}
+      {delegators && delegators?.length > 0 && (
+        <Box sx={{ pl: [3, 4], pr: [3, 4], py: [3, 4] }}>
+          <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
+        </Box>
       )}
       {delegate.status === DelegateStatusEnum.recognized && <Divider />}
       <Box sx={{ pl: [3, 4], pr: [3, 4], pb: [3, 4] }}>

--- a/modules/delegates/components/DelegateMKRChart.tsx
+++ b/modules/delegates/components/DelegateMKRChart.tsx
@@ -16,7 +16,7 @@ import {
 import FilterButton from 'modules/app/components/FilterButton';
 import { useState } from 'react';
 import { MKRWeightTimeRanges } from '../delegates.constants';
-import { fetchJson } from '@ethersproject/web';
+import { fetchJson } from 'lib/fetchJson';
 import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { format } from 'date-fns';

--- a/modules/delegates/components/DelegateVoteHistory.tsx
+++ b/modules/delegates/components/DelegateVoteHistory.tsx
@@ -1,14 +1,11 @@
 import { PollVoteHistoryList } from 'modules/polling/components/PollVoteHistoryList';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
-import { Box, Divider, Flex, Heading, Text } from 'theme-ui';
+import { Box, Divider, Text } from 'theme-ui';
 import { Delegate } from '../types';
 import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/fetchJson';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
-import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
-import DelegatedByAddress from 'modules/delegates/components/DelegatedByAddress';
-import { DelegationHistory } from 'modules/delegates/types';
 
 export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React.ReactElement {
   const { data: statsData } = useSWR<AddressAPIStats>(
@@ -19,28 +16,10 @@ export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React
     }
   );
 
-  const { data: delegators } = useSWR<DelegationHistory[]>(
-    `/api/delegates/delegation-history/${delegate.voteDelegateAddress}?network=${getNetwork()}`,
-    fetchJson,
-    {
-      revalidateOnMount: true
-    }
-  );
-  const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
-
   return (
     <Box>
       <Box sx={{ pb: 2 }}>
         <Box sx={{ pl: [3, 4], pr: [3, 4], pt: [3, 4] }}>
-          {delegators && (
-            <Flex sx={{ flexDirection: 'column' }}>
-              <Heading variant="microHeading" sx={{ mb: 3 }}>
-                MKR Delegated Per Address
-              </Heading>
-              <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
-              <Divider mt={3} mb={3} />
-            </Flex>
-          )}
           <Text
             as="p"
             sx={{

--- a/modules/delegates/components/DelegateVoteHistory.tsx
+++ b/modules/delegates/components/DelegateVoteHistory.tsx
@@ -6,15 +6,11 @@ import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/fetchJson';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
+import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 import DelegatedByAddress from 'modules/delegates/components/DelegatedByAddress';
+import { DelegationHistory } from 'modules/delegates/types';
 
-export function DelegateVoteHistory({
-  delegate,
-  delegatedFrom,
-  totalStaked
-}: {
-  delegate: Delegate;
-}): React.ReactElement {
+export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React.ReactElement {
   const { data: statsData } = useSWR<AddressAPIStats>(
     `/api/address/${delegate.voteDelegateAddress}/stats?network=${getNetwork()}`,
     fetchJson,
@@ -23,11 +19,20 @@ export function DelegateVoteHistory({
     }
   );
 
+  const { data: delegators } = useSWR<DelegationHistory>(
+    `/api/delegates/delegation-history/${delegate.voteDelegateAddress}?network=${getNetwork()}`,
+    fetchJson,
+    {
+      revalidateOnMount: true
+    }
+  );
+  const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
+
   return (
     <Box>
       <Box sx={{ pb: 2 }}>
         <Box sx={{ pl: [3, 4], pr: [3, 4], pt: [3, 4] }}>
-          <DelegatedByAddress delegators={delegatedFrom} totalDelegated={totalStaked} />
+          <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
           <Divider mt={1} mb={1} />
           <Text
             as="p"

--- a/modules/delegates/components/DelegateVoteHistory.tsx
+++ b/modules/delegates/components/DelegateVoteHistory.tsx
@@ -1,6 +1,6 @@
 import { PollVoteHistoryList } from 'modules/polling/components/PollVoteHistoryList';
 import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
-import { Box, Divider, Text } from 'theme-ui';
+import { Box, Divider, Flex, Heading, Text } from 'theme-ui';
 import { Delegate } from '../types';
 import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
@@ -19,7 +19,7 @@ export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React
     }
   );
 
-  const { data: delegators } = useSWR<DelegationHistory>(
+  const { data: delegators } = useSWR<DelegationHistory[]>(
     `/api/delegates/delegation-history/${delegate.voteDelegateAddress}?network=${getNetwork()}`,
     fetchJson,
     {
@@ -32,8 +32,15 @@ export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React
     <Box>
       <Box sx={{ pb: 2 }}>
         <Box sx={{ pl: [3, 4], pr: [3, 4], pt: [3, 4] }}>
-          <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
-          <Divider mt={1} mb={1} />
+          {delegators && (
+            <Flex sx={{ flexDirection: 'column' }}>
+              <Heading variant="microHeading" sx={{ mb: 3 }}>
+                MKR Delegated Per Address
+              </Heading>
+              <DelegatedByAddress delegators={delegators} totalDelegated={totalStaked} />
+              <Divider mt={3} mb={3} />
+            </Flex>
+          )}
           <Text
             as="p"
             sx={{

--- a/modules/delegates/components/DelegateVoteHistory.tsx
+++ b/modules/delegates/components/DelegateVoteHistory.tsx
@@ -6,8 +6,15 @@ import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/fetchJson';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
+import DelegatedByAddress from 'modules/delegates/components/DelegatedByAddress';
 
-export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React.ReactElement {
+export function DelegateVoteHistory({
+  delegate,
+  delegatedFrom,
+  totalStaked
+}: {
+  delegate: Delegate;
+}): React.ReactElement {
   const { data: statsData } = useSWR<AddressAPIStats>(
     `/api/address/${delegate.voteDelegateAddress}/stats?network=${getNetwork()}`,
     fetchJson,
@@ -20,6 +27,8 @@ export function DelegateVoteHistory({ delegate }: { delegate: Delegate }): React
     <Box>
       <Box sx={{ pb: 2 }}>
         <Box sx={{ pl: [3, 4], pr: [3, 4], pt: [3, 4] }}>
+          <DelegatedByAddress delegators={delegatedFrom} totalDelegated={totalStaked} />
+          <Divider mt={1} mb={1} />
           <Text
             as="p"
             sx={{

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -15,8 +15,6 @@ type Props = {
 };
 
 const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element => {
-  console.log('delegators from comp', delegators);
-  console.log('dtotalDelegated', totalDelegated);
   const bpi = useBreakpointIndex();
   const network = getNetwork();
 

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -108,6 +108,21 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: DelegatedByAddressPr
 
   return (
     <Box>
+      <Box mb={3}>
+        <Text
+          as="p"
+          variant="h2"
+          sx={{
+            fontSize: 4,
+            fontWeight: 'semiBold'
+          }}
+        >
+          Delegators
+        </Text>
+        <Text as="p" variant="secondary" color="onSurface">
+          MKR delegated by address
+        </Text>
+      </Box>
       <table
         style={{
           width: '100%',

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -1,0 +1,101 @@
+import Link from 'next/link';
+import { Box, Text, Link as ThemeUILink } from 'theme-ui';
+import { useBreakpointIndex } from '@theme-ui/match-media';
+import BigNumber from 'bignumber.js';
+import { getNetwork } from 'lib/maker';
+import { cutMiddle } from 'lib/string';
+import { useDelegateAddressMap } from 'lib/hooks';
+import { PollTally, Poll } from 'modules/polling/types';
+import { getVoteColor } from 'modules/polling/helpers/getVoteColor';
+import { Address } from 'modules/address/components/Address';
+
+type Props = {
+  delegators: any; //TODO FIXME
+  totalDelegated: any; //TODO FIXME
+};
+
+const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element => {
+  console.log('delegators from comp', delegators);
+  console.log('dtotalDelegated', totalDelegated);
+  const bpi = useBreakpointIndex();
+  const network = getNetwork();
+
+  return (
+    <Box>
+      <table
+        style={{
+          width: '100%',
+          borderCollapse: 'collapse'
+        }}
+      >
+        <thead>
+          <tr>
+            <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '30%' }} variant="caps">
+              Address
+            </Text>
+            <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '30%' }} variant="caps">
+              MKR Delegated
+            </Text>
+            <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '20%' }} variant="caps">
+              Voting Power
+            </Text>
+            {/* <Text as="th" sx={{ textAlign: 'right', pb: 2, width: '20%' }} variant="caps">
+              Verify
+            </Text> */}
+          </tr>
+        </thead>
+        <tbody>
+          {delegators ? (
+            <>
+              {delegators.map(({ address, lockAmount }, i) => (
+                <tr key={i}>
+                  <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>
+                    <Link href={{ pathname: `/address/${address}`, query: { network } }} passHref>
+                      <ThemeUILink title="View address detail">
+                        {/* {delegateAddresses[v.voter] ? (
+                          delegateAddresses[v.voter]
+                        ) : ( */}
+                        <Address address={address} />
+                        {/* )} */}
+                      </ThemeUILink>
+                    </Link>
+                  </Text>
+                  {/* <Text
+                    as="td"
+                    sx={{ color: getVoteColor(v.optionId, poll.voteType), pb: 2, fontSize: bpi < 1 ? 1 : 3 }}
+                  >
+                    {v.rankedChoiceOption && v.rankedChoiceOption.length > 1
+                      ? poll.options[v.rankedChoiceOption[0]]
+                      : poll.options[v.optionId]}
+                    {v.rankedChoiceOption && v.rankedChoiceOption.length > 1 && '*'}
+                  </Text> */}
+                  <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>{`${new BigNumber(
+                    lockAmount
+                  ).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}</Text>
+                  <Text as="td" sx={{ pb: 2 }}>
+                    {`${new BigNumber(lockAmount).div(totalDelegated.toBigNumber()).times(100).toFormat(1)}%`}
+                  </Text>
+                </tr>
+              ))}
+            </>
+          ) : (
+            <tr key={0}>
+              <td colSpan={3}>
+                <Text color="text" variant="allcaps">
+                  Loading
+                </Text>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {/* {showRankedChoiceInfo && (
+        <Text as="p" sx={{ mt: 4, color: 'textSecondary', fontSize: 1 }}>
+          *First choice in ranked choice vote shown
+        </Text>
+      )} */}
+    </Box>
+  );
+};
+
+export default DelegatedByAddress;

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -1,18 +1,108 @@
+import { useState } from 'react';
 import Link from 'next/link';
-import { Box, Text, Link as ThemeUILink } from 'theme-ui';
+import { Box, Text, Link as ThemeUILink, Flex, IconButton } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
+import { Icon } from '@makerdao/dai-ui-icons';
 import BigNumber from 'bignumber.js';
+import { format } from 'date-fns';
 import { getNetwork } from 'lib/maker';
 import { CurrencyObject } from 'types/currency';
 import { Address } from 'modules/address/components/Address';
 import { DelegationHistory } from '../types';
 
-type Props = {
+type DelegatedByAddressProps = {
   delegators: DelegationHistory[];
   totalDelegated: CurrencyObject;
 };
 
-const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element => {
+type CollapsableRowProps = {
+  delegator: DelegationHistory;
+  network: string;
+  bpi: number;
+  totalDelegated: CurrencyObject;
+};
+
+const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: CollapsableRowProps) => {
+  const dateFormat = 'MMM dd yyyy h:mm';
+  const [expanded, setExpanded] = useState(false);
+  const { address, lockAmount, events } = delegator;
+  return (
+    <tr>
+      <Flex as="td" sx={{ flexDirection: 'column' }}>
+        <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
+          <Link href={{ pathname: `/address/${address}`, query: { network } }} passHref>
+            <ThemeUILink title="View address detail">
+              <Address address={address} />
+            </ThemeUILink>
+          </Link>
+        </Text>
+        {expanded && (
+          <Flex sx={{ pl: 3, pb: 2, flexDirection: 'column' }}>
+            {events.map(({ blockTimestamp }) => {
+              return (
+                <Text key={blockTimestamp} variant="smallCaps">
+                  {format(new Date(blockTimestamp), dateFormat)}
+                </Text>
+              );
+            })}
+          </Flex>
+        )}
+      </Flex>
+      <Box as="td" sx={{ flexDirection: 'column' }}>
+        <Text sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>
+          {`${new BigNumber(lockAmount).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}
+        </Text>
+        {expanded && (
+          <Flex sx={{ pb: 2, flexDirection: 'column' }}>
+            {events.map(({ blockTimestamp, lockAmount }) => {
+              return (
+                <Flex key={blockTimestamp} sx={{ alignItems: 'center' }}>
+                  {lockAmount.indexOf('-') === 0 ? (
+                    <Icon name="decrease" size={2} color="bear" />
+                  ) : (
+                    <Icon name="increase" size={2} color="bull" />
+                  )}
+                  <Text key={blockTimestamp} variant="smallCaps" sx={{ pl: 2 }}>
+                    {new BigNumber(
+                      lockAmount.indexOf('-') === 0 ? lockAmount.substring(1) : lockAmount
+                    ).toFormat(2)}
+                  </Text>
+                </Flex>
+              );
+            })}
+          </Flex>
+        )}
+      </Box>
+      <Flex as="td" sx={{ alignSelf: 'flex-start' }}>
+        {totalDelegated ? (
+          <Text sx={{ pb: 2 }}>
+            {`${new BigNumber(lockAmount).div(totalDelegated.toBigNumber()).times(100).toFormat(1)}%`}
+          </Text>
+        ) : (
+          <Text>--</Text>
+        )}
+      </Flex>
+      <Box as="td" sx={{ textAlign: 'end', verticalAlign: 'top', width: '100%' }}>
+        <Flex
+          sx={{
+            bg: 'background',
+            size: 4,
+            float: 'right',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: 'round'
+          }}
+        >
+          <IconButton aria-label="Delegate history expand" onClick={() => setExpanded(!expanded)}>
+            <Icon name={expanded ? 'minus' : 'plus'} />
+          </IconButton>
+        </Flex>
+      </Box>
+    </tr>
+  );
+};
+
+const DelegatedByAddress = ({ delegators, totalDelegated }: DelegatedByAddressProps): JSX.Element => {
   const bpi = useBreakpointIndex();
   const network = getNetwork();
 
@@ -35,41 +125,22 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element 
             <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '20%' }} variant="caps">
               Total Percent
             </Text>
-            {/* <Text as="th" sx={{ textAlign: 'right', pb: 2, width: '20%' }} variant="caps">
+            <Text as="th" sx={{ textAlign: 'right', pb: 2, width: '20%' }} variant="caps">
               Verify
-            </Text> */}
+            </Text>
           </tr>
         </thead>
         <tbody>
           {delegators ? (
-            <>
-              {delegators.map(({ address, lockAmount }, i) => (
-                <tr key={i}>
-                  <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>
-                    <Link href={{ pathname: `/address/${address}`, query: { network } }} passHref>
-                      <ThemeUILink title="View address detail">
-                        <Address address={address} />
-                      </ThemeUILink>
-                    </Link>
-                  </Text>
-                  {/* <Text
-                    as="td"
-                    sx={{ color: getVoteColor(v.optionId, poll.voteType), pb: 2, fontSize: bpi < 1 ? 1 : 3 }}
-                  >
-                    {v.rankedChoiceOption && v.rankedChoiceOption.length > 1
-                      ? poll.options[v.rankedChoiceOption[0]]
-                      : poll.options[v.optionId]}
-                    {v.rankedChoiceOption && v.rankedChoiceOption.length > 1 && '*'}
-                  </Text> */}
-                  <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>{`${new BigNumber(
-                    lockAmount
-                  ).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}</Text>
-                  <Text as="td" sx={{ pb: 2 }}>
-                    {`${new BigNumber(lockAmount).div(totalDelegated.toBigNumber()).times(100).toFormat(1)}%`}
-                  </Text>
-                </tr>
-              ))}
-            </>
+            delegators.map((delegator, i) => (
+              <CollapsableRow
+                key={i}
+                delegator={delegator}
+                network={network}
+                bpi={bpi}
+                totalDelegated={totalDelegated}
+              />
+            ))
           ) : (
             <tr key={0}>
               <td colSpan={3}>

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -3,15 +3,13 @@ import { Box, Text, Link as ThemeUILink } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import BigNumber from 'bignumber.js';
 import { getNetwork } from 'lib/maker';
-import { cutMiddle } from 'lib/string';
-import { useDelegateAddressMap } from 'lib/hooks';
-import { PollTally, Poll } from 'modules/polling/types';
-import { getVoteColor } from 'modules/polling/helpers/getVoteColor';
+import { CurrencyObject } from 'types/currency';
 import { Address } from 'modules/address/components/Address';
+import { DelegationHistory } from '../types';
 
 type Props = {
-  delegators: any; //TODO FIXME
-  totalDelegated: any; //TODO FIXME
+  delegators: DelegationHistory[];
+  totalDelegated: CurrencyObject;
 };
 
 const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element => {
@@ -35,7 +33,7 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element 
               MKR Delegated
             </Text>
             <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '20%' }} variant="caps">
-              Voting Power
+              Total Percent
             </Text>
             {/* <Text as="th" sx={{ textAlign: 'right', pb: 2, width: '20%' }} variant="caps">
               Verify
@@ -50,11 +48,7 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element 
                   <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>
                     <Link href={{ pathname: `/address/${address}`, query: { network } }} passHref>
                       <ThemeUILink title="View address detail">
-                        {/* {delegateAddresses[v.voter] ? (
-                          delegateAddresses[v.voter]
-                        ) : ( */}
                         <Address address={address} />
-                        {/* )} */}
                       </ThemeUILink>
                     </Link>
                   </Text>
@@ -87,11 +81,6 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: Props): JSX.Element 
           )}
         </tbody>
       </table>
-      {/* {showRankedChoiceInfo && (
-        <Text as="p" sx={{ mt: 4, color: 'textSecondary', fontSize: 1 }}>
-          *First choice in ranked choice vote shown
-        </Text>
-      )} */}
     </Box>
   );
 };

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -8,7 +8,8 @@ import { format } from 'date-fns';
 import { getNetwork } from 'lib/maker';
 import { CurrencyObject } from 'types/currency';
 import { Address } from 'modules/address/components/Address';
-import { DelegationHistory } from '../types';
+import Skeleton from 'modules/app/components/SkeletonThemed';
+import { DelegationHistory } from 'modules/delegates/types';
 
 type DelegatedByAddressProps = {
   delegators: DelegationHistory[];
@@ -37,10 +38,10 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
           </Link>
         </Text>
         {expanded && (
-          <Flex sx={{ pl: 3, pb: 2, flexDirection: 'column' }}>
+          <Flex sx={{ pl: 3, flexDirection: 'column' }}>
             {events.map(({ blockTimestamp }) => {
               return (
-                <Text key={blockTimestamp} variant="smallCaps">
+                <Text key={blockTimestamp} variant="smallCaps" sx={{ py: 1 }}>
                   {format(new Date(blockTimestamp), dateFormat)}
                 </Text>
               );
@@ -48,15 +49,15 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
           </Flex>
         )}
       </Flex>
-      <Box as="td" sx={{ flexDirection: 'column' }}>
-        <Text sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3 }}>
+      <Box as="td" sx={{ verticalAlign: 'top' }}>
+        <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
           {`${new BigNumber(lockAmount).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}
         </Text>
         {expanded && (
-          <Flex sx={{ pb: 2, flexDirection: 'column' }}>
+          <Flex sx={{ flexDirection: 'column' }}>
             {events.map(({ blockTimestamp, lockAmount }) => {
               return (
-                <Flex key={blockTimestamp} sx={{ alignItems: 'center' }}>
+                <Flex key={blockTimestamp} sx={{ alignItems: 'center', py: 1 }}>
                   {lockAmount.indexOf('-') === 0 ? (
                     <Icon name="decrease" size={2} color="bear" />
                   ) : (
@@ -75,11 +76,13 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
       </Box>
       <Flex as="td" sx={{ alignSelf: 'flex-start' }}>
         {totalDelegated ? (
-          <Text sx={{ pb: 2 }}>
+          <Text>
             {`${new BigNumber(lockAmount).div(totalDelegated.toBigNumber()).times(100).toFormat(1)}%`}
           </Text>
         ) : (
-          <Text>--</Text>
+          <Box sx={{ width: '100%' }}>
+            <Skeleton />
+          </Box>
         )}
       </Flex>
       <Box as="td" sx={{ textAlign: 'end', verticalAlign: 'top', width: '100%' }}>
@@ -120,7 +123,7 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: DelegatedByAddressPr
           Delegators
         </Text>
         <Text as="p" variant="secondary" color="onSurface">
-          MKR delegated by address
+          Addresses that have delegated MKR
         </Text>
       </Box>
       <table

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Link from 'next/link';
-import { Box, Text, Link as ThemeUILink, Flex, IconButton } from 'theme-ui';
+import { Box, Text, Link as ThemeUILink, Flex, IconButton, Heading } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import { Icon } from '@makerdao/dai-ui-icons';
 import BigNumber from 'bignumber.js';
@@ -29,19 +29,26 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
   const { address, lockAmount, events } = delegator;
   return (
     <tr>
-      <Flex as="td" sx={{ flexDirection: 'column' }}>
-        <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
+      <Flex as="td" sx={{ flexDirection: 'column', mb: 3 }}>
+        <Heading variant="microHeading">
           <Link href={{ pathname: `/address/${address}`, query: { network } }} passHref>
-            <ThemeUILink title="View address detail">
+            <ThemeUILink title="View address detail" sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
               <Address address={address} />
             </ThemeUILink>
           </Link>
-        </Text>
+        </Heading>
         {expanded && (
           <Flex sx={{ pl: 3, flexDirection: 'column' }}>
             {events.map(({ blockTimestamp }) => {
               return (
-                <Text key={blockTimestamp} variant="smallCaps" sx={{ py: 1 }}>
+                <Text
+                  key={blockTimestamp}
+                  variant="smallCaps"
+                  sx={{
+                    ':first-of-type': { pt: 3 },
+                    ':not(:last-of-type)': { pb: 2 }
+                  }}
+                >
                   {format(new Date(blockTimestamp), dateFormat)}
                 </Text>
               );
@@ -57,7 +64,14 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
           <Flex sx={{ flexDirection: 'column' }}>
             {events.map(({ blockTimestamp, lockAmount }) => {
               return (
-                <Flex key={blockTimestamp} sx={{ alignItems: 'center', py: 1 }}>
+                <Flex
+                  key={blockTimestamp}
+                  sx={{
+                    alignItems: 'center',
+                    ':first-of-type': { pt: 3 },
+                    ':not(:last-of-type)': { pb: 2 }
+                  }}
+                >
                   {lockAmount.indexOf('-') === 0 ? (
                     <Icon name="decrease" size={2} color="bear" />
                   ) : (
@@ -89,7 +103,9 @@ const CollapsableRow = ({ delegator, network, bpi, totalDelegated }: Collapsable
         <Flex
           sx={{
             bg: 'background',
-            size: 4,
+            size: 'auto',
+            width: '17px',
+            height: '17px',
             float: 'right',
             alignItems: 'center',
             justifyContent: 'center',
@@ -141,10 +157,10 @@ const DelegatedByAddress = ({ delegators, totalDelegated }: DelegatedByAddressPr
               MKR Delegated
             </Text>
             <Text as="th" sx={{ textAlign: 'left', pb: 2, width: '20%' }} variant="caps">
-              Total Percent
+              Voting Weight
             </Text>
             <Text as="th" sx={{ textAlign: 'right', pb: 2, width: '20%' }} variant="caps">
-              Verify
+              Expand
             </Text>
           </tr>
         </thead>

--- a/modules/delegates/types/delegate.d.ts
+++ b/modules/delegates/types/delegate.d.ts
@@ -37,3 +37,8 @@ export type Delegate = {
   communication?: string;
   mkrDelegated: number;
 };
+
+export type DelegationHistory = {
+  address: string;
+  lockAmount: string;
+};

--- a/modules/delegates/types/delegate.d.ts
+++ b/modules/delegates/types/delegate.d.ts
@@ -41,4 +41,10 @@ export type Delegate = {
 export type DelegationHistory = {
   address: string;
   lockAmount: string;
+  events: DelegationHistoryEvent[];
+};
+
+export type DelegationHistoryEvent = {
+  lockAmount: string;
+  blockTimestamp: string;
 };

--- a/modules/delegates/types/delegatesAPI.d.ts
+++ b/modules/delegates/types/delegatesAPI.d.ts
@@ -15,3 +15,11 @@ export type DelegatesAPIResponse = {
     pageSize: number;
   };
 };
+
+export type MKRLockedDelegateAPIResponse = {
+  fromAddress: string;
+  lockAmount: string;
+  blockNumber: number;
+  blockTimestamp: string;
+  lockTotal: string;
+};

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -4,7 +4,7 @@ import { useBreakpointIndex } from '@theme-ui/match-media';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { Icon } from '@makerdao/dai-ui-icons';
-import { getNetwork } from 'lib/maker';
+import getMaker, { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/fetchJson';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constants';
@@ -20,15 +20,46 @@ import { AddressDetail } from 'modules/address/components/AddressDetail';
 import { DelegateDetail } from 'modules/delegates/components';
 import { HeadComponent } from 'modules/app/components/layout/Head';
 import ManageDelegation from 'modules/delegates/components/ManageDelegation';
+import { SupportedNetworks } from 'lib/constants';
+import { utils } from 'ethers';
 
 const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
   const network = getNetwork();
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
 
+  const [delegatedFrom, setDelegatedFrom] = useState(null);
+
   const { trackButtonClick } = useAnalytics(
     addressInfo.isDelegate ? ANALYTICS_PAGES.DELEGATE_DETAIL : ANALYTICS_PAGES.ADDRESS_DETAIL
   );
 
+  //Using monetsupply to test
+  useEffect(() => {
+    getMaker(network).then(maker => {
+      maker
+        .service('voteDelegate')
+        .getMkrLockedDelegate(addressInfo.address)
+        .then(data => {
+          const red = data.reduce((acc, { fromAddress, lockAmount }) => {
+            // const guy = '0xb088a3bc93f71b4de97b9de773e9647645983688';
+            const currSum = acc[fromAddress]?.lockAmount
+              ? utils.parseEther(acc[fromAddress]?.lockAmount)
+              : utils.parseEther('0');
+
+            acc[fromAddress] = { lockAmount: utils.formatEther(currSum.add(utils.parseEther(lockAmount))) };
+            return acc;
+          }, {});
+
+          //TODO do this in the reducer
+          const delegators = [];
+          for (const x in red) {
+            delegators.push({ address: x, ...red[x] });
+          }
+
+          setDelegatedFrom(delegators.sort((a, b) => (a.lockAmount > b.lockAmount ? -1 : 1)));
+        });
+    });
+  }, []);
   return (
     <PrimaryLayout shortenFooter={true} sx={{ maxWidth: [null, null, null, 'page', 'dashboard'] }}>
       <HeadComponent
@@ -61,7 +92,9 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
           )}
 
           <Box>
-            {addressInfo.delegateInfo && <DelegateDetail delegate={addressInfo.delegateInfo} />}
+            {addressInfo.delegateInfo && (
+              <DelegateDetail delegate={addressInfo.delegateInfo} delegatedFrom={delegatedFrom} />
+            )}
             {!addressInfo.delegateInfo && (
               <AddressDetail address={addressInfo.address} voteProxyInfo={addressInfo.voteProxyInfo} />
             )}

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -4,6 +4,8 @@ import { useBreakpointIndex } from '@theme-ui/match-media';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { Icon } from '@makerdao/dai-ui-icons';
+import useSWR from 'swr';
+
 import getMaker, { getNetwork } from 'lib/maker';
 import { fetchJson } from 'lib/fetchJson';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
@@ -27,39 +29,10 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
   const network = getNetwork();
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
 
-  const [delegatedFrom, setDelegatedFrom] = useState(null);
-
   const { trackButtonClick } = useAnalytics(
     addressInfo.isDelegate ? ANALYTICS_PAGES.DELEGATE_DETAIL : ANALYTICS_PAGES.ADDRESS_DETAIL
   );
 
-  //Using monetsupply to test
-  useEffect(() => {
-    getMaker(network).then(maker => {
-      maker
-        .service('voteDelegate')
-        .getMkrLockedDelegate(addressInfo.address)
-        .then(data => {
-          const red = data.reduce((acc, { fromAddress, lockAmount }) => {
-            // const guy = '0xb088a3bc93f71b4de97b9de773e9647645983688';
-            const currSum = acc[fromAddress]?.lockAmount
-              ? utils.parseEther(acc[fromAddress]?.lockAmount)
-              : utils.parseEther('0');
-
-            acc[fromAddress] = { lockAmount: utils.formatEther(currSum.add(utils.parseEther(lockAmount))) };
-            return acc;
-          }, {});
-
-          //TODO do this in the reducer
-          const delegators = [];
-          for (const x in red) {
-            delegators.push({ address: x, ...red[x] });
-          }
-
-          setDelegatedFrom(delegators.sort((a, b) => (a.lockAmount > b.lockAmount ? -1 : 1)));
-        });
-    });
-  }, []);
   return (
     <PrimaryLayout shortenFooter={true} sx={{ maxWidth: [null, null, null, 'page', 'dashboard'] }}>
       <HeadComponent
@@ -92,9 +65,7 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
           )}
 
           <Box>
-            {addressInfo.delegateInfo && (
-              <DelegateDetail delegate={addressInfo.delegateInfo} delegatedFrom={delegatedFrom} />
-            )}
+            {addressInfo.delegateInfo && <DelegateDetail delegate={addressInfo.delegateInfo} />}
             {!addressInfo.delegateInfo && (
               <AddressDetail address={addressInfo.address} voteProxyInfo={addressInfo.voteProxyInfo} />
             )}

--- a/pages/api/delegates/delegation-history/[address].ts
+++ b/pages/api/delegates/delegation-history/[address].ts
@@ -1,0 +1,17 @@
+import invariant from 'tiny-invariant';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { isSupportedNetwork } from 'lib/maker/index';
+import { DEFAULT_NETWORK } from 'lib/constants';
+import withApiHandler from 'lib/api/withApiHandler';
+import { fetchDelegationHistory } from 'modules/delegates/api/fetchDelegationHistory';
+
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  const network = (req.query.network as string) || DEFAULT_NETWORK;
+  const address = req.query.address as string;
+  invariant(isSupportedNetwork(network), `unsupported network ${network}`);
+
+  const data = await fetchDelegationHistory(address, network);
+  res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
+  res.status(200).json(data);
+});


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/625/add-list-of-delegators-to-delegate-profile-page

### What does this PR do?
Shows a table of delegators who have delegated to a delegate.

### Steps for testing:
1. go to a delegate page and see the table
2. find a delegate with 0 MKR and don't see the table

### Screenshots (if relevant):
![Screen Shot 2021-11-30 at 6 16 34 PM](https://user-images.githubusercontent.com/13105602/144154905-5082dd5a-bfb7-4ef2-a23f-2235e04e8fa2.png)

### Add a GIF:
![](https://media.giphy.com/media/ZArTeTEhiQkD5uLNdJ/giphy.gif)