### PR TITLE
account for multiple txs on same day

### DIFF
--- a/lib/datetime.ts
+++ b/lib/datetime.ts
@@ -1,4 +1,4 @@
-import { formatDistance } from 'date-fns';
+import { formatDistance, format as formatDate } from 'date-fns';
 import { format, utcToZonedTime } from 'date-fns-tz';
 
 export const formatDateWithTime = (dateString: Date | undefined | number | string): string => {
@@ -35,3 +35,19 @@ export const formatTimeAgo = (dateString: Date | undefined | number | string): s
     return '--';
   }
 };
+
+export const isoDateConversion = isoDate => {
+  if (isoDate) {
+    const d = isoDate.split(/[-T:]/);
+    return new Date(d[0], d[1] - 1, d[2], d[3], d[4]);
+  } else {
+    return isoDate;
+  }
+};
+
+export const formatIsoDateConversion = date =>
+  parseInt(
+    formatDate(new Date(isoDateConversion(date)), 'D', {
+      useAdditionalDayOfYearTokens: true
+    })
+  );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,7 @@ import { cloneElement } from 'react';
 import { jsx } from 'theme-ui';
 import { css, ThemeUIStyleObject } from '@theme-ui/css';
 import BigNumber from 'bignumber.js';
+import { format } from 'date-fns';
 import { CurrencyObject } from 'modules/app/types/currency';
 import { SpellStateDiff } from 'modules/app/types/spellStateDiff';
 import { SupportedNetworks, ETHERSCAN_PREFIXES } from './constants';
@@ -176,3 +177,19 @@ export const sortBytesArray = _array =>
 
 export const formatRound = (num, decimals = 2) =>
   isNaN(num) ? '----' : round(num, decimals).toLocaleString({}, { minimumFractionDigits: decimals });
+
+export const isoDateConversion = isoDate => {
+  if (isoDate) {
+    const d = isoDate.split(/[-T:]/);
+    return new Date(d[0], d[1] - 1, d[2], d[3], d[4]);
+  } else {
+    return isoDate;
+  }
+};
+
+export const formatIsoDateConversion = date =>
+  parseInt(
+    format(new Date(isoDateConversion(date)), 'D', {
+      useAdditionalDayOfYearTokens: true
+    })
+  );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,7 +5,6 @@ import { cloneElement } from 'react';
 import { jsx } from 'theme-ui';
 import { css, ThemeUIStyleObject } from '@theme-ui/css';
 import BigNumber from 'bignumber.js';
-import { format } from 'date-fns';
 import { CurrencyObject } from 'modules/app/types/currency';
 import { SpellStateDiff } from 'modules/app/types/spellStateDiff';
 import { SupportedNetworks, ETHERSCAN_PREFIXES } from './constants';
@@ -177,19 +176,3 @@ export const sortBytesArray = _array =>
 
 export const formatRound = (num, decimals = 2) =>
   isNaN(num) ? '----' : round(num, decimals).toLocaleString({}, { minimumFractionDigits: decimals });
-
-export const isoDateConversion = isoDate => {
-  if (isoDate) {
-    const d = isoDate.split(/[-T:]/);
-    return new Date(d[0], d[1] - 1, d[2], d[3], d[4]);
-  } else {
-    return isoDate;
-  }
-};
-
-export const formatIsoDateConversion = date =>
-  parseInt(
-    format(new Date(isoDateConversion(date)), 'D', {
-      useAdditionalDayOfYearTokens: true
-    })
-  );

--- a/modules/delegates/api/fetchMKRWeightHistory.ts
+++ b/modules/delegates/api/fetchMKRWeightHistory.ts
@@ -1,4 +1,5 @@
 import { SupportedNetworks } from 'lib/constants';
+import { formatIsoDateConversion } from 'lib/utils';
 import { MKRWeightTimeRanges } from '../delegates.constants';
 import { MKRWeightHisory } from '../types/mkrWeight';
 import getMaker from 'lib/maker';
@@ -19,11 +20,7 @@ export async function fetchDelegatesMKRWeightHistory(
 
   // We need to fill all the data for the interval
   // If we get last month, we need to add all the missing days
-  const start = parseInt(
-    format(new Date(addressData[0].blockTimestamp), 'D', {
-      useAdditionalDayOfYearTokens: true
-    })
-  );
+  const start = formatIsoDateConversion(addressData[0].blockTimestamp);
 
   const end = parseInt(
     format(new Date(), 'D', {
@@ -35,11 +32,7 @@ export async function fetchDelegatesMKRWeightHistory(
 
   for (let i = start; i <= end; i++) {
     const existingItem = addressData.filter(item => {
-      const day = parseInt(
-        format(new Date(item.blockTimestamp), 'D', {
-          useAdditionalDayOfYearTokens: true
-        })
-      );
+      const day = formatIsoDateConversion(item.blockTimestamp);
       if (day === i) {
         return item;
       }

--- a/modules/delegates/api/fetchMKRWeightHistory.ts
+++ b/modules/delegates/api/fetchMKRWeightHistory.ts
@@ -34,7 +34,7 @@ export async function fetchDelegatesMKRWeightHistory(
   const output: MKRWeightHisory[] = [];
 
   for (let i = start; i <= end; i++) {
-    const existingItem = addressData.find(item => {
+    const existingItem = addressData.filter(item => {
       const day = parseInt(
         format(new Date(item.blockTimestamp), 'D', {
           useAdditionalDayOfYearTokens: true
@@ -44,12 +44,15 @@ export async function fetchDelegatesMKRWeightHistory(
         return item;
       }
     });
-    if (existingItem) {
+
+    if (existingItem && existingItem.length > 0) {
+      // If we have multiple items for the same day, use the final one because the lockTotal will be accurate.
+      const mostRecent = existingItem[existingItem.length - 1];
       output.push({
-        date: parse(i.toString(), 'D', new Date(existingItem.blockTimestamp), {
+        date: parse(i.toString(), 'D', new Date(mostRecent.blockTimestamp), {
           useAdditionalDayOfYearTokens: true
         }),
-        MKR: new BigNumber(existingItem.lockTotal).toNumber()
+        MKR: new BigNumber(mostRecent.lockTotal).toNumber()
       });
     } else {
       output.push({

--- a/modules/delegates/api/fetchMKRWeightHistory.ts
+++ b/modules/delegates/api/fetchMKRWeightHistory.ts
@@ -1,5 +1,5 @@
 import { SupportedNetworks } from 'lib/constants';
-import { formatIsoDateConversion } from 'lib/utils';
+import { formatIsoDateConversion } from 'lib/datetime';
 import { MKRWeightTimeRanges } from '../delegates.constants';
 import { MKRWeightHisory } from '../types/mkrWeight';
 import getMaker from 'lib/maker';

--- a/modules/delegates/components/DelegateMKRChart.tsx
+++ b/modules/delegates/components/DelegateMKRChart.tsx
@@ -20,6 +20,7 @@ import { fetchJson } from 'lib/fetchJson';
 import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { format } from 'date-fns';
+import { isoDateConversion } from 'lib/utils';
 
 export function DelegateMKRChart({ delegate }: { delegate: Delegate }): React.ReactElement {
   const { theme } = useThemeUI();
@@ -87,7 +88,7 @@ export function DelegateMKRChart({ delegate }: { delegate: Delegate }): React.Re
       // Sometimes the tickItem is "auto", ignore this case
       return 'auto';
     }
-    return format(new Date(tickItem), dateFormat);
+    return format(new Date(isoDateConversion(tickItem)), dateFormat);
   };
 
   return (

--- a/modules/delegates/components/DelegateMKRChart.tsx
+++ b/modules/delegates/components/DelegateMKRChart.tsx
@@ -20,7 +20,7 @@ import { fetchJson } from 'lib/fetchJson';
 import useSWR from 'swr';
 import { getNetwork } from 'lib/maker';
 import { format } from 'date-fns';
-import { isoDateConversion } from 'lib/utils';
+import { isoDateConversion } from 'lib/datetime';
 
 export function DelegateMKRChart({ delegate }: { delegate: Delegate }): React.ReactElement {
   const { theme } = useThemeUI();


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/876/mkr-delegate-weight-chart-dates-on-chart-don-t-always-line-up-with-dates-on-the-delegation-history-table

### What does this PR do?
Handle situation where there are multiple transactions in a single day, selecting the most recent one which will have the correct lockTotal.

### Steps for testing:
Open the metrics tab and compare the delegation history table with the MKR weight chart and verify that the dates on the chart and the table line up.

### Screenshots (if relevant):
**Before:**
![2021-12-07_083559](https://user-images.githubusercontent.com/13105602/145449214-3e66e947-ba85-48be-8fbc-590faa0c16c5.png)

**After:**
![Screen Shot 2021-12-09 at 10 47 57 AM](https://user-images.githubusercontent.com/13105602/145449065-4d15746e-cdd5-4a0c-9a7e-9a8080d210e1.png)
