### PR TITLE
Add ranked choice indicator, fix mobile displays

### DIFF
--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { Text, Flex, Box, Button, Link as ThemeUILink, ThemeUIStyleObject, Divider, Badge } from 'theme-ui';
-
 import { isActivePoll } from 'modules/polling/helpers/utils';
 import Stack from '../../app/components/layout/layouts/Stack';
 import CountdownTimer from '../../app/components/CountdownTimer';
@@ -11,7 +11,6 @@ import QuickVote from './QuickVote';
 import { PollCategoryTag } from './PollCategoryTag';
 import { PollVotePluralityResultsCompact } from './PollVotePluralityResultsCompact';
 import { POLL_VOTE_TYPE } from '../polling.constants';
-
 import PollWinningOptionBox from './PollWinningOptionBox';
 import { formatDateWithTime } from 'lib/datetime';
 import { usePollTally } from '../hooks/usePollTally';
@@ -62,9 +61,17 @@ export default function PollOverviewCard({
               )}
               <Box sx={{ cursor: 'pointer' }}>
                 <Box>
-                  <Text as="p" variant="caps" sx={{ color: 'textSecondary', mb: 2 }}>
-                    Posted {formatDateWithTime(poll.startDate)} | Poll ID {poll.pollId}
-                  </Text>
+                  <Flex sx={{ justifyContent: 'space-between' }}>
+                    <Text as="p" variant="caps" sx={{ color: 'textSecondary', mb: 2 }}>
+                      Posted {formatDateWithTime(poll.startDate)} | Poll ID {poll.pollId}
+                    </Text>
+                    {poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && (
+                      <Flex sx={{ alignItems: 'center', mb: 3 }}>
+                        <Text variant="caps">Ranked-choice poll</Text>
+                        <Icon name="stackedVotes" size={3} ml={2} />
+                      </Flex>
+                    )}
+                  </Flex>
                   <Link href={`/polling/${poll.slug}`} passHref>
                     <ThemeUILink variant="nostyle" title="View Poll Details">
                       <Text

--- a/modules/polling/components/VoteBreakdown.tsx
+++ b/modules/polling/components/VoteBreakdown.tsx
@@ -2,12 +2,14 @@ import { Box, Text, Progress, Flex } from 'theme-ui';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import Tooltip from 'modules/app/components/Tooltip';
 import Delay from 'modules/app/components/Delay';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { PollTally, Poll, RankedChoiceResult, PluralityResult } from 'modules/polling/types';
 import { POLL_VOTE_TYPE } from 'modules/polling/polling.constants';
 import { getVoteColor } from 'modules/polling/helpers/getVoteColor';
 import { BigNumber as BigNumberJS } from 'bignumber.js';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
+
 export default function VoteBreakdown({
   poll,
   shownOptions,
@@ -20,9 +22,15 @@ export default function VoteBreakdown({
   if (poll.voteType === (POLL_VOTE_TYPE.RANKED_VOTE || POLL_VOTE_TYPE.UNKNOWN)) {
     return (
       <Box key={2} sx={{ p: [3, 4] }} data-testid="vote-breakdown">
-        <Text variant="microHeading" sx={{ display: 'block', mb: 3 }}>
-          Vote Breakdown
-        </Text>
+        <Flex sx={{ flexDirection: ['column', 'row'], justifyContent: 'space-between' }}>
+          <Text variant="microHeading" sx={{ display: 'block', mb: 3 }}>
+            Vote Breakdown
+          </Text>
+          <Flex sx={{ alignItems: 'center', mb: 3 }}>
+            <Text variant="caps">Ranked-choice poll</Text>
+            <Icon name="stackedVotes" size={3} ml={2} />
+          </Flex>
+        </Flex>
         {Object.keys(poll.options)
           .slice(0, shownOptions)
           .map((_, i) => {
@@ -31,9 +39,9 @@ export default function VoteBreakdown({
             const transfer = new BigNumberJS(tallyResult.transfer || 0);
             return (
               <div key={i}>
-                <Flex sx={{ justifyContent: 'space-between' }}>
+                <Flex sx={{ flexDirection: ['column', 'row'], justifyContent: 'space-between' }}>
                   {tallyResult ? (
-                    <Text as="p" sx={{ color: 'textSecondary', width: '20%', mr: 2 }}>
+                    <Text as="p" sx={{ color: 'textSecondary', mr: 2 }}>
                       {tallyResult.optionName}
                     </Text>
                   ) : (
@@ -129,7 +137,14 @@ export default function VoteBreakdown({
                 </Delay>
               )}
               {tally && tallyResult ? (
-                <Text as="p" sx={{ color: 'textSecondary', width: tally ? 'unset' : '30%' }}>
+                <Text
+                  as="p"
+                  sx={{
+                    color: 'textSecondary',
+                    width: tally ? 'unset' : '30%',
+                    textAlign: 'right'
+                  }}
+                >
                   {`${formatValue(parseUnits(tallyResult.mkrSupport.toString()))} MKR Voting (${formatValue(
                     parseUnits(tallyResult.firstPct.toString())
                   )}%)`}


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/818/add-ranked-choice-poll-indicator-to-vote-breakdown

### What does this PR do?

Add ranked-choice indicator to vote breakdown

Add ranked-choice indicator to poll overview

### Steps for testing:

Go to `http://localhost:3000/polling/QmYj6Wzd#vote-breakdown` and see indicator

### Screenshots (if relevant):
<img width="860" alt="Screen Shot 2022-03-09 at 1 05 47 PM" src="https://user-images.githubusercontent.com/5225766/157440840-240ba65f-7f66-4d1a-8014-2e3ff2dab2b0.png">
<img width="817" alt="Screen Shot 2022-03-10 at 9 12 46 AM" src="https://user-images.githubusercontent.com/5225766/157619304-8bd00201-7057-4207-a99f-6c863eee5aac.png">

