### PR TITLE
Reduce some calls to fetch MKR Support

### DIFF
--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -151,16 +151,20 @@ export async function getExecutiveProposal(
   // Use goerli as a Key for Goerli fork. In order to pick the the current executives
   const currentNetwork = net === SupportedNetworks.GOERLIFORK ? SupportedNetworks.GOERLI : net;
 
-  const proposals = await getGithubExecutivesWithMKR(currentNetwork);
+  const proposals = await getGithubExecutives(currentNetwork);
 
   const proposal = proposals.find(proposal => proposal.key === proposalId || proposal.address === proposalId);
   if (!proposal) return null;
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
+  const mkrSupport = await getExecutiveMKRSupport(proposal.address, currentNetwork);
   const spellData = await analyzeSpell(proposal.address, currentNetwork);
   const content = await markdownToHtml(proposal.about || '');
   return {
     ...proposal,
-    spellData,
+    spellData: {
+      ...spellData,
+      mkrSupport
+    },
     content
   };
 }


### PR DESCRIPTION
### Link to Shortcut ticket:

### What does this PR do?
Updates when we fetch spell data, including MKR support, when building the executive & executive detail pages. Only fetch it after filtering & slicing unneeded proposals so we don't make unnecessary requests.

### Steps for testing:
- load executive page, and/or exec detail pages to make sure build isn't broken and pages still load correctly with data
- hopefully we notice build failures are reduced and build times are faster

### Additional Info:
Two changes included in this PR. 
1.  The first affects the dynamic pages built with `executive/[slug]`. In this case for every executive page we were fetching every spell & checking the MKR support, even though we only care about the one we're building. I updated this to only fetch MKR support for the one, this should reduce a lot of calls made.
2. The second affects the `/executive` main page. Same issue as above, but in this case we can reduce the calls by sorting and filtering the proposals first, then fetching the MKR support on the subset. Except in the case of sorting by MKR. In this case we need to fetch the MKR support for each spell. A future optimization would be to fetch all the MKR support from the DB with a single call and match them with their proposal.