### PR TITLE
Remove query parameters on api docs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -49,7 +49,9 @@ const moduleExports = {
         destination: '/address/:address'
       }
     ];
-  }
+  },
+
+  
 };
 
 const SentryWebpackPluginOptions = {

--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function middleware(req: NextRequest) {
+  const { pathname, search } = req.nextUrl;
+
+  if (pathname === '/api-docs' && search.length > 0) {
+    return NextResponse.redirect('/api-docs');
+  }
+
+  return NextResponse.next();
+}

--- a/pages/api-docs/index.tsx
+++ b/pages/api-docs/index.tsx
@@ -8,7 +8,6 @@ import Link from 'next/link';
 
 const ApiDoc = ({ spec }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const router = useRouter();
-  console.log(router.query);
   return Object.keys(router.query).length > 0 ? (
     <Box>
       <h2>Invaid Route</h2>

--- a/pages/api-docs/index.tsx
+++ b/pages/api-docs/index.tsx
@@ -1,11 +1,24 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
-
+import { Box } from 'theme-ui';
 import { createSwaggerSpec } from 'next-swagger-doc';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
 
 const ApiDoc = ({ spec }: InferGetStaticPropsType<typeof getStaticProps>) => {
-  return <SwaggerUI spec={spec} />;
+  const router = useRouter();
+  console.log(router.query);
+  return Object.keys(router.query).length > 0 ? (
+    <Box>
+      <h2>Invaid Route</h2>
+      <Link href="/api-docs">
+        <a title="See API docs">Go to the API docs.</a>
+      </Link>
+    </Box>
+  ) : (
+    <SwaggerUI spec={spec} />
+  );
 };
 
 export const getStaticProps: GetStaticProps = async ctx => {


### PR DESCRIPTION
Fix vulnerability query HTML injection can be done to swagger through query parameters. Force the user to access the route without query parameters. 

Added a middleware https://nextjs.org/docs/middleware that redirects any request with query parameters to non query parameters