### PR TITLE
Add video modal home

### DIFF
--- a/modules/app/components/VideoModal.tsx
+++ b/modules/app/components/VideoModal.tsx
@@ -27,7 +27,7 @@ const VideoModal = ({
       >
         <Box sx={{ height: ['180px', '445px'] }}>
           <iframe
-            src="https://player.vimeo.com/video/649207489?h=f49086d1ab&color=68FEE3"
+            src="https://player.vimeo.com/video/649207489?h=f49086d1ab&color=68FEE3&autoplay=1"
             width="620"
             height="360"
             sx={{

--- a/modules/app/components/VideoModal.tsx
+++ b/modules/app/components/VideoModal.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Box } from 'theme-ui';
+import { DialogOverlay, DialogContent } from '@reach/dialog';
+import { useBreakpointIndex } from '@theme-ui/match-media';
+import { fadeIn, slideUp } from 'lib/keyframes';
+
+const VideoModal = ({
+  embedId,
+  isOpen,
+  onDismiss
+}: {
+  embedId?: string;
+  isOpen: boolean;
+  onDismiss: () => void;
+}): React.ReactElement => {
+  const bpi = useBreakpointIndex();
+
+  return (
+    <DialogOverlay isOpen={isOpen} onDismiss={onDismiss}>
+      <DialogContent
+        aria-label="Video"
+        sx={
+          bpi === 0
+            ? { p: 0, variant: 'dialog.mobile', animation: `${slideUp} 350ms ease` }
+            : { p: 0, variant: 'dialog.desktop', animation: `${fadeIn} 350ms ease` }
+        }
+      >
+        <Box sx={{ height: ['180px', '445px'] }}>
+          <iframe
+            src="https://player.vimeo.com/video/649207489?h=f49086d1ab&color=68FEE3"
+            width="620"
+            height="360"
+            sx={{
+              width: '100%',
+              height: '100%'
+            }}
+            frameBorder="0"
+            allow="autoplay; fullscreen; picture-in-picture"
+            allowFullScreen
+          />
+          {/* <iframe 
+          width="600" 
+          height="400" 
+          sx={{
+            width: '100%',
+            height: '100%'
+          }}
+          src={`https://www.youtube-nocookie.com/embed/${embedId}?controls=0`} 
+          title="YouTube video player" 
+          frameborder="0" 
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+          allowfullscreen /> */}
+        </Box>
+      </DialogContent>
+    </DialogOverlay>
+  );
+};
+
+export default VideoModal;

--- a/modules/app/components/layout/Head.tsx
+++ b/modules/app/components/layout/Head.tsx
@@ -40,7 +40,7 @@ export function HeadComponent({
         httpEquiv="Content-Security-Policy"
         content={
           "default-src 'none';" +
-          'frame-src https://connect.trezor.io;' +
+          'frame-src https://connect.trezor.io https://www.youtube-nocookie.com https://player.vimeo.com;' +
           "font-src 'self';" +
           "connect-src 'self' https: wss:;" +
           "style-src 'self' 'unsafe-inline';" +

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useEffect, useState } from 'react';
 import { GetStaticProps } from 'next';
-import { Heading, Container, Grid, Text, Flex, useColorMode } from 'theme-ui';
+import { Heading, Container, Grid, Text, Flex, useColorMode, Box, Button } from 'theme-ui';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { Global } from '@emotion/core';
@@ -26,6 +26,7 @@ import { BlogPost } from 'modules/blog/types/blogPost';
 import { getPolls } from 'modules/polling/api/fetchPolls';
 import { getExecutiveProposals } from 'modules/executive/api/fetchExecutives';
 import PollOverviewCard from 'modules/polling/components/PollOverviewCard';
+import VideoModal from 'modules/app/components/VideoModal';
 
 type Props = {
   proposals: CMSProposal[];
@@ -37,6 +38,7 @@ const LandingPage = ({ proposals, polls, blogPosts }: Props) => {
   const [mode] = useColorMode();
   const recentPolls = useMemo(() => polls.slice(0, 4), [polls]);
   const activePolls = useMemo(() => polls.filter(poll => isActivePoll(poll)), [polls]);
+  const [videoOpen, setVideoOpen] = useState(false);
 
   const [backgroundImage, setBackroundImage] = useState('url(/assets/heroVisual.svg');
 
@@ -62,6 +64,7 @@ const LandingPage = ({ proposals, polls, blogPosts }: Props) => {
           backgroundRepeat: 'no-repeat'
         }}
       />
+      <VideoModal isOpen={videoOpen} onDismiss={() => setVideoOpen(false)} />
       <PrimaryLayout sx={{ maxWidth: 'page' }}>
         {/* <Flex sx={{ justifyContent: 'center' }}>
           <Badge
@@ -139,6 +142,15 @@ const LandingPage = ({ proposals, polls, blogPosts }: Props) => {
                     <PollingIndicator polls={polls} sx={{ mb: [2, 0] }} />
                     <ExecutiveIndicator proposals={proposals} sx={{ mt: [2, 0] }} />
                   </Flex>
+                  <Box>
+                    <Button
+                      variant="outline"
+                      sx={{ borderRadius: 'round' }}
+                      onClick={() => setVideoOpen(true)}
+                    >
+                      How to vote
+                    </Button>
+                  </Box>
                 </Stack>
               </Container>
             </Stack>


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/847/add-how-to-vote-button-with-vimeo-embed-to-homepage

### What does this PR do?

adds a video on how to vote on the home page 

### Steps for testing:
Go to the home page, click on "how to vote" see video poping



### Screenshots (if relevant):

![image](https://user-images.githubusercontent.com/1152768/144441229-e03fdf71-12e7-461e-9dff-74d930e91a91.png)

