### PR TITLE
fix/fallback data

### DIFF
--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -130,9 +130,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
     revalidateOnFocus: false,
     initialSize: 1,
     revalidateFirstPage: false,
-    fallback: {
-      [`/api/executive?network=${network}&start=0&limit=10&sortBy=${sortBy}`]: proposals
-    }
+    fallbackData: proposals
   });
 
   const isLoadingInitialData = !paginatedProposals && !error;
@@ -376,9 +374,6 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
 
               {isLoadingInitialData && (
                 <Box>
-                  <Box my={3}>
-                    <SkeletonThemed width={'100%'} height={'200px'} />
-                  </Box>
                   <Box my={3}>
                     <SkeletonThemed width={'100%'} height={'200px'} />
                   </Box>


### PR DESCRIPTION
- try pre-building a smaller amount of pages with static paths (#388) (#390)
- use fallbackData option to display pre-fetched execs before loading more

### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/1214/fix-exec-loading-time

### What does this PR do?
Update `fallback` option to `fallbackData`

### Any additional helpful information?:
[See this discussion](https://github.com/vercel/swr/issues/588#issuecomment-913485081)
[Docs](https://swr.vercel.app/docs/prefetching#pre-fill-data)