### PR TITLE
Comments link

### DIFF
--- a/modules/app/components/Tabs.tsx
+++ b/modules/app/components/Tabs.tsx
@@ -15,14 +15,14 @@ type Props = {
 
 const TabbedLayout = ({
   tabTitles,
-  tabRoutes,
+  tabRoutes = [],
   tabPanels,
   tabListStyles = {},
   hashRoute = true,
   banner
 }: Props): JSX.Element => {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
-  if (!tabRoutes) tabRoutes = tabTitles;
+  if (tabRoutes.length === 0) tabRoutes = tabTitles;
   const activeTab = tabRoutes[activeTabIndex];
 
   useEffect(() => {

--- a/modules/app/components/Tabs.tsx
+++ b/modules/app/components/Tabs.tsx
@@ -6,6 +6,7 @@ import { slugify } from 'lib/utils';
 
 type Props = {
   tabTitles: string[];
+  tabRoutes?: string[];
   tabPanels: React.ReactNode[];
   tabListStyles?: ThemeUIStyleObject;
   hashRoute?: boolean;
@@ -14,18 +15,20 @@ type Props = {
 
 const TabbedLayout = ({
   tabTitles,
+  tabRoutes,
   tabPanels,
   tabListStyles = {},
   hashRoute = true,
   banner
 }: Props): JSX.Element => {
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
-  const activeTab = tabTitles[activeTabIndex];
+  if (!tabRoutes) tabRoutes = tabTitles;
+  const activeTab = tabRoutes[activeTabIndex];
 
   useEffect(() => {
     const [, hash] = location.href.split('#');
     if (hashRoute && hash) {
-      tabTitles.forEach((title, i) => {
+      tabRoutes.forEach((title, i) => {
         if (slugify(title) === hash) setActiveTabIndex(i);
       });
     }
@@ -45,14 +48,14 @@ const TabbedLayout = ({
     >
       <Tabs index={activeTabIndex} onChange={index => setActiveTabIndex(index)}>
         <TabList sx={{ display: ['flex', 'block'], bg: 'inherit', ...tabListStyles }}>
-          {tabTitles.map((tabTitle, index) => (
+          {tabRoutes.map((tabRoute, index) => (
             <Tab
-              key={tabTitle}
+              key={tabRoute}
               sx={{
-                ...getTabStyles({ isActive: activeTab === tabTitle, isFirst: index === 0 })
+                ...getTabStyles({ isActive: activeTab === tabRoute, isFirst: index === 0 })
               }}
             >
-              {tabTitle}
+              {tabTitles[index]}
             </Tab>
           ))}
         </TabList>

--- a/modules/comments/components/CommentItem.tsx
+++ b/modules/comments/components/CommentItem.tsx
@@ -85,7 +85,7 @@ export default function CommentItem({
           <Text as="p" variant="caps" color="textMuted" sx={{ lineHeight: '22px' }}>
             {formatDateWithTime(comment.comment.date)}
           </Text>
-          <Text variant="smallCaps" sx={{ maxWidth: ['100%', '40%'] }}>
+          <Text variant="smallCaps">
             {votedOption
               ? votedOption
               : `Voted with ${new BigNumber(comment.comment.voterWeight).toFixed(2)} MKR`}

--- a/modules/comments/components/CommentItem.tsx
+++ b/modules/comments/components/CommentItem.tsx
@@ -85,7 +85,7 @@ export default function CommentItem({
           <Text as="p" variant="caps" color="textMuted" sx={{ lineHeight: '22px' }}>
             {formatDateWithTime(comment.comment.date)}
           </Text>
-          <Text variant="smallCaps" sx={{maxWidth: ['100%', '40%']}}>
+          <Text variant="smallCaps" sx={{ maxWidth: ['100%', '40%'] }}>
             {votedOption
               ? votedOption
               : `Voted with ${new BigNumber(comment.comment.voterWeight).toFixed(2)} MKR`}

--- a/modules/comments/components/CommentItem.tsx
+++ b/modules/comments/components/CommentItem.tsx
@@ -85,7 +85,7 @@ export default function CommentItem({
           <Text as="p" variant="caps" color="textMuted" sx={{ lineHeight: '22px' }}>
             {formatDateWithTime(comment.comment.date)}
           </Text>
-          <Text variant="smallCaps">
+          <Text variant="smallCaps" sx={{maxWidth: ['100%', '40%']}}>
             {votedOption
               ? votedOption
               : `Voted with ${new BigNumber(comment.comment.voterWeight).toFixed(2)} MKR`}

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -176,7 +176,7 @@ export default function ExecutiveOverviewCard({ proposal, isHat, spellData, ...p
 
           {comments && comments.length > 0 && (
             <Box sx={{ mt: 2 }}>
-              <InternalLink href={`/executive/${proposal.key}/#comments`}>
+              <InternalLink href={`/executive/${proposal.key}?network=${getNetwork()}#comments`}>
                 <CommentCount count={comments.length} />
               </InternalLink>
             </Box>

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import { Text, Flex, Box, Button, Badge, Divider, Card } from 'theme-ui';
+import { Text, Flex, Box, Button, Badge, Divider, Card, Link as InternalLink } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 
 import Skeleton from 'modules/app/components/SkeletonThemed';
@@ -176,7 +176,9 @@ export default function ExecutiveOverviewCard({ proposal, isHat, spellData, ...p
 
           {comments && comments.length > 0 && (
             <Box sx={{ mt: 2 }}>
-              <CommentCount count={comments.length} />
+              <InternalLink href={`/executive/${proposal.key}/#comments`}>
+                <CommentCount count={comments.length} />
+              </InternalLink>
             </Box>
           )}
         </Box>

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -97,7 +97,7 @@ export default function PollOverviewCard({
                 </Box>
 
                 {comments && comments.length > 0 && (
-                  <InternalLink href={`/polling/${poll.slug}/#comments`}>
+                  <InternalLink href={`/polling/${poll.slug}?network=${getNetwork()}#comments`}>
                     <CommentCount count={comments.length} />
                   </InternalLink>
                 )}

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -97,9 +97,9 @@ export default function PollOverviewCard({
                 </Box>
 
                 {comments && comments.length > 0 && (
-                  <Box>
+                  <InternalLink href={`/polling/${poll.slug}/#comments`}>
                     <CommentCount count={comments.length} />
-                  </Box>
+                  </InternalLink>
                 )}
               </Flex>
             )}

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -210,10 +210,10 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
                 tabListStyles={{ pl: [3, 4] }}
                 tabTitles={[
                   'Proposal Detail',
-
                   'Spell Details',
                   `Comments ${comments ? `(${comments.length})` : ''}`
                 ]}
+                tabRoutes={['Proposal Detail', 'Spell Details', 'Comments']}
                 tabPanels={[
                   <div
                     key={'about'}

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -188,6 +188,7 @@ const PollView = ({ poll }: { poll: Poll }) => {
                 'Vote Breakdown',
                 `Comments${comments ? ` (${comments.length})` : ''}`
               ]}
+              tabRoutes={['Poll Detail', 'Vote Breakdown', 'Comments']}
               tabPanels={[
                 <div key={1}>
                   <div


### PR DESCRIPTION
### What does this PR do?
Link to comments tab from comment count component.
Doesn't work for executives now since the entire executive card is clickable. So clicking it for an exec will still take you to the poll-detail tab.
Made a change to the Tabs component so the slug for the comments tab ends in #comments (instead of .e.g. #comments-4)
Also minor formatting improvement for comments on ranked choice polls.
### Steps for testing:
On preview deployment, click on a comment count from either the home page or polling page. 

