### PR TITLE
use mongodb insertMany instead of insertOne for polling comments

### DIFF
--- a/pages/api/comments/polling/add.ts
+++ b/pages/api/comments/polling/add.ts
@@ -48,19 +48,24 @@ export default withApiHandler(
     invariant(await client.isConnected(), 'Mongo client failed to connect');
 
     const collection = db.collection('pollingComments');
-    body.comments.forEach(async comment => {
-      const commentToInsert: PollComment = {
-        pollId: comment.pollId as number,
-        comment: comment.comment as string,
-        network,
-        date: new Date(),
-        voterAddress: body.voterAddress,
-        voteProxyAddress: body.voteProxyAddress || '',
-        delegateAddress: body.delegateAddress || '',
-        txHash: body.txHash
-      };
-      await collection.insertOne(commentToInsert);
-    });
+    const commentsToInsert: PollComment[] = body.comments.map(comment => ({
+      pollId: comment.pollId as number,
+      comment: comment.comment as string,
+      network,
+      date: new Date(),
+      voterAddress: body.voterAddress,
+      voteProxyAddress: body.voteProxyAddress || '',
+      delegateAddress: body.delegateAddress || '',
+      txHash: body.txHash
+    }));
+
+    try {
+      await collection.insertMany(commentsToInsert);
+    } catch (e) {
+      console.error(
+        `A MongoBulkWriteException occurred, but there are ${e.result.result.nInserted} successfully processed documents.`
+      );
+    }
 
     res.status(200).json({ success: 'Added Successfully' });
   },


### PR DESCRIPTION
### Link to Shortcut ticket:

### What does this PR do?
instead of looping over comments and inserting one by one use mongodb `insertMany` to insert an array of comments.

### Steps for testing:

1. vote on any number of polls and make comments
2. submit them
3. look at the mongo dashboard and verify the comments were inserted

### Screenshots (if relevant):
![Screen Shot 2022-01-12 at 5 16 44 PM](https://user-images.githubusercontent.com/13105602/149243390-1e08eb5a-15a6-4191-969b-1662f38d4759.png)

### Add a GIF:
![](https://media.giphy.com/media/2fjjoFrNS4XzW/giphy.gif)
