### PR TITLE
Show pre-fetched proposals first

### DIFF
--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -141,7 +141,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
     }
   });
 
-  const isLoadingInitialData = !paginatedProposals && !paginatedProposals && !error;
+  const isLoadingInitialData = !proposals && !paginatedProposals && !error;
 
   const isLoadingMore =
     size > 0 && paginatedProposals && typeof paginatedProposals[size - 1] === 'undefined' && isValidating;

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -141,7 +141,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
     }
   });
 
-  const isLoadingInitialData = !paginatedProposals && !error;
+  const isLoadingInitialData = !paginatedProposals && !paginatedProposals && !error;
 
   const isLoadingMore =
     size > 0 && paginatedProposals && typeof paginatedProposals[size - 1] === 'undefined' && isValidating;
@@ -386,9 +386,6 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
 
               {isLoadingInitialData && (
                 <Box>
-                  <Box my={3}>
-                    <SkeletonThemed width={'100%'} height={'200px'} />
-                  </Box>
                   <Box my={3}>
                     <SkeletonThemed width={'100%'} height={'200px'} />
                   </Box>

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -115,6 +115,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
     ],
     shallow
   );
+
   // Use SWRInfinite to do a loaded pagination of the proposals
   // Preload with the server side data as "fallback"
   const getKey = (pageIndex, previousPageData) => {
@@ -171,8 +172,8 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
   }, [sortBy]);
 
   const flattenedProposals = useMemo(() => {
-    return paginatedProposals?.flat() || [];
-  }, [paginatedProposals]);
+    return paginatedProposals ? paginatedProposals.flat() : proposals || [];
+  }, [proposals, paginatedProposals]);
 
   const { data: hat } = useHat();
 


### PR DESCRIPTION
### Link to Shortcut ticket:

https://app.shortcut.com/dux-makerdao/story/1214/fix-exec-loading-time

### What does this PR do?

Shows pre-fetched proposals until paginated proposals are fetched
