### PR TITLE
show active delegators count in delegate detail page

### DIFF
--- a/modules/delegates/api/fetchDelegationHistory.ts
+++ b/modules/delegates/api/fetchDelegationHistory.ts
@@ -1,6 +1,7 @@
 import { utils } from 'ethers';
 import { SupportedNetworks } from 'lib/constants';
-import { DelegationHistory, MKRLockedDelegateAPIResponse } from '../types';
+import { DelegationHistory } from '../types/delegate';
+import { MKRLockedDelegateAPIResponse } from '../types/delegatesAPI';
 import getMaker from 'lib/maker';
 
 export async function fetchDelegationHistory(

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -22,7 +22,7 @@ import { AddressAPIStats } from 'modules/address/types/addressApiResponse';
 import LastVoted from 'modules/polling/components/LastVoted';
 import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 import DelegatedByAddress from 'modules/delegates/components/DelegatedByAddress';
-import { DelegationHistory } from 'modules/delegates/types';
+import { DelegationHistory } from 'modules/delegates/types/delegate';
 
 type PropTypes = {
   delegate: Delegate;
@@ -47,6 +47,9 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
     }
   );
   const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
+
+  const activeDelegators = delegators?.filter(({ lockAmount }) => parseInt(lockAmount) > 0);
+  const delegatorCount = activeDelegators?.length || 0;
 
   const tabTitles = [
     delegate.status === DelegateStatusEnum.recognized ? 'Delegate Credentials' : null,
@@ -120,7 +123,7 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
           </Flex>
         </Flex>
         <Box sx={{ mt: [2], display: 'flex', flexDirection: 'column' }}>
-          <DelegateMKRDelegatedStats delegate={delegate} />
+          <DelegateMKRDelegatedStats delegate={delegate} delegatorCount={delegatorCount} />
         </Box>
       </Box>
 

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -49,7 +49,7 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
   const { data: totalStaked } = useLockedMkr(delegate.voteDelegateAddress);
 
   const activeDelegators = delegators?.filter(({ lockAmount }) => parseInt(lockAmount) > 0);
-  const delegatorCount = activeDelegators?.length || 0;
+  const delegatorCount = delegators ? activeDelegators?.length : undefined;
 
   const tabTitles = [
     delegate.status === DelegateStatusEnum.recognized ? 'Delegate Credentials' : null,

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -10,7 +10,7 @@ export function DelegateMKRDelegatedStats({
   delegatorCount
 }: {
   delegate: Delegate;
-  delegatorCount: number;
+  delegatorCount?: number;
 }): React.ReactElement {
   const account = useAccountsStore(state => state.currentAccount);
   const address = account?.address;
@@ -32,9 +32,12 @@ export function DelegateMKRDelegatedStats({
         value={new BigNumber(delegate.mkrDelegated).toFormat(2) ?? 'Untracked'}
         label={'Total MKR Delegated'}
       />
-      <StatBox value={new BigNumber(delegatorCount).toFormat(2)} label={'Total Active Delegators'} />
       <StatBox
-        value={mkrStaked ? mkrStaked.toBigNumber().toFormat(2) : '0.00'}
+        value={typeof delegatorCount !== 'undefined' ? new BigNumber(delegatorCount).toFormat(2) : '--'}
+        label={'Total Active Delegators'}
+      />
+      <StatBox
+        value={typeof mkrStaked !== 'undefined' ? mkrStaked.toBigNumber().toFormat(2) : '0.00'}
         label={'MKR Delegated by you'}
       />
     </Flex>

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -5,10 +5,15 @@ import { Delegate } from 'modules/delegates/types';
 import { StatBox } from 'modules/app/components/StatBox';
 import useAccountsStore from 'modules/app/stores/accounts';
 
-export function DelegateMKRDelegatedStats({ delegate }: { delegate: Delegate }): React.ReactElement {
+export function DelegateMKRDelegatedStats({
+  delegate,
+  delegatorCount
+}: {
+  delegate: Delegate;
+  delegatorCount: number;
+}): React.ReactElement {
   const account = useAccountsStore(state => state.currentAccount);
   const address = account?.address;
-
   // TODO: Fetch addresses suporting through API fetching
 
   const { data: mkrStaked } = useMkrDelegated(address, delegate.voteDelegateAddress);
@@ -27,8 +32,7 @@ export function DelegateMKRDelegatedStats({ delegate }: { delegate: Delegate }):
         value={new BigNumber(delegate.mkrDelegated).toFormat(2) ?? 'Untracked'}
         label={'Total MKR Delegated'}
       />
-      {/* TODO add once we have data */}
-      {/* <StatBox value={'TBD'} label={'Delegators (wallets)'} />*/}
+      <StatBox value={new BigNumber(delegatorCount).toFormat(2)} label={'Total Active Delegators'} />
       <StatBox
         value={mkrStaked ? mkrStaked.toBigNumber().toFormat(2) : '0.00'}
         label={'MKR Delegated by you'}

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -33,7 +33,7 @@ export function DelegateMKRDelegatedStats({
         label={'Total MKR Delegated'}
       />
       <StatBox
-        value={typeof delegatorCount !== 'undefined' ? new BigNumber(delegatorCount).toFormat(2) : '--'}
+        value={typeof delegatorCount !== 'undefined' ? new BigNumber(delegatorCount).toFormat(0) : '--'}
         label={'Total Active Delegators'}
       />
       <StatBox


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/913/add-of-delegating-addresses-to-delegate-detail-page

### What does this PR do?
add total active delegators to delegate detail page status bar

### Screenshots (if relevant):

![Screen Shot 2021-12-14 at 5 47 07 PM](https://user-images.githubusercontent.com/13105602/146102423-54cfb0a6-3398-4800-b6e2-7c4f16c43956.png)

### Add a GIF:
![](https://media.giphy.com/media/3tEFVAbfzzcwo/giphy-downsized.gif)
