### PR TITLE
use new rules for decimal places

### DIFF
--- a/lib/string.ts
+++ b/lib/string.ts
@@ -15,7 +15,7 @@ const builtInUnits = ['wei', 'kwei', 'mwei', 'gwei', 'szabo', 'finney', 'ether']
 export function formatValue(
   value: BigNumber,
   type: string | number = 'wad',
-  dp = 6,
+  dp = 2,
   withCommas = true
 ): string {
   if (typeof type === 'string') {
@@ -31,6 +31,7 @@ export function formatValue(
     }
   }
   const formatted = formatUnits(value, type);
+  if (+formatted > 999) dp = 0;
   const fixed = dp || dp === 0 ? (+formatted).toFixed(dp) : formatted;
   const finished = withCommas ? commify(fixed) : fixed;
   return finished;

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -768,7 +768,7 @@ export default {
           />
         </g>
       ),
-      viewBox: '0 0 24 24'
+      viewBox: '0 0 20 18'
     },
     pencil: {
       path: (

--- a/modules/address/components/AddressDelegatedTo.tsx
+++ b/modules/address/components/AddressDelegatedTo.tsx
@@ -13,6 +13,8 @@ import { formatDateWithTime } from 'lib/datetime';
 import Tooltip from 'modules/app/components/Tooltip';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import AddressIconBox from './AddressIconBox';
+import { parseUnits } from 'ethers/lib/utils';
+import { formatValue } from 'lib/string';
 
 type CollapsableRowProps = {
   delegate: DelegationHistory;
@@ -58,7 +60,7 @@ const CollapsableRow = ({ delegate, network, bpi, totalDelegated }: CollapsableR
       </Flex>
       <Box as="td" sx={{ verticalAlign: 'top', pt: 2 }}>
         <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
-          {`${new BigNumber(lockAmount).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}
+          {`${formatValue(parseUnits(lockAmount))}${bpi > 0 ? ' MKR' : ''}`}
         </Text>
         {expanded && (
           <Flex sx={{ flexDirection: 'column' }}>
@@ -78,9 +80,9 @@ const CollapsableRow = ({ delegate, network, bpi, totalDelegated }: CollapsableR
                     <Icon name="increase" size={2} color="bull" />
                   )}
                   <Text key={blockTimestamp} variant="smallCaps" sx={{ pl: 2 }}>
-                    {`${new BigNumber(
-                      lockAmount.indexOf('-') === 0 ? lockAmount.substring(1) : lockAmount
-                    ).toFormat(2)}${bpi > 0 ? ' MKR' : ''}`}
+                    {`${formatValue(
+                      parseUnits(lockAmount.indexOf('-') === 0 ? lockAmount.substring(1) : lockAmount)
+                    )}${bpi > 0 ? ' MKR' : ''}`}
                   </Text>
                 </Flex>
               );

--- a/modules/address/components/AddressMKRDelegatedStats.tsx
+++ b/modules/address/components/AddressMKRDelegatedStats.tsx
@@ -29,7 +29,7 @@ export function AddressMKRDelegatedStats({
         styles={{
           textAlign: 'right'
         }}
-        value={totalMKRDelegated ? formatValue(BigNumber.from(totalMKRDelegated)) : '0.000'}
+        value={totalMKRDelegated ? totalMKRDelegated.toFixed(2) : '0.00'}
         label={'Total MKR Delegated'}
       />
     </Flex>

--- a/modules/app/components/SystemStatsSidebar.tsx
+++ b/modules/app/components/SystemStatsSidebar.tsx
@@ -64,7 +64,7 @@ export default function SystemStatsSidebar({
           <Text sx={{ fontSize: 3, color: 'textSecondary' }}>MKR in Chief</Text>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {chiefBalance ? (
-              `${formatValue(chiefBalance, 'wad', 0)} MKR`
+              `${formatValue(chiefBalance)} MKR`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />
@@ -104,7 +104,7 @@ export default function SystemStatsSidebar({
           <Text sx={{ fontSize: 3, color: 'textSecondary' }}>MKR needed to pass</Text>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {mkrOnHat ? (
-              `${formatValue(mkrOnHat, 'wad', 0)} MKR`
+              `${formatValue(mkrOnHat)} MKR`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />
@@ -142,7 +142,7 @@ export default function SystemStatsSidebar({
           <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Total Dai</Text>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {totalDai ? (
-              `${formatValue(totalDai, 'rad', 0)} DAI`
+              `${formatValue(totalDai, 'rad')} DAI`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />
@@ -161,7 +161,7 @@ export default function SystemStatsSidebar({
           <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Dai Debt Ceiling</Text>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {debtCeiling ? (
-              `${formatValue(debtCeiling, 'rad', 0)} DAI`
+              `${formatValue(debtCeiling, 'rad')} DAI`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />
@@ -180,7 +180,7 @@ export default function SystemStatsSidebar({
           <Text sx={{ fontSize: 3, color: 'textSecondary' }}>System Surplus</Text>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {systemSurplus ? (
-              `${formatValue(systemSurplus, 'rad', 0)} DAI`
+              `${formatValue(systemSurplus, 'rad')} DAI`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />

--- a/modules/delegates/components/DelegateCard.tsx
+++ b/modules/delegates/components/DelegateCard.tsx
@@ -188,7 +188,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                   sx={{ fontSize: [3, 5] }}
                   data-testid="total-mkr-delegated"
                 >
-                  {totalStaked ? formatValue(totalStaked) : '0.000'}
+                  {totalStaked ? formatValue(totalStaked) : '0.00'}
                 </Text>
                 <Text as="p" variant="secondary" color="onSecondary" sx={{ fontSize: [2, 3] }}>
                   Total MKR delegated
@@ -201,7 +201,7 @@ export function DelegateCard({ delegate }: PropTypes): React.ReactElement {
                   sx={{ fontSize: [3, 5] }}
                   data-testid="mkr-delegated-by-you"
                 >
-                  {mkrDelegated ? formatValue(mkrDelegated) : '0.000'}
+                  {mkrDelegated ? formatValue(mkrDelegated) : '0.00'}
                 </Text>
                 <Text as="p" variant="secondary" color="onSecondary" sx={{ fontSize: [2, 3] }}>
                   MKR delegated by you

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -38,7 +38,7 @@ export function DelegateMKRDelegatedStats({
         label={'Total Active Delegators'}
       />
       <StatBox
-        value={typeof mkrStaked !== 'undefined' ? formatValue(mkrStaked) : '0.000'}
+        value={typeof mkrStaked !== 'undefined' ? formatValue(mkrStaked) : '0.00'}
         label={'MKR Delegated by you'}
       />
     </Flex>

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -35,7 +35,7 @@ const formatTotalDelegated = (num: BigNumber, denom: BigNumber): string => {
     const denomB = new BigNumberJS(denom.toString());
 
     const weight = numB.div(denomB).times(100);
-    return formatValue(parseUnits(weight.toString()), 'wad', 2);
+    return formatValue(parseUnits(weight.toString()));
   } catch (e) {
     return '0.0';
   }

--- a/modules/delegates/components/DelegatesSystemInfo.tsx
+++ b/modules/delegates/components/DelegatesSystemInfo.tsx
@@ -42,7 +42,7 @@ export function DelegatesSystemInfo({
     {
       title: 'Total MKR delegated',
       id: 'total-mkr-system-info',
-      value: new BigNumber(stats.totalMKRDelegated).toFormat(2)
+      value: new BigNumber(stats.totalMKRDelegated).toFormat(0)
     },
     {
       title: 'Percent of MKR delegated',

--- a/modules/esm/components/ProgressRing.tsx
+++ b/modules/esm/components/ProgressRing.tsx
@@ -51,7 +51,7 @@ const ProgressRing = ({
           )}
         </text>
         <text x="50%" y="58%" textAnchor="middle" fill="#708390" fontSize="14px" dy=".3em">
-          {`of ${thresholdAmount ? `${formatValue(thresholdAmount, 'wad', 0)} MKR` : '---'}`}
+          {`of ${thresholdAmount ? `${formatValue(thresholdAmount)} MKR` : '---'}`}
         </text>
       </svg>
     </Flex>

--- a/modules/esm/components/ShutdownModal.tsx
+++ b/modules/esm/components/ShutdownModal.tsx
@@ -31,9 +31,9 @@ const ModalContent = ({
         Shutting down the Dai Credit System
       </Text>
       <Text variant="text" sx={{ mt: 3 }}>
-        The {thresholdAmount ? `${formatValue(thresholdAmount, 'wad', 0)}` : '---'} MKR limit for the
-        emergency shutdown module has been reached. By continuing past this alert, emergency shutdown will be
-        initiated for the Dai Credit System.
+        The {thresholdAmount ? `${formatValue(thresholdAmount)}` : '---'} MKR limit for the emergency shutdown
+        module has been reached. By continuing past this alert, emergency shutdown will be initiated for the
+        Dai Credit System.
       </Text>
       <Grid columns={2} mt={4}>
         <Button

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -143,7 +143,7 @@ export default function ExecutiveOverviewCard({
                     m: 1
                   }}
                 >
-                  {formatValue(BigNumber.from(spellData?.mkrSupport), 'wad', 2)} MKR Supporting
+                  {formatValue(BigNumber.from(spellData?.mkrSupport))} MKR Supporting
                 </Badge>
               )}
             </Flex>

--- a/modules/executive/helpers/getStatusText.ts
+++ b/modules/executive/helpers/getStatusText.ts
@@ -51,9 +51,7 @@ export const getStatusText = ({
   // not expired, passed, or executed, check support level
   if (!!spellData.mkrSupport && !!mkrOnHat) {
     return `${formatValue(
-      mkrOnHat.sub(spellData.mkrSupport),
-      'wad',
-      3
+      mkrOnHat.sub(spellData.mkrSupport)
     )} additional MKR support needed to pass. Expires at ${formatDateWithTime(spellData.expiration)}.`;
   }
 

--- a/modules/home/components/SystemStats.tsx
+++ b/modules/home/components/SystemStats.tsx
@@ -20,15 +20,15 @@ export default function SystemStats(): JSX.Element {
     },
     {
       title: 'Total Dai',
-      value: totalDai ? `${formatValue(totalDai, 'rad', 0)} DAI` : <Skeleton />
+      value: totalDai ? `${formatValue(totalDai, 'rad')} DAI` : <Skeleton />
     },
     {
       title: 'Dai Debt Ceiling',
-      value: debtCeiling ? `${formatValue(debtCeiling, 'rad', 0)} DAI` : <Skeleton />
+      value: debtCeiling ? `${formatValue(debtCeiling, 'rad')} DAI` : <Skeleton />
     },
     {
       title: 'System Surplus',
-      value: systemSurplus ? `${formatValue(systemSurplus, 'rad', 0)} DAI` : <Skeleton />
+      value: systemSurplus ? `${formatValue(systemSurplus, 'rad')} DAI` : <Skeleton />
     }
   ];
   return (

--- a/modules/mkr/components/MKRInput.tsx
+++ b/modules/mkr/components/MKRInput.tsx
@@ -18,7 +18,7 @@ export type MKRInputProps = {
 };
 
 export function MKRInput({
-  placeholder = '0.000 MKR',
+  placeholder = '0.000000 MKR',
   errorMaxMessage = 'MKR balance too low',
   onChange,
   min = BigNumber.from(0),

--- a/modules/mkr/components/MkrLiquiditySidebar.tsx
+++ b/modules/mkr/components/MkrLiquiditySidebar.tsx
@@ -117,9 +117,7 @@ export default function MkrLiquiditySidebar({
   ].sort((a, b) => (a[1] && b[1] ? ((a[1] as BigNumber).gt(b[1] as BigNumber) ? -1 : 1) : 0));
 
   const totalLiquidity = `${formatValue(
-    mkrPools.reduce((acc, cur) => acc.add((cur[1] as BigNumber) || 0), BigNumber.from(0)),
-    'wad',
-    0
+    mkrPools.reduce((acc, cur) => acc.add((cur[1] as BigNumber) || 0), BigNumber.from(0))
   )} MKR`;
 
   const PoolComponent = pool => {
@@ -159,7 +157,7 @@ export default function MkrLiquiditySidebar({
           </Flex>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {poolLiquidity ? (
-              `${formatValue(poolLiquidity, 'wad', 0)} MKR`
+              `${formatValue(poolLiquidity)} MKR`
             ) : (
               <Box sx={{ width: 6 }}>
                 <Skeleton />
@@ -186,7 +184,7 @@ export default function MkrLiquiditySidebar({
                   </Flex>
                   <Text variant="h2" sx={{ fontSize: 2, color: 'textSecondary' }}>
                     {subpoolLiquidity ? (
-                      `${formatValue(subpoolLiquidity, 'wad', 0)} MKR`
+                      `${formatValue(subpoolLiquidity)} MKR`
                     ) : (
                       <Box sx={{ width: 6 }}>
                         <Skeleton />

--- a/modules/polling/components/VoteBreakdown.tsx
+++ b/modules/polling/components/VoteBreakdown.tsx
@@ -56,9 +56,7 @@ export default function VoteBreakdown({
                       )} MKR Voting (${formatValue(
                         parseUnits(
                           new BigNumberJS(tallyResult.firstPct).plus(tallyResult.transferPct).toString()
-                        ),
-                        'wad',
-                        2
+                        )
                       )}%)`}
                     </Text>
                   ) : (
@@ -73,7 +71,7 @@ export default function VoteBreakdown({
                     <Tooltip
                       label={`First choice ${formatValue(
                         parseUnits(firstChoice.toString())
-                      )}; Transfer ${formatValue(parseUnits(transfer.toString()), 'wad', 2)}`}
+                      )}; Transfer ${formatValue(parseUnits(transfer.toString()))}`}
                     >
                       <Box my={2}>
                         <Box>
@@ -148,9 +146,7 @@ export default function VoteBreakdown({
                   }}
                 >
                   {`${formatValue(parseUnits(tallyResult.mkrSupport.toString()))} MKR Voting (${formatValue(
-                    parseUnits(tallyResult.firstPct.toString()),
-                    'wad',
-                    2
+                    parseUnits(tallyResult.firstPct.toString())
                   )}%)`}
                 </Text>
               ) : (

--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -67,7 +67,9 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
                   <Text
                     as="td"
                     sx={{ textAlign: 'right', pb: 2, fontSize: bpi < 1 ? 1 : 3 }}
-                  >{`${new BigNumber(v.mkrSupport).toFormat(3)}${bpi > 0 ? ' MKR' : ''}`}</Text>
+                  >{`${new BigNumber(v.mkrSupport).toFormat(new BigNumber(v.mkrSupport).gt(999) ? 0 : 2)}${
+                    bpi > 0 ? ' MKR' : ''
+                  }`}</Text>
                 </tr>
               ))}
             </>

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -207,11 +207,7 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
                 label="Spell Address"
               />
               <StatBox
-                value={
-                  spellData &&
-                  spellData.mkrSupport &&
-                  formatValue(BigNumber.from(spellData.mkrSupport), 'wad', 0)
-                }
+                value={spellData && spellData.mkrSupport && formatValue(BigNumber.from(spellData.mkrSupport))}
                 label="MKR Support"
               />
               <StatBox

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -380,7 +380,7 @@ const ProposalView = ({ proposal }: Props): JSX.Element => {
 
                         <Box sx={{ textAlign: 'right' }}>
                           <Text color="onSecondary">
-                            {supporter.percent}% ({new BigNumberJS(supporter.deposits).toFormat(3)} MKR)
+                            {supporter.percent}% ({new BigNumberJS(supporter.deposits).toFormat(2)} MKR)
                           </Text>
                         </Box>
                       </Flex>


### PR DESCRIPTION
### Link to Shortcut ticket:

### What does this PR do?

> 2 decimals whenever an MKR value is displayed (except for >999) and we want 6 decimals for inputs (eg delegate/u delegate and deposit/withdraw)
