### PR TITLE
Add check to see if abstain is the only vote

### DIFF
--- a/modules/polling/api/fetchTallyPlurality.ts
+++ b/modules/polling/api/fetchTallyPlurality.ts
@@ -46,10 +46,14 @@ export async function fetchTallyPlurality(
 
   const sorted = summedSupport.sort((prev, next) => (prev.mkrSupport.gt(next.mkrSupport) ? -1 : 1));
 
-  // The winner is the first option, unless the first option is "0" which is abstain
-  // in that case we pick the next option
   const winner =
-    sorted.length > 0
+    // first check if abstain is only option in sorted
+    // if so, then no winner, return null
+    sorted.length === 1 && sorted[0].optionId === '0'
+      ? null
+      : // otherwise the winner is the first option, unless the first option is "0" which is abstain
+      // in that case we pick the next option
+      sorted.length > 0
       ? sorted[0].optionId !== '0'
         ? sorted[0].optionId.toString()
         : sorted[1].optionId.toString()


### PR DESCRIPTION
### Link to Shortcut ticket:

https://app.shortcut.com/dux-makerdao/story/1045/if-abstain-is-the-only-vote-there-is-an-error

### What does this PR do?

Fix error that occurs if abstain is only vote in a poll

### Steps for testing:

Go to `/polling`, see latest poll added (all the way at bottom) has only abstain vote in it. No error occurs anymore.

### Screenshots (if relevant):
<img width="816" alt="Screen Shot 2022-03-07 at 3 02 31 PM" src="https://user-images.githubusercontent.com/5225766/157049927-4fc02749-3ec6-4bfb-8527-e746b365e283.png">

