### PR TITLE
Feature/sc 803/show current poll vote option on mobile

### DIFF
--- a/modules/polling/components/ChoiceSummary.tsx
+++ b/modules/polling/components/ChoiceSummary.tsx
@@ -8,7 +8,6 @@ import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constant
 const ChoiceSummary = ({ choice, poll, edit, voteIsPending, ...props }): React.ReactElement => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING_REVIEW);
 
-  const voteBoxStyle = props.showHeader ? {} : { width: '100%', justifyContent: 'center', mt: 3 };
   const isSingleSelect = typeof choice === 'number';
   return (
     <Box {...props}>
@@ -35,8 +34,7 @@ const ChoiceSummary = ({ choice, poll, edit, voteIsPending, ...props }): React.R
         sx={{
           display: voteIsPending ? 'none' : 'inline-flex',
           flexDirection: 'row',
-          alignItems: 'center',
-          ...voteBoxStyle
+          alignItems: 'center'
         }}
       >
         <Icon name="edit" size={3} mr={1} />

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -44,7 +44,8 @@ export default function PollOverviewCard({
   const account = useAccountsStore(state => state.currentAccount);
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
   const canVote = !!account && isActivePoll(poll);
-  const showQuickVote = canVote && bpi > 0 && showVoting;
+  const showQuickVote = canVote && showVoting;
+
   const ballot = useBallotStore(state => state.ballot);
   const onBallot = !isNil(ballot[poll.pollId]?.option);
 
@@ -58,7 +59,9 @@ export default function PollOverviewCard({
             {bpi === 0 && (
               <Box sx={{ justifyContent: 'space-between', flexDirection: 'row', flexWrap: 'nowrap' }}>
                 <CountdownTimer endText="Poll ended" endDate={poll.endDate} />
-                <VotingStatus poll={poll} />
+                <Box sx={{ mt: 1 }}>
+                  <VotingStatus poll={poll} />
+                </Box>
               </Box>
             )}
             <Box sx={{ cursor: 'pointer' }}>
@@ -103,7 +106,7 @@ export default function PollOverviewCard({
               </Box>
             )}
           </Stack>
-          {showQuickVote && (
+          {showQuickVote && bpi > 0 && (
             <Box sx={{ ml: 2, minWidth: '265px' }}>
               <QuickVote
                 poll={poll}
@@ -121,7 +124,7 @@ export default function PollOverviewCard({
             sx={{
               alignItems: 'center',
               justifyContent: 'space-between',
-              flexDirection: ['column-reverse', 'row']
+              flexDirection: ['column', 'row']
             }}
           >
             <Flex
@@ -129,43 +132,9 @@ export default function PollOverviewCard({
                 alignItems: 'center',
                 justifyContent: 'flex-start',
                 width: bpi > 0 ? 'auto' : '100%',
-                p: bpi > 0 ? 0 : 2
+                mt: 3
               }}
             >
-              {canVote &&
-                showVoting &&
-                bpi === 0 &&
-                (onBallot ? (
-                  <Button
-                    variant="outline"
-                    mr={2}
-                    onClick={() => {
-                      trackButtonClick('showHistoricalPolls');
-                      startMobileVoting && startMobileVoting();
-                    }}
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      flexWrap: 'nowrap',
-                      alignItems: 'center'
-                    }}
-                  >
-                    <Icon name="edit" size={3} mr={2} />
-                    Edit Choices
-                  </Button>
-                ) : (
-                  <Button
-                    variant="primary"
-                    mr={2}
-                    px={4}
-                    onClick={() => {
-                      trackButtonClick('startMobileVoting');
-                      startMobileVoting && startMobileVoting();
-                    }}
-                  >
-                    Vote
-                  </Button>
-                ))}
               <Link
                 key={poll.slug}
                 href={{ pathname: '/polling/[poll-hash]', query: { network } }}
@@ -188,10 +157,18 @@ export default function PollOverviewCard({
               </Link>
             </Flex>
 
+            {showQuickVote && bpi === 0 && (
+              <Box sx={{ mt: 3, width: '100%' }}>
+                <QuickVote poll={poll} showHeader={false} account={account} showStatus={!reviewPage} />
+              </Box>
+            )}
+
             {poll.voteType === POLL_VOTE_TYPE.PLURALITY_VOTE && (
               <Box sx={{ width: bpi > 0 ? '265px' : '100%', p: bpi > 0 ? 0 : 2 }}>
                 {tally && tally.totalMkrParticipation > 0 && (
-                  <PollVotePluralityResultsCompact tally={tally} showTitles={false} />
+                  <Box sx={{ mt: 3 }}>
+                    <PollVotePluralityResultsCompact tally={tally} showTitles={false} />
+                  </Box>
                 )}
                 {!tally && <SkeletonThemed width={'265px'} height={'30px'} />}
               </Box>

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -1,7 +1,5 @@
 import Link from 'next/link';
 import { Text, Flex, Box, Button, Link as InternalLink, ThemeUIStyleObject, Divider } from 'theme-ui';
-import { Icon } from '@makerdao/dai-ui-icons';
-import isNil from 'lodash/isNil';
 
 import { isActivePoll } from 'modules/polling/helpers/utils';
 import { getNetwork } from 'lib/maker';
@@ -11,10 +9,7 @@ import VotingStatus from './PollVotingStatus';
 import { Poll } from 'modules/polling/types';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import useAccountsStore from 'modules/app/stores/accounts';
-import useBallotStore from 'modules/polling/stores/ballotStore';
 import QuickVote from './QuickVote';
-import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
-import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constants';
 import { PollCategoryTag } from './PollCategoryTag';
 import { PollVotePluralityResultsCompact } from './PollVotePluralityResultsCompact';
 import { POLL_VOTE_TYPE } from '../polling.constants';
@@ -26,28 +21,16 @@ import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 
 type Props = {
   poll: Poll;
-  startMobileVoting?: () => void;
   reviewPage: boolean;
   sx?: ThemeUIStyleObject;
   showVoting?: boolean;
 };
-export default function PollOverviewCard({
-  poll,
-  startMobileVoting,
-  reviewPage,
-  showVoting,
-  ...props
-}: Props): JSX.Element {
-  const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING);
-
+export default function PollOverviewCard({ poll, reviewPage, showVoting, ...props }: Props): JSX.Element {
   const network = getNetwork();
   const account = useAccountsStore(state => state.currentAccount);
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
   const canVote = !!account && isActivePoll(poll);
   const showQuickVote = canVote && showVoting;
-
-  const ballot = useBallotStore(state => state.ballot);
-  const onBallot = !isNil(ballot[poll.pollId]?.option);
 
   const { tally } = usePollTally(poll.pollId);
 

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -59,9 +59,6 @@ export default function PollOverviewCard({
             {bpi === 0 && (
               <Box sx={{ justifyContent: 'space-between', flexDirection: 'row', flexWrap: 'nowrap' }}>
                 <CountdownTimer endText="Poll ended" endDate={poll.endDate} />
-                <Box sx={{ mt: 1 }}>
-                  <VotingStatus poll={poll} />
-                </Box>
               </Box>
             )}
             <Box sx={{ cursor: 'pointer' }}>
@@ -159,6 +156,7 @@ export default function PollOverviewCard({
 
             {showQuickVote && bpi === 0 && (
               <Box sx={{ mt: 3, width: '100%' }}>
+                <VotingStatus poll={poll} />
                 <QuickVote poll={poll} showHeader={false} account={account} showStatus={!reviewPage} />
               </Box>
             )}

--- a/modules/polling/components/RankedChoiceSelect.tsx
+++ b/modules/polling/components/RankedChoiceSelect.tsx
@@ -50,7 +50,7 @@ export default function RankedChoiceSelect({
     <Box {...props}>
       <Stack gap={2}>
         {Array.from({ length: numConfirmed }).map((_, index) => (
-          <Flex sx={{ backgroundColor: 'background', py: 2, px: 3 }} key={index}>
+          <Flex sx={{ backgroundColor: 'background', p: 2 }} key={index}>
             <Flex sx={{ flexDirection: 'column' }}>
               <Text sx={{ variant: 'text.caps', fontSize: 1 }}>{getNumberWithOrdinal(index + 1)} choice</Text>
               <Text>{poll.options[choice[index]]}</Text>
@@ -85,7 +85,7 @@ export default function RankedChoiceSelect({
             }}
           >
             <ListboxButton
-              sx={{ variant: 'listboxes.default.button', fontWeight: 400, py: [3, 2] }}
+              sx={{ variant: 'listboxes.default.button', fontWeight: 400, py: 2 }}
               arrow={<Icon name="chevron_down" size={2} />}
             />
             <ListboxPopover sx={{ variant: 'listboxes.default.popover' }}>

--- a/modules/polling/components/SingleSelect.tsx
+++ b/modules/polling/components/SingleSelect.tsx
@@ -15,7 +15,7 @@ export default function SingleSelect({ poll, choice, setChoice, ...props }: Prop
       {...props}
     >
       <ListboxButton
-        sx={{ variant: 'listboxes.default.button', fontWeight: 400, py: [0, 2] }}
+        sx={{ variant: 'listboxes.default.button', fontWeight: 400 }}
         arrow={<Icon name="chevron_down" size={2} />}
       />
       <ListboxPopover sx={{ variant: 'listboxes.default.popover' }}>

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -184,7 +184,7 @@ const PollingOverview = ({ polls, categories }: Props) => {
                   <Stack>
                     {sortedEndDatesActive.map(date => (
                       <div key={date}>
-                        <Text variant="caps" color="textSecondary" mb={2}>
+                        <Text as="p" variant="caps" color="textSecondary" mb={2}>
                           {groupedActivePolls[date].length} Poll
                           {groupedActivePolls[date].length === 1 ? '' : 's'} - Ending{' '}
                           {formatDateWithTime(date)}

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -26,7 +26,6 @@ import SystemStatsSidebar from 'modules/app/components/SystemStatsSidebar';
 import useBallotStore from 'modules/polling/stores/ballotStore';
 import useAccountsStore from 'modules/app/stores/accounts';
 import useUiFiltersStore from 'modules/app/stores/uiFilters';
-import MobileVoteSheet from 'modules/polling/components/MobileVoteSheet';
 import BallotStatus from 'modules/polling/components/BallotStatus';
 import PageLoadingPlaceholder from 'modules/app/components/PageLoadingPlaceholder';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
@@ -69,7 +68,6 @@ const PollingOverview = ({ polls, categories }: Props) => {
 
   const [numHistoricalGroupingsLoaded, setNumHistoricalGroupingsLoaded] = useState(3);
   const ballot = useBallotStore(state => state.ballot);
-  const ballotLength = Object.keys(ballot).length;
   const network = getNetwork();
   const loader = useRef<HTMLDivElement>(null);
   const bpi = useBreakpointIndex();
@@ -136,8 +134,6 @@ const PollingOverview = ({ polls, categories }: Props) => {
     mutateAllUserVotes();
   }, [addressToCheck]);
 
-  const [mobileVotingPoll, setMobileVotingPoll] = useState<Poll | null>();
-
   return (
     <PrimaryLayout shortenFooter={true} sx={{ maxWidth: [null, null, null, 'page', 'dashboard'] }}>
       <HeadComponent
@@ -145,15 +141,6 @@ const PollingOverview = ({ polls, categories }: Props) => {
         description={`Lastest poll: ${polls[0].title}. Active Polls: ${activePolls.length}. Total Polls: ${polls.length}. .`}
       />
 
-      {mobileVotingPoll && (
-        <MobileVoteSheet
-          account={account}
-          ballotCount={ballotLength}
-          poll={mobileVotingPoll}
-          setPoll={setMobileVotingPoll}
-          close={() => setMobileVotingPoll(null)}
-        />
-      )}
       <Stack gap={3}>
         {bpi <= 1 && account && <BallotStatus />}
         <Flex sx={{ alignItems: 'center', flexDirection: ['column', 'row'] }}>
@@ -195,7 +182,6 @@ const PollingOverview = ({ polls, categories }: Props) => {
                               key={poll.multiHash}
                               poll={poll}
                               showVoting={true}
-                              startMobileVoting={() => setMobileVotingPoll(poll)}
                               reviewPage={false}
                             />
                           ))}

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { Heading, Box, Button, Flex } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 import ErrorPage from 'next/error';
-import invariant from 'tiny-invariant';
 import shallow from 'zustand/shallow';
 
 import { useBreakpointIndex } from '@theme-ui/match-media';
@@ -19,7 +18,6 @@ import { Poll } from 'modules/polling/types';
 import ReviewBox from 'modules/polling/components/review/ReviewBox';
 import useBallotStore from 'modules/polling/stores/ballotStore';
 import useAccountsStore from 'modules/app/stores/accounts';
-import MobileVoteSheet from 'modules/polling/components/MobileVoteSheet';
 import PageLoadingPlaceholder from 'modules/app/components/PageLoadingPlaceholder';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
 import { ANALYTICS_PAGES } from 'modules/app/client/analytics/analytics.constants';
@@ -37,7 +35,6 @@ const PollingReview = ({ polls }: { polls: Poll[] }) => {
   const account = useAccountsStore(state => state.currentAccount);
   const ballotLength = Object.keys(ballot).length;
   const activePolls = polls.filter(poll => isActivePoll(poll));
-  const [mobileVotingPoll, setMobileVotingPoll] = useState<Poll | null>(null);
 
   const SubmitButton = props => (
     <Flex sx={{ flexDirection: 'column', width: '100%' }} {...props}>
@@ -59,14 +56,6 @@ const PollingReview = ({ polls }: { polls: Poll[] }) => {
 
   return (
     <PrimaryLayout shortenFooter={true} sx={{ maxWidth: 'dashboard' }}>
-      {mobileVotingPoll && (
-        <MobileVoteSheet
-          account={account}
-          editingOnly
-          poll={mobileVotingPoll}
-          close={() => setMobileVotingPoll(null)}
-        />
-      )}
       <Stack gap={3}>
         <Heading mb={3} as="h4">
           {bpi <= 2 ? 'Review & Submit Ballot' : 'Review Your Ballot'}
@@ -96,7 +85,6 @@ const PollingReview = ({ polls }: { polls: Poll[] }) => {
                         poll={poll}
                         reviewPage={true}
                         showVoting={true}
-                        startMobileVoting={() => setMobileVotingPoll(poll)}
                         sx={cardStyles(index, ballotLength)}
                       />
                     );
@@ -168,7 +156,7 @@ export default function PollingReviewPage({ polls: prefetchedPolls }: { polls: P
   return <PollingReview polls={isDefaultNetwork() ? prefetchedPolls : (_polls as Poll[])} />;
 }
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getStaticProps: GetStaticProps = async () => {
   // fetch polls at build-time if on the default network
   const pollsData = await getPolls();
 


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/803/show-current-poll-vote-option-on-mobile

### What does this PR do?
Updates the mobile voting experience to match desktop

### Steps for testing:
1. On mobile sized screen, go to `polling` page
2. Connect wallet
3. Attempt to vote

### Screenshots (if relevant):
<img width="365" alt="Screen Shot 2021-12-09 at 11 29 46 AM" src="https://user-images.githubusercontent.com/5225766/145384987-40568cdb-d855-47b0-b46a-acebe3323ca9.png">

### Add a GIF:
![](https://media.giphy.com/media/pGS8eskcHEuyqxRRcZ/giphy.gif)