### PR TITLE
Adding pagination

### DIFF
--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -99,7 +99,7 @@ export async function fetchDelegates(network?: SupportedNetworks): Promise<Deleg
   const delegatesInfo = await fetchDelegatesInformation(currentNetwork);
 
   const contracts = getContracts(networkNameToChainId(currentNetwork));
-  const executives = await getExecutiveProposals(currentNetwork);
+  const executives = await getExecutiveProposals(0, 10, currentNetwork);
   const delegates = await Promise.all(
     delegatesInfo.map(async delegate => {
       const votedSlate = await contracts.chief.votes(delegate.voteDelegateAddress);

--- a/modules/executive/api/analyzeSpell.ts
+++ b/modules/executive/api/analyzeSpell.ts
@@ -75,7 +75,8 @@ export const analyzeSpell = async (address: string, network: SupportedNetworks):
   const getApprovals = async () => {
     try {
       const approvals = await getChiefApprovals(address, network);
-      return approvals;
+
+      return approvals.toString();
     } catch (err) {
       return undefined;
     }

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -2,7 +2,7 @@ import { config } from 'lib/config';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import { fsCacheGet, fsCacheSet } from 'lib/fscache';
 import { fetchGitHubPage } from 'lib/github';
-import { CMSProposal, Proposal } from 'modules/executive/types';
+import { CMSProposal, Proposal, ProposalsAPIResponse } from 'modules/executive/types';
 import { parseExecutive } from './parseExecutive';
 import invariant from 'tiny-invariant';
 import { markdownToHtml } from 'lib/utils';
@@ -10,15 +10,10 @@ import { EXEC_PROPOSAL_INDEX } from '../executive.constants';
 import { analyzeSpell } from './analyzeSpell';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 
-export async function getExecutiveProposals(network?: SupportedNetworks): Promise<Proposal[]> {
-  const net = network ? network : DEFAULT_NETWORK.network;
-
-  // Use goerli as a Key for Goerli fork. In order to pick the the current executives
-  const currentNetwork = net === SupportedNetworks.GOERLIFORK ? SupportedNetworks.GOERLI : net;
-
-  const cacheKey = 'proposals';
+async function getGithubExecutives(network: SupportedNetworks): Promise<CMSProposal[]> {
+  const cacheKey = 'github-proposals';
   if (config.USE_FS_CACHE) {
-    const cachedProposals = fsCacheGet(cacheKey, currentNetwork);
+    const cachedProposals = fsCacheGet(cacheKey, network);
     if (cachedProposals) {
       return JSON.parse(cachedProposals);
     }
@@ -41,7 +36,7 @@ export async function getExecutiveProposals(network?: SupportedNetworks): Promis
       try {
         const proposalDoc = await (await fetch(proposalLink)).text();
 
-        return parseExecutive(proposalDoc, proposalIndex, proposalLink, currentNetwork);
+        return parseExecutive(proposalDoc, proposalIndex, proposalLink, network);
       } catch (e) {
         console.log(e);
         // Catch error and return null if failed fetching one proposal
@@ -54,8 +49,42 @@ export async function getExecutiveProposals(network?: SupportedNetworks): Promis
     .filter(x => !!x)
     .filter(x => x?.address !== ZERO_ADDRESS) as CMSProposal[];
 
+  const sortedProposals = filteredProposals
+    .sort((a, b) => new Date(b.date || '').getTime() - new Date(a.date || '').getTime())
+    .slice(0, 100);
+
+  if (config.USE_FS_CACHE) {
+    fsCacheSet(cacheKey, JSON.stringify(sortedProposals), network);
+  }
+
+  return sortedProposals;
+}
+
+export async function getExecutiveProposals(
+  start: number,
+  limit: number,
+  network?: SupportedNetworks
+): Promise<ProposalsAPIResponse> {
+  const net = network ? network : DEFAULT_NETWORK.network;
+
+  // Use goerli as a Key for Goerli fork. In order to pick the the current executives
+  const currentNetwork = net === SupportedNetworks.GOERLIFORK ? SupportedNetworks.GOERLI : net;
+
+  const cacheKey = `proposals-${start}-${limit}`;
+
+  if (config.USE_FS_CACHE) {
+    const cachedProposals = fsCacheGet(cacheKey, currentNetwork);
+    if (cachedProposals) {
+      return JSON.parse(cachedProposals);
+    }
+  }
+
+  const proposals = await getGithubExecutives(currentNetwork);
+
+  const subset = proposals.slice(start, start + limit);
+
   const analyzedProposals = await Promise.all(
-    filteredProposals.map(async p => {
+    subset.map(async p => {
       const spellData = await analyzeSpell(p.address, currentNetwork);
       return {
         ...p,
@@ -64,27 +93,35 @@ export async function getExecutiveProposals(network?: SupportedNetworks): Promis
     })
   );
 
-  const sortedProposals = analyzedProposals
-    .sort((a, b) => new Date(b.date || '').getTime() - new Date(a.date || '').getTime())
-    .slice(0, 100);
-
   if (config.USE_FS_CACHE) {
-    fsCacheSet(cacheKey, JSON.stringify(sortedProposals), currentNetwork);
+    fsCacheSet(cacheKey, JSON.stringify(analyzedProposals), currentNetwork);
   }
-  return sortedProposals;
+
+  return {
+    total: proposals.length,
+    proposals: analyzedProposals
+  };
 }
 
 export async function getExecutiveProposal(
   proposalId: string,
   network?: SupportedNetworks
 ): Promise<Proposal | null> {
-  const proposals = await getExecutiveProposals(network);
+  const net = network ? network : DEFAULT_NETWORK.network;
+
+  // Use goerli as a Key for Goerli fork. In order to pick the the current executives
+  const currentNetwork = net === SupportedNetworks.GOERLIFORK ? SupportedNetworks.GOERLI : net;
+
+  const proposals = await getGithubExecutives(currentNetwork);
+
   const proposal = proposals.find(proposal => proposal.key === proposalId || proposal.address === proposalId);
   if (!proposal) return null;
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
+  const spellData = await analyzeSpell(proposal.address, currentNetwork);
   const content = await markdownToHtml(proposal.about || '');
   return {
     ...proposal,
+    spellData,
     content
   };
 }

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -2,7 +2,7 @@ import { config } from 'lib/config';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import { fsCacheGet, fsCacheSet } from 'lib/fscache';
 import { fetchGitHubPage } from 'lib/github';
-import { CMSProposal, Proposal, ProposalsAPIResponse } from 'modules/executive/types';
+import { CMSProposal, Proposal } from 'modules/executive/types';
 import { parseExecutive } from './parseExecutive';
 import invariant from 'tiny-invariant';
 import { markdownToHtml } from 'lib/utils';
@@ -64,7 +64,7 @@ export async function getExecutiveProposals(
   start: number,
   limit: number,
   network?: SupportedNetworks
-): Promise<ProposalsAPIResponse> {
+): Promise<Proposal[]> {
   const net = network ? network : DEFAULT_NETWORK.network;
 
   // Use goerli as a Key for Goerli fork. In order to pick the the current executives
@@ -97,10 +97,7 @@ export async function getExecutiveProposals(
     fsCacheSet(cacheKey, JSON.stringify(analyzedProposals), currentNetwork);
   }
 
-  return {
-    total: proposals.length,
-    proposals: analyzedProposals
-  };
+  return analyzedProposals;
 }
 
 export async function getExecutiveProposal(

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -51,6 +51,7 @@ async function getGithubExecutives(network: SupportedNetworks): Promise<CMSPropo
 
   const sortedProposals = filteredProposals
     .sort((a, b) => new Date(b.date || '').getTime() - new Date(a.date || '').getTime())
+    .sort((a) => a.active ? -1 : 1) // Sort by active first
     .slice(0, 100);
 
   if (config.USE_FS_CACHE) {

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -51,7 +51,7 @@ async function getGithubExecutives(network: SupportedNetworks): Promise<CMSPropo
 
   const sortedProposals = filteredProposals
     .sort((a, b) => new Date(b.date || '').getTime() - new Date(a.date || '').getTime())
-    .sort((a) => a.active ? -1 : 1) // Sort by active first
+    .sort(a => (a.active ? -1 : 1)) // Sort by active first
     .slice(0, 100);
 
   if (config.USE_FS_CACHE) {

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -18,6 +18,7 @@ import { useExecutiveComments } from 'modules/comments/hooks/useExecutiveComment
 import CommentCount from 'modules/comments/components/CommentCount';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { useSpellData } from '../hooks/useSpellData';
+import { parseUnits } from 'ethers/lib/utils';
 
 type Props = {
   proposal: Proposal;
@@ -142,7 +143,7 @@ export default function ExecutiveOverviewCard({
                     m: 1
                   }}
                 >
-                  {formatValue(spellData?.mkrSupport, 'wad', 2)} MKR Supporting
+                  {formatValue(BigNumber.from(spellData?.mkrSupport), 'wad', 2)} MKR Supporting
                 </Badge>
               )}
             </Flex>

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -18,7 +18,6 @@ import { useExecutiveComments } from 'modules/comments/hooks/useExecutiveComment
 import CommentCount from 'modules/comments/components/CommentCount';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { useSpellData } from '../hooks/useSpellData';
-import { parseUnits } from 'ethers/lib/utils';
 
 type Props = {
   proposal: Proposal;

--- a/modules/executive/types/proposal.d.ts
+++ b/modules/executive/types/proposal.d.ts
@@ -15,3 +15,9 @@ export type CMSProposal = {
 export type Proposal = CMSProposal & {
   spellData: SpellData;
 };
+
+
+export type ProposalsAPIResponse = {
+  total: number,
+  proposals: Proposal[]
+}

--- a/modules/executive/types/proposal.d.ts
+++ b/modules/executive/types/proposal.d.ts
@@ -15,9 +15,3 @@ export type CMSProposal = {
 export type Proposal = CMSProposal & {
   spellData: SpellData;
 };
-
-
-export type ProposalsAPIResponse = {
-  total: number,
-  proposals: Proposal[]
-}

--- a/modules/executive/types/spellData.d.ts
+++ b/modules/executive/types/spellData.d.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 
 export type SpellData = {
   hasBeenCast?: boolean;
@@ -8,7 +7,7 @@ export type SpellData = {
   nextCastTime?: Date;
   datePassed?: Date;
   dateExecuted?: Date;
-  mkrSupport?: BigNumber;
+  mkrSupport?: string;
   executiveHash?: string;
   officeHours?: boolean;
 };

--- a/modules/executive/types/spellData.d.ts
+++ b/modules/executive/types/spellData.d.ts
@@ -1,4 +1,3 @@
-
 export type SpellData = {
   hasBeenCast?: boolean;
   hasBeenScheduled: boolean;

--- a/modules/home/components/ExecutiveIndicator.tsx
+++ b/modules/home/components/ExecutiveIndicator.tsx
@@ -58,7 +58,7 @@ const ExecutiveIndicatorComponent = ({
 
   const { account } = useAccount();
   const { data: votedProposals } = useVotedProposals();
-  
+
   const newUnvotedProposals =
     votedProposals && account
       ? unscheduledProposals.filter(

--- a/pages/api/executive/index.ts
+++ b/pages/api/executive/index.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { isSupportedNetwork } from 'modules/web3/helpers/networks';
 
 import { getExecutiveProposals } from 'modules/executive/api/fetchExecutives';
-import { CMSProposal, ProposalsAPIResponse } from 'modules/executive/types';
+import { Proposal } from 'modules/executive/types';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
 
@@ -65,7 +65,7 @@ import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
  *                   schema:
  *                     $ref: '#/definitions/ArrayOfExecutives'
  */
-export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<ProposalsAPIResponse>) => {
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<Proposal[]>) => {
   const network = (req.query.network as string) || DEFAULT_NETWORK.network;
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
   const start = req.query.start ? parseInt(req.query.start as string, 10) : 0;

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Heading, Box, Flex, Card, Text, Link as ThemeUILInk, Button } from 'theme-ui';
-import { GetServerSideProps } from 'next';
+import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
 import Link from 'next/link';
 import { BigNumber as BigNumberJS } from 'bignumber.js';
@@ -244,7 +244,7 @@ export default function DelegatesPage({ delegates, stats }: Props): JSX.Element 
   );
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const delegatesAPIResponse = await fetchDelegates();
 
   return {

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -422,14 +422,14 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
                   </Stack>
                   {isLoadingMore && (
                     <Box>
-                      <Box m={3}>
-                        <SkeletonThemed width={'100%'} height={'100px'} />
+                      <Box my={3}>
+                        <SkeletonThemed width={'100%'} height={'200px'} />
                       </Box>
-                      <Box m={3}>
-                        <SkeletonThemed width={'100%'} height={'100px'} />
+                      <Box my={3}>
+                        <SkeletonThemed width={'100%'} height={'200px'} />
                       </Box>
-                      <Box m={3}>
-                        <SkeletonThemed width={'100%'} height={'100px'} />
+                      <Box my={3}>
+                        <SkeletonThemed width={'100%'} height={'200px'} />
                       </Box>
                     </Box>
                   )}

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -202,7 +202,11 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
                 label="Spell Address"
               />
               <StatBox
-                value={spellData && spellData.mkrSupport && formatValue(spellData.mkrSupport, 'wad', 3)}
+                value={
+                  spellData &&
+                  spellData.mkrSupport &&
+                  formatValue(BigNumber.from(spellData.mkrSupport), 'wad', 3)
+                }
                 label="MKR Support"
               />
               <StatBox value={supporters && supporters.length} label="Supporters" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -329,7 +329,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     revalidate: 30, // allow revalidation every 30 seconds
     props: {
-      proposals: proposals.proposals.filter(i => i.active),
+      proposals: proposals.filter(i => i.active),
       polls: pollsData.polls,
       blogPosts
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -288,11 +288,11 @@ export default function Index({
     if (!isDefaultNetwork(network) && (!_polls || !_proposals)) {
       Promise.all([
         fetchJson(`/api/polling/all-polls?network=${network}`),
-        fetchJson(`/api/executive?network=${network}&active=true`)
+        fetchJson(`/api/executive?network=${network}`)
       ])
-        .then(([pollsData, proposals]) => {
+        .then(([pollsData, proposalsResponse]) => {
           setPolls(pollsData.polls);
-          setProposals(proposals);
+          setProposals(proposalsResponse.proposals.filter(p => p.active));
         })
         .catch(setError);
     }
@@ -321,7 +321,7 @@ export default function Index({
 export const getStaticProps: GetStaticProps = async () => {
   // fetch polls, proposals, blog posts at build-time
   const [proposals, pollsData, blogPosts] = await Promise.all([
-    getExecutiveProposals(),
+    getExecutiveProposals(0, 10),
     getPolls(),
     fetchBlogPosts()
   ]);
@@ -329,7 +329,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     revalidate: 30, // allow revalidation every 30 seconds
     props: {
-      proposals: proposals.filter(i => i.active),
+      proposals: proposals.proposals.filter(i => i.active),
       polls: pollsData.polls,
       blogPosts
     }


### PR DESCRIPTION
- We trying to fetch the spell data for the executives on the backend, because it was failing to load the executives page (big FE query that blocks the following requests)

We moved it to the backend, so the executives come with some of the spell data 

Why? 

Is used on the frontend by several components:
- sorting all the executives by MKR
- executive indicator uses all the proposals that have been scheduled 

The problem is that fetching all the spellData on the backend is blocking now the serverside rendering/static generation on the build, it takes a lot of time to do for all the executives.

This is a problem that will scalate over time, the more executives, the worse it gets.

## Short term solution:
- I'm adding a pagination to fetch 0-20 executives on the first load, and then allow the user to fetch more

## Better solution:
Our system should be able to aggregate that information asynchronously and the FE should be able to query by different states:

- Active executives, scheduled dates, and so on.

