### PR TITLE
Chore/replace fire event with user event

### DIFF
--- a/__tests__/helpers.tsx
+++ b/__tests__/helpers.tsx
@@ -1,4 +1,4 @@
-import { act, render, RenderResult, screen } from '@testing-library/react';
+import { render, RenderResult, screen } from '@testing-library/react';
 import { TestAccountProvider } from '@makerdao/test-helpers';
 import { formatAddress } from 'lib/utils';
 import { ThemeProvider } from 'theme-ui';
@@ -10,14 +10,19 @@ import { accountsApi } from 'modules/app/stores/accounts';
 import { createCurrency } from '@makerdao/currency';
 import { AnalyticsProvider } from 'modules/app/client/analytics/AnalyticsContext';
 import { CookiesProvider } from 'modules/app/client/cookies/CookiesContext';
+import BigNumber from 'bignumber.js';
 
 const MKR = createCurrency('MKR');
+
+export const UINT256_MAX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+export const WAD = new BigNumber('1e18');
+
+export const DEMO_ACCOUNT_TESTS = '0x16Fb96a5fa0427Af0C8F7cF1eB4870231c8154B6';
 
 export function renderWithTheme(component: React.ReactNode): RenderResult {
   return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
 }
-
-export const DEMO_ACCOUNT_TESTS = '0x16Fb96a5fa0427Af0C8F7cF1eB4870231c8154B6';
 
 // TODO: research when/why this is necesssary as it tends to cause an error "Warning: eth_requestAccounts was unsuccessful, falling back to enable"
 export function injectProvider(address = DEMO_ACCOUNT_TESTS): void {

--- a/__tests__/pages/account.spec.tsx
+++ b/__tests__/pages/account.spec.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, configure, screen } from '@testing-library/react';
+import { act, configure, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import getMaker from '../../lib/maker';
 import CreateDelegate from '../../pages/account';
 import { connectAccount, renderWithAccountSelect as render } from '../helpers';
@@ -11,8 +12,6 @@ jest.mock('@theme-ui/match-media', () => {
 });
 
 let maker;
-
-const { click } = fireEvent;
 
 async function setup() {
   const view = render(
@@ -28,7 +27,7 @@ async function setup() {
   return view;
 }
 
-describe('Delegate Create page', () => {
+describe('/account page', () => {
   beforeAll(async () => {
     jest.setTimeout(30000);
     configure({ asyncUtilTimeout: 4500 });
@@ -42,13 +41,13 @@ describe('Delegate Create page', () => {
   test('can create a delegate contract', async () => {
     const checkbox = screen.getByRole('checkbox');
     act(() => {
-      click(checkbox);
+      userEvent.click(checkbox);
     });
 
     const createButton = screen.getByTestId('create-button');
 
     act(() => {
-      click(createButton);
+      userEvent.click(createButton);
     });
 
     // Transaction is initialized
@@ -63,7 +62,7 @@ describe('Delegate Create page', () => {
     const closeButton = screen.getByText('Close');
 
     act(() => {
-      click(closeButton);
+      userEvent.click(closeButton);
     });
 
     // Fetch address of our newly create vote delegate contract

--- a/__tests__/pages/account.spec.tsx
+++ b/__tests__/pages/account.spec.tsx
@@ -40,15 +40,11 @@ describe('/account page', () => {
 
   test('can create a delegate contract', async () => {
     const checkbox = screen.getByRole('checkbox');
-    act(() => {
-      userEvent.click(checkbox);
-    });
+    userEvent.click(checkbox);
 
     const createButton = screen.getByTestId('create-button');
 
-    act(() => {
-      userEvent.click(createButton);
-    });
+    userEvent.click(createButton);
 
     // Transaction is initialized
     await screen.findByText('Confirm Transaction');
@@ -61,15 +57,15 @@ describe('/account page', () => {
 
     const closeButton = screen.getByText('Close');
 
-    act(() => {
-      userEvent.click(closeButton);
-    });
+    userEvent.click(closeButton);
 
     // Fetch address of our newly create vote delegate contract
-    const { voteDelegate } = await maker
-      .service('voteDelegateFactory')
-      .getVoteDelegate(maker.currentAccount().address);
+    await act(async () => {
+      const { voteDelegate } = await maker
+        .service('voteDelegateFactory')
+        .getVoteDelegate(maker.currentAccount().address);
 
-    await screen.findByText(voteDelegate.getVoteDelegateAddress());
+      await screen.findByText(voteDelegate.getVoteDelegateAddress());
+    });
   });
 });

--- a/__tests__/pages/delegates.spec.tsx
+++ b/__tests__/pages/delegates.spec.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
-import { act, fireEvent, configure, screen } from '@testing-library/react';
+import { act, configure, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import getMaker from '../../lib/maker';
 import DelegatesPage from '../../pages/delegates';
 import {
@@ -49,7 +50,6 @@ jest.mock('@theme-ui/match-media', () => {
   };
 });
 
-const { click } = fireEvent;
 let maker, voteDelegateAddress;
 
 async function setup(maker, mockResponse) {
@@ -66,7 +66,7 @@ async function setup(maker, mockResponse) {
   return view;
 }
 
-describe('Delegates list page', () => {
+describe('/delegates page', () => {
   const mkrToDeposit = '3.2';
 
   beforeEach(async () => {
@@ -90,11 +90,15 @@ describe('Delegates list page', () => {
 
     // Open delegate modal
     const delegateButton = screen.getByText('Delegate');
-    click(delegateButton);
+    act(() => {
+      userEvent.click(delegateButton);
+    });
 
     // Approval Process
     const approveMKRButton = screen.getByText('Approve Delegate Contract', { selector: 'button' });
-    click(approveMKRButton);
+    act(() => {
+      userEvent.click(approveMKRButton);
+    });
 
     // Transaction is initialized
     await screen.findByText('Confirm Transaction');
@@ -104,11 +108,16 @@ describe('Delegates list page', () => {
     await screen.findByText('Deposit into delegate contract');
 
     const input = screen.getByTestId('mkr-input');
-    fireEvent.change(input, { target: { value: mkrToDeposit } });
+
+    act(() => {
+      userEvent.type(input, mkrToDeposit);
+    });
 
     // Delegate Process
     const delegateMKRButton = screen.getByText('Delegate MKR', { selector: 'button' });
-    click(delegateMKRButton);
+    act(() => {
+      userEvent.click(delegateMKRButton);
+    });
 
     // Make sure modal displays etherscan links correctly
     screen.getByText(/You are delegating/);
@@ -119,7 +128,9 @@ describe('Delegates list page', () => {
     expect(creatorLink).toHaveAttribute('href', `https://etherscan.io/address/${DEMO_ACCOUNT_TESTS}`);
 
     const confirmButton = await screen.findByText(/Confirm Transaction/, { selector: 'button' });
-    click(confirmButton);
+    act(() => {
+      userEvent.click(confirmButton);
+    });
 
     // Wait for transactions again...
     await screen.findByText('Transaction Pending');
@@ -132,11 +143,15 @@ describe('Delegates list page', () => {
 
     // Open undelegate modal
     const unDelegateButton = screen.getByText('Undelegate');
-    click(unDelegateButton);
+    act(() => {
+      userEvent.click(unDelegateButton);
+    });
 
     // IOU Approval Process
     const approveIOUButton = screen.getByText('Approve Delegate Contract', { selector: 'button' });
-    click(approveIOUButton);
+    act(() => {
+      userEvent.click(approveIOUButton);
+    });
 
     // More transaction screens...
     await screen.findByText('Confirm Transaction');
@@ -145,13 +160,17 @@ describe('Delegates list page', () => {
 
     // Set max button adds input value correctly
     const setMaxButton = screen.getByRole('button', { name: /Set max/ });
-    click(setMaxButton);
+    act(() => {
+      userEvent.click(setMaxButton);
+    });
 
     const unInput = screen.getByRole('spinbutton') as HTMLInputElement;
     expect(unInput.value).toBe('3.2');
 
     const undelegateMKRButton = screen.getByText('Undelegate MKR', { selector: 'button' });
-    click(undelegateMKRButton);
+    act(() => {
+      userEvent.click(undelegateMKRButton);
+    });
 
     // Wait for transactions again...
     await screen.findByText('Transaction Pending');
@@ -159,7 +178,9 @@ describe('Delegates list page', () => {
 
     // Close the modal
     const closeUndelegateBtn = screen.getByText(/Close/, { selector: 'button' });
-    click(closeUndelegateBtn);
+    act(() => {
+      userEvent.click(closeUndelegateBtn);
+    });
 
     // Voting weights are returned to 0 after undelegating
     const newTotal = screen.getByTestId('total-mkr-delegated');

--- a/__tests__/pages/delegates.spec.tsx
+++ b/__tests__/pages/delegates.spec.tsx
@@ -90,15 +90,11 @@ describe('/delegates page', () => {
 
     // Open delegate modal
     const delegateButton = screen.getByText('Delegate');
-    act(() => {
-      userEvent.click(delegateButton);
-    });
+    userEvent.click(delegateButton);
 
     // Approval Process
     const approveMKRButton = screen.getByText('Approve Delegate Contract', { selector: 'button' });
-    act(() => {
-      userEvent.click(approveMKRButton);
-    });
+    userEvent.click(approveMKRButton);
 
     // Transaction is initialized
     await screen.findByText('Confirm Transaction');
@@ -109,15 +105,11 @@ describe('/delegates page', () => {
 
     const input = screen.getByTestId('mkr-input');
 
-    act(() => {
-      userEvent.type(input, mkrToDeposit);
-    });
+    userEvent.type(input, mkrToDeposit);
 
     // Delegate Process
     const delegateMKRButton = screen.getByText('Delegate MKR', { selector: 'button' });
-    act(() => {
-      userEvent.click(delegateMKRButton);
-    });
+    userEvent.click(delegateMKRButton);
 
     // Make sure modal displays etherscan links correctly
     screen.getByText(/You are delegating/);
@@ -128,9 +120,7 @@ describe('/delegates page', () => {
     expect(creatorLink).toHaveAttribute('href', `https://etherscan.io/address/${DEMO_ACCOUNT_TESTS}`);
 
     const confirmButton = await screen.findByText(/Confirm Transaction/, { selector: 'button' });
-    act(() => {
-      userEvent.click(confirmButton);
-    });
+    userEvent.click(confirmButton);
 
     // Wait for transactions again...
     await screen.findByText('Transaction Pending');
@@ -143,15 +133,11 @@ describe('/delegates page', () => {
 
     // Open undelegate modal
     const unDelegateButton = screen.getByText('Undelegate');
-    act(() => {
-      userEvent.click(unDelegateButton);
-    });
+    userEvent.click(unDelegateButton);
 
     // IOU Approval Process
     const approveIOUButton = screen.getByText('Approve Delegate Contract', { selector: 'button' });
-    act(() => {
-      userEvent.click(approveIOUButton);
-    });
+    userEvent.click(approveIOUButton);
 
     // More transaction screens...
     await screen.findByText('Confirm Transaction');
@@ -160,17 +146,13 @@ describe('/delegates page', () => {
 
     // Set max button adds input value correctly
     const setMaxButton = screen.getByRole('button', { name: /Set max/ });
-    act(() => {
-      userEvent.click(setMaxButton);
-    });
+    userEvent.click(setMaxButton);
 
     const unInput = screen.getByRole('spinbutton') as HTMLInputElement;
     expect(unInput.value).toBe('3.2');
 
     const undelegateMKRButton = screen.getByText('Undelegate MKR', { selector: 'button' });
-    act(() => {
-      userEvent.click(undelegateMKRButton);
-    });
+    userEvent.click(undelegateMKRButton);
 
     // Wait for transactions again...
     await screen.findByText('Transaction Pending');
@@ -178,9 +160,7 @@ describe('/delegates page', () => {
 
     // Close the modal
     const closeUndelegateBtn = screen.getByText(/Close/, { selector: 'button' });
-    act(() => {
-      userEvent.click(closeUndelegateBtn);
-    });
+    userEvent.click(closeUndelegateBtn);
 
     // Voting weights are returned to 0 after undelegating
     const newTotal = screen.getByTestId('total-mkr-delegated');

--- a/__tests__/pages/esmodule.spec.tsx
+++ b/__tests__/pages/esmodule.spec.tsx
@@ -1,5 +1,5 @@
 import { renderWithTheme, UINT256_MAX, WAD } from '../helpers';
-import { act, waitFor, screen, fireEvent } from '@testing-library/react';
+import { waitFor, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import waitForExpect from 'wait-for-expect';
 import { TestAccountProvider } from '@makerdao/test-helpers';
@@ -73,32 +73,18 @@ describe('/esmodule page', () => {
     test('burn MKR in modal flow', async () => {
       renderWithTheme(<ESModule />);
 
-      // Intro Render
-      // await wait(() =>
-      //   screen.getByText('The Emergency Shutdown Module (ESM) is responsible for', {
-      //     exact: false
-      //   })
-      // );
-      // click(screen.getByText('Continue'));
-
       // First Step Render
       const burnButton = await screen.findByText('Burn Your MKR', {}, { timeout: 5000 });
-      act(() => {
-        userEvent.click(burnButton);
-      });
+      userEvent.click(burnButton);
       await screen.findByText('Are you sure you want to burn MKR?');
-      act(() => {
-        userEvent.click(screen.getByText('Continue'));
-      });
+      userEvent.click(screen.getByText('Continue'));
 
       // Second Step Render
       await screen.findByText('Enter the amount of MKR to burn');
 
       // Not Enough MKR Check
       const amount = '35';
-      act(() => {
-        userEvent.type(screen.getByTestId('mkr-input'), amount);
-      });
+      userEvent.type(screen.getByTestId('mkr-input'), amount);
       const tooLow = await screen.findByText('MKR balance too low', {}, { timeout: 3000 });
       expect(tooLow).toBeInTheDocument();
 
@@ -114,9 +100,7 @@ describe('/esmodule page', () => {
       // Set Max Check
       const setMaxButton = screen.getByTestId('mkr-input-set-max');
       // Click on the button
-      act(() => {
-        userEvent.click(setMaxButton);
-      });
+      userEvent.click(setMaxButton);
       expect(input).toHaveValue(2.0);
 
       // Valid Amount Check
@@ -126,9 +110,7 @@ describe('/esmodule page', () => {
       await waitFor(() => expect(continueButton).toBeEnabled());
 
       expect(continueButton).toBeEnabled();
-      act(() => {
-        userEvent.click(continueButton);
-      });
+      userEvent.click(continueButton);
 
       // Third Step Render
       await screen.findByText('Burn amount', {}, { timeout: 5000 });
@@ -139,17 +121,13 @@ describe('/esmodule page', () => {
 
       // click the terms of service
       const tos = await screen.findByTestId('tosCheck');
-      act(() => {
-        userEvent.click(tos);
-      });
+      userEvent.click(tos);
       await waitFor(() => expect(tos).toBeChecked());
 
       // click the unlock mkr
       const allowanceBtn = await screen.findByTestId('allowance-toggle');
       expect(allowanceBtn).toBeEnabled();
-      act(() => {
-        userEvent.click(allowanceBtn);
-      });
+      userEvent.click(allowanceBtn);
       await waitFor(() => expect(allowanceBtn).toBeDisabled());
 
       const confirmInput = screen.getByTestId('confirm-input');
@@ -159,16 +137,12 @@ describe('/esmodule page', () => {
       fireEvent.change(confirmInput, { target: { value: 'I am burning 2.00 MKR' } });
       await waitFor(() => expect(burnMKRbutton).toBeDisabled());
 
-      act(() => {
-        // userEvent type doesn't work on this input
-        fireEvent.change(confirmInput, { target: { value: 'I am burning 1.00 MKR' } });
-      });
+      // userEvent type doesn't work on this input
+      fireEvent.change(confirmInput, { target: { value: 'I am burning 1.00 MKR' } });
 
       await waitFor(() => expect(burnMKRbutton).toBeEnabled());
 
-      act(() => {
-        userEvent.click(burnMKRbutton);
-      });
+      userEvent.click(burnMKRbutton);
 
       // Third Step Render
       const signTransaction = await screen.findByText('Sign Transaction');

--- a/__tests__/pages/esmodule.spec.tsx
+++ b/__tests__/pages/esmodule.spec.tsx
@@ -120,6 +120,8 @@ describe('/esmodule page', () => {
       expect(input).toHaveValue(2.0);
 
       // Valid Amount Check
+
+      // userEvent type doesn't work on this input
       fireEvent.change(input, { target: { value: 1 } });
       await waitFor(() => expect(continueButton).toBeEnabled());
 
@@ -152,6 +154,8 @@ describe('/esmodule page', () => {
 
       const confirmInput = screen.getByTestId('confirm-input');
       // Incorrect Input Check
+
+      // userEvent type doesn't work on this input
       fireEvent.change(confirmInput, { target: { value: 'I am burning 2.00 MKR' } });
       await waitFor(() => expect(burnMKRbutton).toBeDisabled());
 

--- a/__tests__/pages/executive.spec.tsx
+++ b/__tests__/pages/executive.spec.tsx
@@ -49,41 +49,29 @@ describe('/executive page', () => {
   test('can deposit and withdraw into chief', async () => {
     const depositButton = await screen.findByTestId('deposit-button');
 
-    act(() => {
-      userEvent.click(depositButton);
-    });
+    userEvent.click(depositButton);
 
     await screen.findByText('Approve voting contract');
     const approveButton = screen.getByTestId('deposit-approve-button');
 
-    act(() => {
-      userEvent.click(approveButton);
-    });
+    userEvent.click(approveButton);
 
     await screen.findByText('Deposit into voting contract');
     const input = screen.getByTestId('mkr-input');
-    act(() => {
-      userEvent.type(input, '10');
-    });
+    userEvent.type(input, '10');
     const finalDepositButton = await screen.findByText('Deposit MKR');
     expect(finalDepositButton).toBeEnabled();
 
-    act(() => {
-      userEvent.click(finalDepositButton);
-    });
+    userEvent.click(finalDepositButton);
 
     const withdrawButton = await screen.findByTestId('withdraw-button');
 
-    act(() => {
-      userEvent.click(withdrawButton);
-    });
+    userEvent.click(withdrawButton);
 
     await screen.findByText('Approve voting contract');
     const approveButtonWithdraw = screen.getByTestId('withdraw-approve-button', {}, { timeout: 15000 });
 
-    act(() => {
-      userEvent.click(approveButtonWithdraw);
-    });
+    userEvent.click(approveButtonWithdraw);
 
     await screen.findByText('Withdraw from voting contract');
     const inputWithdraw = screen.getByTestId('mkr-input');
@@ -93,9 +81,7 @@ describe('/executive page', () => {
 
     expect(finalDepositButtonWithdraw).toBeEnabled();
 
-    act(() => {
-      userEvent.click(finalDepositButtonWithdraw);
-    });
+    userEvent.click(finalDepositButtonWithdraw);
 
     const dialog = screen.getByRole('dialog');
     await waitForElementToBeRemoved(dialog);
@@ -107,13 +93,9 @@ describe('/executive page', () => {
 
   test('can vote on an executive', async () => {
     const [voteButtonOne] = screen.getAllByTestId('vote-button-exec-overview-card');
-    act(() => {
-      userEvent.click(voteButtonOne);
-    });
+    userEvent.click(voteButtonOne);
     const submitButton = screen.getByText('Submit Vote');
-    act(() => {
-      userEvent.click(submitButton);
-    });
+    userEvent.click(submitButton);
 
     // wait for transaction to progress
     await screen.findByText('Transaction Sent');

--- a/__tests__/pages/executive.spec.tsx
+++ b/__tests__/pages/executive.spec.tsx
@@ -1,4 +1,5 @@
-import { configure, act, fireEvent, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { configure, act, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import getMaker from '../../lib/maker';
 import {
@@ -18,7 +19,6 @@ jest.mock('@theme-ui/match-media', () => {
   };
 });
 
-const { click } = fireEvent;
 let maker;
 
 async function setup() {
@@ -33,7 +33,7 @@ async function setup() {
   return view;
 }
 
-describe('executive page', () => {
+describe('/executive page', () => {
   beforeAll(async () => {
     jest.setTimeout(30000);
     configure({ asyncUtilTimeout: 4500 });
@@ -49,39 +49,53 @@ describe('executive page', () => {
   test('can deposit and withdraw into chief', async () => {
     const depositButton = await screen.findByTestId('deposit-button');
 
-    click(depositButton);
+    act(() => {
+      userEvent.click(depositButton);
+    });
 
     await screen.findByText('Approve voting contract');
     const approveButton = screen.getByTestId('deposit-approve-button');
 
-    click(approveButton);
+    act(() => {
+      userEvent.click(approveButton);
+    });
 
     await screen.findByText('Deposit into voting contract');
     const input = screen.getByTestId('mkr-input');
-    fireEvent.change(input, { target: { value: '10' } });
+    act(() => {
+      userEvent.type(input, '10');
+    });
     const finalDepositButton = await screen.findByText('Deposit MKR');
     expect(finalDepositButton).toBeEnabled();
 
-    click(finalDepositButton);
+    act(() => {
+      userEvent.click(finalDepositButton);
+    });
 
     const withdrawButton = await screen.findByTestId('withdraw-button');
 
-    click(withdrawButton);
+    act(() => {
+      userEvent.click(withdrawButton);
+    });
 
     await screen.findByText('Approve voting contract');
     const approveButtonWithdraw = screen.getByTestId('withdraw-approve-button', {}, { timeout: 15000 });
 
-    click(approveButtonWithdraw);
+    act(() => {
+      userEvent.click(approveButtonWithdraw);
+    });
 
     await screen.findByText('Withdraw from voting contract');
     const inputWithdraw = screen.getByTestId('mkr-input');
-    fireEvent.change(inputWithdraw, { target: { value: '6' } });
+    userEvent.type(inputWithdraw, '6');
 
     const finalDepositButtonWithdraw = await screen.findByText('Withdraw MKR');
 
     expect(finalDepositButtonWithdraw).toBeEnabled();
 
-    click(finalDepositButtonWithdraw);
+    act(() => {
+      userEvent.click(finalDepositButtonWithdraw);
+    });
 
     const dialog = screen.getByRole('dialog');
     await waitForElementToBeRemoved(dialog);
@@ -93,9 +107,13 @@ describe('executive page', () => {
 
   test('can vote on an executive', async () => {
     const [voteButtonOne] = screen.getAllByTestId('vote-button-exec-overview-card');
-    click(voteButtonOne);
+    act(() => {
+      userEvent.click(voteButtonOne);
+    });
     const submitButton = screen.getByText('Submit Vote');
-    click(submitButton);
+    act(() => {
+      userEvent.click(submitButton);
+    });
 
     // wait for transaction to progress
     await screen.findByText('Transaction Sent');

--- a/__tests__/pages/polling.spec.tsx
+++ b/__tests__/pages/polling.spec.tsx
@@ -39,21 +39,26 @@ describe('polling page', () => {
 
   describe('renders polls', () => {
     test('renders active polls', async () => {
-      const activePollsText = await screen.findAllByText('Active Polls', {}, { timeout: 15000 });
+      const activePollsText = screen.queryAllByText('Active Polls');
       expect(activePollsText.length).toBe(2);
       expect(activePollsText[0]).toBeInTheDocument();
       expect(activePollsText[1]).toBeInTheDocument();
     });
 
     test('shows ballot when account is connected', async () => {
-      expect(await screen.findByText('Your Ballot', {}, { timeout: 15000 })).toBeInTheDocument();
-      await screen.findByText(formatAddress(DEMO_ACCOUNT_TESTS));
+      const address = screen.queryByText(formatAddress(DEMO_ACCOUNT_TESTS));
+      expect(address).toBeInTheDocument();
+      const ballot = screen.queryByText('Your Ballot');
+      expect(ballot).toBeInTheDocument();
     });
 
-    // TODO
-    xtest('does not show ballot when no account connected', async () => {
-      expect(await screen.findByText('Your Ballot', {}, { timeout: 15000 })).not.toBeInTheDocument();
-      await screen.findByText(formatAddress(DEMO_ACCOUNT_TESTS));
+    test('does not show ballot when no account connected', async () => {
+      // remove account from state
+      accountsApi.setState({ currentAccount: undefined });
+      const address = screen.queryByText(formatAddress(DEMO_ACCOUNT_TESTS));
+      expect(address).not.toBeInTheDocument();
+      const ballot = screen.queryByText('Your Ballot');
+      expect(ballot).not.toBeInTheDocument();
     });
   });
 });

--- a/modules/app/components/__tests__/AccountSelect.spec.tsx
+++ b/modules/app/components/__tests__/AccountSelect.spec.tsx
@@ -9,15 +9,11 @@ describe('Account select', () => {
     const connectButton = await screen.findByText('Connect wallet');
     expect(connectButton).toBeInTheDocument();
 
-    act(() => {
-      userEvent.click(connectButton);
-    });
+    userEvent.click(connectButton);
 
     const metamaskButton = await screen.findByText('MetaMask');
 
-    act(() => {
-      userEvent.click(metamaskButton);
-    });
+    userEvent.click(metamaskButton);
 
     await act(async () => {
       await connectAccount();

--- a/modules/app/components/__tests__/AccountSelect.spec.tsx
+++ b/modules/app/components/__tests__/AccountSelect.spec.tsx
@@ -1,20 +1,23 @@
 import { renderWithTheme as render, connectAccount } from '../../../../__tests__/helpers';
-import { act, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act, screen } from '@testing-library/react';
 import WrappedAccountSelect from 'modules/app/components/layout/header/AccountSelect';
-
-const { click } = fireEvent;
 
 describe('Account select', () => {
   test('can connect an account', async () => {
-    const view = render(<WrappedAccountSelect />);
+    render(<WrappedAccountSelect />);
     const connectButton = await screen.findByText('Connect wallet');
     expect(connectButton).toBeInTheDocument();
 
-    click(connectButton);
+    act(() => {
+      userEvent.click(connectButton);
+    });
 
     const metamaskButton = await screen.findByText('MetaMask');
 
-    click(metamaskButton);
+    act(() => {
+      userEvent.click(metamaskButton);
+    });
 
     await act(async () => {
       await connectAccount();

--- a/modules/mkr/components/__tests__/MKRInput.spec.tsx
+++ b/modules/mkr/components/__tests__/MKRInput.spec.tsx
@@ -51,9 +51,7 @@ describe('MKRInput', () => {
     const setMaxButton = screen.getByTestId('mkr-input-set-max');
     const input = screen.getByTestId('mkr-input');
 
-    act(() => {
-      userEvent.click(setMaxButton);
-    });
+    userEvent.click(setMaxButton);
 
     expect(props.onChange).toHaveBeenCalledWith(new BigNumber(24.5));
 
@@ -69,9 +67,7 @@ describe('MKRInput', () => {
 
     renderMKRInput(props);
     const input = screen.getByTestId('mkr-input');
-    act(() => {
-      userEvent.type(input, '3.2');
-    });
+    userEvent.type(input, '3.2');
     expect(props.onChange).toHaveBeenCalledWith(new BigNumber(3.2));
     expect(input).toHaveValue(3.2);
   });

--- a/modules/mkr/components/__tests__/MKRInput.spec.tsx
+++ b/modules/mkr/components/__tests__/MKRInput.spec.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { render, cleanup, fireEvent, screen } from '@testing-library/react';
-
+import { render, cleanup, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MKRInput, MKRInputProps } from '../MKRInput';
 import BigNumber from 'bignumber.js';
 
@@ -52,8 +51,9 @@ describe('MKRInput', () => {
     const setMaxButton = screen.getByTestId('mkr-input-set-max');
     const input = screen.getByTestId('mkr-input');
 
-    // Click on the button
-    fireEvent.click(setMaxButton);
+    act(() => {
+      userEvent.click(setMaxButton);
+    });
 
     expect(props.onChange).toHaveBeenCalledWith(new BigNumber(24.5));
 
@@ -69,7 +69,9 @@ describe('MKRInput', () => {
 
     renderMKRInput(props);
     const input = screen.getByTestId('mkr-input');
-    fireEvent.change(input, { target: { value: '3.2' } });
+    act(() => {
+      userEvent.type(input, '3.2');
+    });
     expect(props.onChange).toHaveBeenCalledWith(new BigNumber(3.2));
     expect(input).toHaveValue(3.2);
   });

--- a/package.json
+++ b/package.json
@@ -72,9 +72,10 @@
   "devDependencies": {
     "@makerdao/test-helpers": "^0.3.0",
     "@makerdao/testchain": "^1.1.33-beta5",
-    "@testing-library/dom": "^8.1.0",
+    "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
+    "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^26.0.24",
     "@types/react": "^17.0.11",
     "@types/testing-library__jest-dom": "^5.14.0",

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -176,7 +176,7 @@ const AccountPage = (): JSX.Element => {
                   <Label sx={{ mt: 2, fontSize: 2, alignItems: 'center' }}>
                     <Checkbox
                       checked={warningRead}
-                      onClick={event => {
+                      onChange={() => {
                         setWarningRead(!warningRead);
                         trackButtonClick('setWarningRead');
                       }}
@@ -201,7 +201,7 @@ const AccountPage = (): JSX.Element => {
                   <Text as="p">
                     You have a DSChief balance of{' '}
                     <Text sx={{ fontWeight: 'bold' }}>{chiefBalance.toBigNumber().toFormat(6)} MKR.</Text>
-                    <Text as="p" sx={{ my: 2 }}>
+                    <Text sx={{ display: 'block', my: 2 }}>
                       {voteDelegate
                         ? 'As a delegate you can only vote with your delegate contract through the portal. You can withdraw your MKR and delegate it to yourself to vote with it.'
                         : 'If you become a delegate, you will only be able to vote through the portal as a delegate. In this case, it is recommended to withdraw your MKR and delegate it to yourself or create the delegate contract from a different account.'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2121,7 +2121,7 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^8.1.0":
+"@testing-library/dom@^8.11.1":
   version "8.11.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
   integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
@@ -2157,6 +2157,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
+
+"@testing-library/user-event@^13.5.0":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 "@theme-ui/color-modes@0.12.0":
   version "0.12.0"


### PR DESCRIPTION
### What does this PR do?

Replaces `fireEvent` in tests with `userEvent`

This is recommended by react testing library: https://testing-library.com/docs/dom-testing-library/api-events

Why?

> the userEvent library uses fireEvent methods to trigger some events, but it calls them in sequence and in the order in which they would occur if a real user was the one behind the screen.

Article with more details: https://blog.mimacom.com/react-testing-library-fireevent-vs-userevent/

