### PR TITLE
Sort executives on the server side

### DIFF
--- a/modules/app/stores/uiFilters.ts
+++ b/modules/app/stores/uiFilters.ts
@@ -20,8 +20,8 @@ type Store = {
   setShowPollActive: (showActive: boolean) => void;
   setShowPollEnded: (ended: boolean) => void;
   resetPollFilters: () => void;
-  executiveSortBy: 'Date Posted' | 'MKR Amount';
-  setExecutiveSortBy: (method: 'Date Posted' | 'MKR Amount') => void;
+  executiveSortBy: 'date' | 'mkr';
+  setExecutiveSortBy: (method: 'date' | 'mkr') => void;
 };
 
 const [useUiFiltersStore] = create<Store>((set, get) => ({
@@ -78,7 +78,7 @@ const [useUiFiltersStore] = create<Store>((set, get) => ({
     });
   },
 
-  executiveSortBy: 'Date Posted',
+  executiveSortBy: 'date',
 
   setExecutiveSortBy: sortMethod => {
     set({ executiveSortBy: sortMethod });

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -99,7 +99,7 @@ export async function fetchDelegates(network?: SupportedNetworks): Promise<Deleg
   const delegatesInfo = await fetchDelegatesInformation(currentNetwork);
 
   const contracts = getContracts(networkNameToChainId(currentNetwork));
-  const executives = await getExecutiveProposals(0, 10, currentNetwork);
+  const executives = await getExecutiveProposals(0, 10, 'date', currentNetwork);
   const delegates = await Promise.all(
     delegatesInfo.map(async delegate => {
       const votedSlate = await contracts.chief.votes(delegate.voteDelegateAddress);

--- a/modules/executive/api/analyzeSpell.ts
+++ b/modules/executive/api/analyzeSpell.ts
@@ -8,6 +8,15 @@ import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { getSpellContract } from 'modules/web3/helpers/getSpellContract';
 import { SpellData } from '../types';
 
+export const getExecutiveMKRSupport = async (
+  address: string,
+  network: SupportedNetworks
+): Promise<string> => {
+  const approvals = await getChiefApprovals(address, network);
+
+  return approvals.toString();
+};
+
 // executiveHash returns the hash of the executive proposal
 export const analyzeSpell = async (address: string, network: SupportedNetworks): Promise<SpellData> => {
   const spellContract = getSpellContract(address, network);
@@ -78,7 +87,7 @@ export const analyzeSpell = async (address: string, network: SupportedNetworks):
 
       return approvals.toString();
     } catch (err) {
-      return undefined;
+      return '0';
     }
   };
 

--- a/modules/executive/components/ProposalsSortBy.tsx
+++ b/modules/executive/components/ProposalsSortBy.tsx
@@ -12,24 +12,24 @@ export default function ProposalsSortBy(props): JSX.Element {
 
   return (
     <FilterButton
-      name={() => `Sort by ${executiveSortBy !== 'Date Posted' ? executiveSortBy : 'date'}`}
+      name={() => `Sort by ${executiveSortBy !== 'date' ? executiveSortBy : 'date'}`}
       listVariant="menubuttons.default.list"
       {...props}
     >
       <MenuItem
-        onSelect={() => setExecutiveSortBy('Date Posted')}
+        onSelect={() => setExecutiveSortBy('date')}
         sx={{
           variant: 'menubuttons.default.item',
-          fontWeight: executiveSortBy === 'Date Posted' ? 'bold' : undefined
+          fontWeight: executiveSortBy === 'date' ? 'bold' : undefined
         }}
       >
         Date Posted
       </MenuItem>
       <MenuItem
-        onSelect={() => setExecutiveSortBy('MKR Amount')}
+        onSelect={() => setExecutiveSortBy('mkr')}
         sx={{
           variant: 'menubuttons.default.item',
-          fontWeight: executiveSortBy === 'MKR Amount' ? 'bold' : undefined
+          fontWeight: executiveSortBy === 'mkr' ? 'bold' : undefined
         }}
       >
         MKR Amount

--- a/modules/executive/types/proposal.d.ts
+++ b/modules/executive/types/proposal.d.ts
@@ -10,6 +10,9 @@ export type CMSProposal = {
   title: string;
   date: string;
   proposalLink: string;
+  spellData: {
+    mkrSupport: string;
+  };
 };
 
 export type Proposal = CMSProposal & {

--- a/modules/executive/types/spellData.d.ts
+++ b/modules/executive/types/spellData.d.ts
@@ -6,7 +6,7 @@ export type SpellData = {
   nextCastTime?: Date;
   datePassed?: Date;
   dateExecuted?: Date;
-  mkrSupport?: string;
+  mkrSupport: string;
   executiveHash?: string;
   officeHours?: boolean;
 };

--- a/pages/api/executive/index.ts
+++ b/pages/api/executive/index.ts
@@ -70,8 +70,9 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse<P
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);
   const start = req.query.start ? parseInt(req.query.start as string, 10) : 0;
   const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20;
+  const sortBy = req.query.sortBy || 'date';
 
-  const response = await getExecutiveProposals(start, limit, network);
+  const response = await getExecutiveProposals(start, limit, sortBy as 'date' | 'mkr', network);
 
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
   res.status(200).json(response);

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -106,11 +106,15 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
   const { chiefOld } = useContracts() as MainnetSdk;
   const { data: mkrOnHat } = useMkrOnHat();
 
+  const [startDate, endDate, sortBy] = useUiFiltersStore(
+    state => [state.executiveFilters.startDate, state.executiveFilters.endDate, state.executiveSortBy],
+    shallow
+  );
   // Use SWRInfinite to do a loaded pagination of the proposals
   // Preload with the server side data as "fallback"
   const getKey = (pageIndex, previousPageData) => {
     if (previousPageData && !previousPageData.length) return null; // reached the end
-    return `/api/executive?network=${network}&start=${pageIndex * 10}&limit=10`; // SWR key
+    return `/api/executive?network=${network}&start=${pageIndex * 10}&limit=10&sortBy=${sortBy}`; // SWR key
   };
 
   const {
@@ -125,7 +129,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
     initialSize: 1,
     revalidateFirstPage: false,
     fallback: {
-      [`/api/executive?network=${network}&start=0&limit=10`]: proposals
+      [`/api/executive?network=${network}&start=0&limit=10&sortBy=${sortBy}`]: proposals
     }
   });
 
@@ -151,11 +155,6 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
 
   const votingForSomething = votedProposals && votedProposals.length > 0;
 
-  const [startDate, endDate, sortBy] = useUiFiltersStore(
-    state => [state.executiveFilters.startDate, state.executiveFilters.endDate, state.executiveSortBy],
-    shallow
-  );
-
   const prevSortByRef = useRef<string>(sortBy);
   useEffect(() => {
     if (sortBy !== prevSortByRef.current) {
@@ -167,22 +166,13 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
   const filteredProposals = useMemo(() => {
     const start = startDate && new Date(startDate);
     const end = endDate && new Date(endDate);
-    return (
-      (paginatedProposals?.flat() || []).filter(proposal => {
-        // filter out non-cms proposals for now
-        if (!('about' in proposal) || !('date' in proposal)) return false;
-        if (start && new Date(proposal.date).getTime() < start.getTime()) return false;
-        if (end && new Date(proposal.date).getTime() > end.getTime()) return false;
-        return true;
-      }) as Proposal[]
-    ).sort((a, b) => {
-      if (sortBy === 'MKR Amount') {
-        const bSupport = b.spellData ? b.spellData?.mkrSupport || 0 : 0;
-        const aSupport = a.spellData ? a.spellData?.mkrSupport || 0 : 0;
-        return BigNumber.from(bSupport).gt(BigNumber.from(aSupport)) ? 1 : -1;
-      }
-      return new Date(b.date).getTime() - new Date(a.date).getTime();
-    });
+    return (paginatedProposals?.flat() || []).filter(proposal => {
+      // filter out non-cms proposals for now
+      if (!('about' in proposal) || !('date' in proposal)) return false;
+      if (start && new Date(proposal.date).getTime() < start.getTime()) return false;
+      if (end && new Date(proposal.date).getTime() > end.getTime()) return false;
+      return true;
+    }) as Proposal[];
   }, [paginatedProposals, startDate, endDate, sortBy]);
 
   const { data: hat } = useHat();
@@ -534,7 +524,7 @@ export default function ExecutiveOverviewPage({
 
 export const getStaticProps: GetStaticProps = async () => {
   // fetch proposals at build-time if on the default network
-  const proposals = await getExecutiveProposals(0, 10);
+  const proposals = await getExecutiveProposals(0, 10, 'date');
 
   return {
     // revalidate: 30, // allow revalidation every 30 seconds

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -321,7 +321,7 @@ export default function Index({
 export const getStaticProps: GetStaticProps = async () => {
   // fetch polls, proposals, blog posts at build-time
   const [proposals, pollsData, blogPosts] = await Promise.all([
-    getExecutiveProposals(0, 10),
+    getExecutiveProposals(0, 10, 'date'),
     getPolls(),
     fetchBlogPosts()
   ]);


### PR DESCRIPTION
- Pass sortBy to the backend
- Each executive MKR support is fetched and catched so the pagination can use that data


## Future:

In the future we should be able to query those values without having to recache data