### PR TITLE
account for dates in a different year in mkr delegation graph

### DIFF
--- a/modules/delegates/api/fetchMKRWeightHistory.ts
+++ b/modules/delegates/api/fetchMKRWeightHistory.ts
@@ -46,8 +46,13 @@ export async function fetchDelegatesMKRWeightHistory(
 
   for (let i = start; i <= end; i++) {
     const existingItem = addressData.filter(item => {
-      const day = formatIsoDateConversion(item.blockTimestamp);
-      if (day === i) {
+      const years = differenceInCalendarYears(
+        new Date(item.blockTimestamp),
+        new Date(addressData[0].blockTimestamp)
+      );
+      const dayOfYear = formatIsoDateConversion(item.blockTimestamp);
+      const dayNumber = dayOfYear + years * 365;
+      if (dayNumber === i) {
         return item;
       }
     });


### PR DESCRIPTION
### What does this PR do?
In the MKR delegate graph, properly account for events that are in a different calendar year
### Steps for testing:
View Flip Flap Flop's MKR weight over time graph.  It should show that it drops to ~17K, since that how much he has delegated to him now. Whereas production still shows ~30K.
### Screenshots (if relevant):
<img width="1044" alt="Screen Shot 2022-03-08 at 11 10 08 AM" src="https://user-images.githubusercontent.com/3388550/157308175-37d4fa3a-c413-4ddc-8444-52bd4bd726f7.png">