### PR TITLE
convert voterWeight to BigNumber in useExecutiveComments hook

### DIFF
--- a/modules/comments/components/CommentItem.tsx
+++ b/modules/comments/components/CommentItem.tsx
@@ -7,7 +7,7 @@ import { getNetwork } from 'lib/maker';
 import useAccountsStore from 'modules/app/stores/accounts';
 import DelegateAvatarName from 'modules/delegates/components/DelegateAvatarName';
 import AddressIconBox from 'modules/address/components/AddressIconBox';
-import { ExecutiveCommentsAPIResponseItem, PollCommentsAPIResponseItemWithWeight } from '../types/comments';
+import { ParsedExecutiveComments, PollCommentsAPIResponseItemWithWeight } from '../types/comments';
 import BigNumber from 'bignumber.js';
 import { getEtherscanLink } from 'lib/utils';
 
@@ -16,7 +16,7 @@ export default function CommentItem({
   votedOption,
   twitterUrl
 }: {
-  comment: PollCommentsAPIResponseItemWithWeight | ExecutiveCommentsAPIResponseItem;
+  comment: PollCommentsAPIResponseItemWithWeight | ParsedExecutiveComments;
   votedOption?: React.ReactNode;
   twitterUrl: string;
 }): React.ReactElement {

--- a/modules/comments/components/ExecutiveComments.tsx
+++ b/modules/comments/components/ExecutiveComments.tsx
@@ -6,7 +6,7 @@ import Stack from 'modules/app/components/layout/layouts/Stack';
 import { Proposal } from '../../executive/types';
 import FilterButton from 'modules/app/components/FilterButton';
 import { MenuItem } from '@reach/menu-button';
-import { ExecutiveCommentsAPIResponseItem } from '../types/comments';
+import { ParsedExecutiveComments } from '../types/comments';
 import CommentItem from './CommentItem';
 
 export default function ExecutiveComments({
@@ -15,7 +15,7 @@ export default function ExecutiveComments({
   ...props
 }: {
   proposal: Proposal;
-  comments: ExecutiveCommentsAPIResponseItem[] | undefined;
+  comments: ParsedExecutiveComments[] | undefined;
 }): JSX.Element {
   const [commentSortBy, setCommentSortBy] = useState('latest');
   const sortedComments = useMemo(() => {

--- a/modules/comments/hooks/useExecutiveComments.ts
+++ b/modules/comments/hooks/useExecutiveComments.ts
@@ -1,10 +1,11 @@
+import BigNumber from 'bignumber.js';
 import { fetchJson } from 'lib/fetchJson';
 import { getNetwork } from 'lib/maker';
 import useSWR from 'swr';
-import { ExecutiveCommentsAPIResponseItem } from '../types/comments';
+import { ExecutiveCommentsAPIResponseItem, ParsedExecutiveComments } from '../types/comments';
 
 type UseExecutiveCommentsResponse = {
-  comments: ExecutiveCommentsAPIResponseItem[] | undefined;
+  comments: ParsedExecutiveComments[] | undefined;
   mutate: () => void;
   error: boolean;
 };
@@ -27,8 +28,21 @@ export function useExecutiveComments(
     }
   );
 
+  //convert voterWeight from strings to BigNumbers
+  const commentsParsed = commentsDatas?.map(c => {
+    const { comment, ...rest } = c;
+    const { voterWeight } = comment;
+    return {
+      comment: {
+        ...comment,
+        voterWeight: new BigNumber(voterWeight.replace(/,/g, '')) //remove commas from string before converting to BigNumber
+      },
+      ...rest
+    };
+  });
+
   return {
-    comments: commentsDatas,
+    comments: commentsParsed,
     mutate,
     error
   };

--- a/modules/comments/types/comments.d.ts
+++ b/modules/comments/types/comments.d.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { AddressApiResponse } from 'modules/address/types/addressApiResponse';
 import { ExecutiveComment } from './executiveComment';
 import { PollComment, PollCommentWithWeight } from './pollComments';
@@ -14,5 +15,10 @@ export type PollCommentsAPIResponseItemWithWeight = {
 
 export type ExecutiveCommentsAPIResponseItem = {
   comment: ExecutiveComment;
+  address: AddressApiResponse;
+};
+
+export type ParsedExecutiveComments = {
+  comment: Omit<ExecutiveComment, 'voterWeight'> & { voterWeight: BigNumber };
   address: AddressApiResponse;
 };


### PR DESCRIPTION
The UI showed NaN in the voter weight of an executive comment when the weight was >1000 because the db would return commas in the string representation of the numbers, which caused an error when converting them to BigNumbers.

This PR converts the voterWeight from a string to a bigNumber, minding the commas, in the useExecutiveComments hook.

Poll comments use type BigNumber for the voterWeight variable, so this reduces differences between the exec comments and poll comments types used by the components.

To test:
Pantera's vote weight is shown here: https://governance-portal-v2-fpiwhy0pj-dux-core-unit.vercel.app/executive/template-executive-vote-offboarding-usdt-collateral-core-unit-budget-distributions-october-1-2021?network=mainnet#comments
but not on production: https://vote.makerdao.com/executive/template-executive-vote-offboarding-usdt-collateral-core-unit-budget-distributions-october-1-2021?network=mainnet#comments