### PR TITLE
feat: ens avatar support

### DIFF
--- a/modules/address/components/AddressIcon.tsx
+++ b/modules/address/components/AddressIcon.tsx
@@ -1,16 +1,16 @@
 import { Box } from 'theme-ui';
-import { Jazzicon } from '@ukstv/jazzicon-react';
+import Davatar from '@davatar/react';
 
 export default function AddressIcon({
   address,
-  width = '22px'
+  width = 22
 }: {
   address: string;
-  width?: string;
+  width?: number;
 }): React.ReactElement {
   return (
     <Box sx={{ height: width, width: width }}>
-      <Jazzicon address={address} sx={{ height: width, width: width }} />
+      <Davatar size={width} address={address} generatedAvatarType="jazzicon" />
     </Box>
   );
 }

--- a/modules/address/components/AddressIconBox.tsx
+++ b/modules/address/components/AddressIconBox.tsx
@@ -38,7 +38,7 @@ export default function AddressIconBox({
   return (
     <Flex>
       <Box sx={{ minWidth: '41px', mr: 2 }}>
-        <AddressIcon address={address} width="41px" />
+        <AddressIcon address={address} width={41} />
       </Box>
       <Flex
         sx={{

--- a/modules/app/components/layout/header/AccountBox.tsx
+++ b/modules/app/components/layout/header/AccountBox.tsx
@@ -34,7 +34,7 @@ const AccountBox = ({ address, accountName, change }: Props): JSX.Element => {
           </Text>
           <Flex sx={{ alignItems: 'center', flexDirection: 'row', mt: 1 }}>
             <Box sx={{ mr: 2 }}>
-              <AddressIcon address={address} width="22px" />
+              <AddressIcon address={address} width={22} />
             </Box>
             <Text sx={{ fontFamily: 'body' }} data-testid="current-wallet">
               {formatAddress(address)}

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -108,7 +108,7 @@ export function DelegateDetail({ delegate }: PropTypes): React.ReactElement {
         >
           <Box>
             <Flex>
-              <DelegatePicture delegate={delegate} key={delegate.id} width={'52px'} />
+              <DelegatePicture delegate={delegate} key={delegate.id} width={52} />
               <Box sx={{ width: '100%' }}>
                 <Box sx={{ ml: 3 }}>
                   <Flex sx={{ alignItems: 'center' }}>

--- a/modules/delegates/components/DelegatePicture.tsx
+++ b/modules/delegates/components/DelegatePicture.tsx
@@ -1,6 +1,6 @@
 import { DelegateStatusEnum } from '../delegates.constants';
 import { Box, Flex, Image } from 'theme-ui';
-import { Jazzicon } from '@ukstv/jazzicon-react';
+import Davatar from '@davatar/react';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { Delegate } from '../types';
 import Tooltip from 'modules/app/components/Tooltip';
@@ -8,10 +8,10 @@ import { DelegateParticipationMetrics } from './DelegateParticipationMetrics';
 
 export function DelegatePicture({
   delegate,
-  width = '41px'
+  width = 41
 }: {
   delegate: Delegate;
-  width?: string;
+  width?: number;
 }): React.ReactElement {
   const delegateMetrics = (
     <Box sx={{ maxWidth: ['auto', '530px'], width: ['auto', '530px'], display: 'block' }}>
@@ -28,10 +28,7 @@ export function DelegatePicture({
             src={delegate.picture}
           />
         ) : (
-          <Jazzicon
-            address={delegate.address}
-            sx={{ height: ['150px', '200px'], width: ['150px', '200px'] }}
-          />
+          <Davatar size={50} address={delegate.address} generatedAvatarType="jazzicon" />
         )}
         <Box sx={{ marginLeft: 1, flex: 1 }}>
           <DelegateParticipationMetrics delegate={delegate} />
@@ -56,7 +53,7 @@ export function DelegatePicture({
           />
         </Tooltip>
       ) : (
-        <Jazzicon address={delegate.address} sx={{ height: width, width: width }} />
+        <Davatar size={width} address={delegate.address} generatedAvatarType="jazzicon" />
       )}
       {delegate.status === DelegateStatusEnum.recognized && (
         <Icon

--- a/modules/web3/components/ConnectWalletButton.tsx
+++ b/modules/web3/components/ConnectWalletButton.tsx
@@ -63,7 +63,7 @@ export default function ConnectWalletButton({ onClickConnect, address, pending }
         ) : (
           <Flex sx={{ alignItems: 'center', mr: 2 }}>
             <Box sx={{ mr: 2 }}>
-              <AddressIcon address={address} width="22px" />
+              <AddressIcon address={address} width={22} />
             </Box>
             <Text sx={{ fontFamily: 'body' }}>{addressFormated}</Text>
           </Flex>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint --ext .tsx,.ts pages/ modules/ lib/"
   },
   "dependencies": {
+    "@davatar/react": "^1.8.1",
     "@makerdao/dai": "^0.42.4",
     "@makerdao/dai-plugin-governance": "^0.16.7",
     "@makerdao/dai-plugin-ledger-web": "^0.9.10",
@@ -46,7 +47,6 @@
     "@sentry/nextjs": "^6.17.3",
     "@theme-ui/css": "^0.12.0",
     "@theme-ui/match-media": "^0.12.0",
-    "@ukstv/jazzicon-react": "^1.0.0",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "6.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,6 +411,19 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@davatar/react@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.8.1.tgz#2fe3e619422a46092c57025328be56b1e911550e"
+  integrity sha512-vq9zNwAfnZCoY8W2eAbjWP1GPQutUfdxG+lKG2fAPqNFP2qrzDhIziKyCKtt7jwaXp79P1Cy1Gjzlvs1XkzwOQ==
+  dependencies:
+    "@ethersproject/contracts" "^5.4.1"
+    "@ethersproject/providers" "^5.4.5"
+    "@types/react-blockies" "^1.4.1"
+    bn.js "^5.2.0"
+    color "^3.2.1"
+    mersenne-twister "^1.1.0"
+    react-blockies "^1.4.1"
+
 "@emotion/babel-plugin@^11.3.0":
   version "11.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
@@ -784,7 +797,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
 
-"@ethersproject/contracts@5.5.0":
+"@ethersproject/contracts@5.5.0", "@ethersproject/contracts@^5.4.1":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.5.0.tgz#b735260d4bd61283a670a82d5275e2a38892c197"
   integrity sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==
@@ -890,6 +903,31 @@
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.2.tgz#131ccf52dc17afd0ab69ed444b8c0e3a27297d99"
   integrity sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/providers@^5.4.5":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.3.tgz#56c2b070542ac44eb5de2ed3cf6784acd60a3130"
+  integrity sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==
   dependencies:
     "@ethersproject/abstract-provider" "^5.5.0"
     "@ethersproject/abstract-signer" "^5.5.0"
@@ -2572,6 +2610,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/react-blockies@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-blockies/-/react-blockies-1.4.1.tgz#d5f6fff8ece3e90f2e7708f8f3156c87333312df"
+  integrity sha512-aDX0g0hwzdodkGLSDNUQr6gXxwclGjnhS8jhsR8uQhAfe/7i3GZD/NDcSlQ2SiQiLhfRxX3NlY+nvBwf5Y0tTg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.20":
   version "7.1.22"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
@@ -2788,14 +2833,6 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
-
-"@ukstv/jazzicon-react@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ukstv/jazzicon-react/-/jazzicon-react-1.0.0.tgz#f319ebf3b6a165bfc5feaea7ee4c1eb81c5d9b85"
-  integrity sha512-V0klHdrO8Mk+faTGhQRd4t2vR+1IUHJa9sLaP/vhed0klPrOblhEU/Mc+Utgxep6oUuyhcGigjvkEJUOVE1/sg==
-  dependencies:
-    color "^3.1.2"
-    mersenne-twister "^1.1.0"
 
 "@walletconnect/browser-utils@^1.7.1":
   version "1.7.1"
@@ -4977,7 +5014,7 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.1.2:
+color@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
@@ -11567,7 +11604,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11803,6 +11840,13 @@ raw-body@2.4.2, raw-body@^2.4.1:
     http-errors "1.8.1"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-blockies@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-blockies/-/react-blockies-1.4.1.tgz#d4f0faf95ac197213a297a370a4d7f77ea3d0b08"
+  integrity sha512-4N015X5oPNnD3xQPsiqolOFzPZSSWyc5mJhJUZShUCHtiGUxVN+1qsWTcglkHMNySux9hUofaispqcw9QkWP5Q==
+  dependencies:
+    prop-types "^15.5.10"
 
 react-clientside-effect@^1.2.5:
   version "1.2.5"
@@ -14534,7 +14578,7 @@ web3-net@1.6.0:
     web3-core-method "1.6.0"
     web3-utils "1.6.0"
 
-web3-provider-engine@14.0.4, "web3-provider-engine@github:makerdao/provider-engine#kovan-fix-dist":
+web3-provider-engine@14.0.4, web3-provider-engine@makerdao/provider-engine#kovan-fix-dist:
   version "14.0.4"
   resolved "https://codeload.github.com/makerdao/provider-engine/tar.gz/7c4b187809f156409473246de15dc595e1fe3356"
   dependencies:


### PR DESCRIPTION
### What does this PR do?

Show user ens avatar if already had, else fallbacks to jazzicon

### Steps for testing:
Places to test:

- Connect Button
- Account Popup
- Delegate card
- Delegate detail

### Screenshots (if relevant):
![image](https://user-images.githubusercontent.com/29498872/153139713-a06d51e3-5ff2-41d0-943a-57e33531acfc.png)

![image](https://user-images.githubusercontent.com/29498872/153139681-3edb2b34-7acd-42d3-b583-2b7ffc64366e.png)

![image](https://user-images.githubusercontent.com/29498872/153139742-51b96b84-5b0b-4ace-95d6-08e5afb841e1.png)

![image](https://user-images.githubusercontent.com/29498872/153139773-eb5dcea3-5b14-4a54-8bbe-0e40e7867ae7.png)

### Any additional helpful information?:

Replaced `@ukstv/jazzicon-react` packaged with `@davatar/react`

### Add a GIF:
![image](https://user-images.githubusercontent.com/29498872/153140162-d1293288-6f29-4716-8f51-0b9b7ba0d4b3.png)