### PR TITLE
Remove round corners on video modal

### DIFF
--- a/modules/app/components/VideoModal.tsx
+++ b/modules/app/components/VideoModal.tsx
@@ -21,8 +21,20 @@ const VideoModal = ({
         aria-label="Video"
         sx={
           bpi === 0
-            ? { p: 0, variant: 'dialog.mobile', animation: `${slideUp} 350ms ease` }
-            : { p: 0, variant: 'dialog.desktop', animation: `${fadeIn} 350ms ease` }
+            ? {
+                variant: 'dialog.mobile',
+                animation: `${slideUp} 350ms ease`,
+                borderRadius: 0,
+                p: 0,
+                background: 'black'
+              }
+            : {
+                variant: 'dialog.desktop',
+                animation: `${fadeIn} 350ms ease`,
+                borderRadius: 0,
+                p: 0,
+                background: 'black'
+              }
         }
       >
         <Box sx={{ height: ['180px', '445px'] }}>
@@ -38,18 +50,6 @@ const VideoModal = ({
             allow="autoplay; fullscreen; picture-in-picture"
             allowFullScreen
           />
-          {/* <iframe 
-          width="600" 
-          height="400" 
-          sx={{
-            width: '100%',
-            height: '100%'
-          }}
-          src={`https://www.youtube-nocookie.com/embed/${embedId}?controls=0`} 
-          title="YouTube video player" 
-          frameborder="0" 
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-          allowfullscreen /> */}
         </Box>
       </DialogContent>
     </DialogOverlay>


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/878/disable-round-bottom-corners-for-how-to-vote-video-overlay

### What does this PR do?
Fixes border radius on how to vote video modal

### Steps for testing:
1. Open the "how to vote" modal
2. See updates ✨ 

### Screenshots (if relevant):
<img width="898" alt="Screen Shot 2021-12-09 at 12 05 48 PM" src="https://user-images.githubusercontent.com/5225766/145385233-e1e0e568-d509-46dc-bd43-d047d6e55982.png">

### Add a GIF:
![](https://media.giphy.com/media/DEPHUnn7IAcEVdkcad/giphy.gif)
