### PR TITLE
Fix/mkr locked delegate

### DIFF
--- a/cypress/integration/delegates.spec.ts
+++ b/cypress/integration/delegates.spec.ts
@@ -26,7 +26,7 @@ describe('Delegates Page', () => {
 
     setAccount(TEST_ACCOUNTS.normal, () => {
       // Shoudl find various delegates
-      cy.get('[data-testid="delegate-card"]').its('length').should('be.gte', 12).and('be.lessThan', 18);
+      cy.get('[data-testid="delegate-card"]').its('length').should('be.gte', 12).and('be.lessThan', 30);
     });
   });
 
@@ -34,7 +34,7 @@ describe('Delegates Page', () => {
     visitPage('/delegates');
     setAccount(TEST_ACCOUNTS.normal, () => {
       // Checks the total amount of delegates
-      cy.get('[data-testid="total-delegates-system-info"]').contains(/17/);
+      cy.get('[data-testid="total-delegates-system-info"]').contains(/25/);
       cy.get('[data-testid="total-recognized-delegates-system-info"]').contains('2');
       cy.get('[data-testid="total-shadow-delegates-system-info"]').contains(/15/);
       cy.get('[data-testid="total-mkr-system-info"]').contains('1,279');

--- a/modules/delegates/api/fetchChainDelegates.ts
+++ b/modules/delegates/api/fetchChainDelegates.ts
@@ -5,7 +5,6 @@ import { gqlRequest } from 'modules/gql/gqlRequest';
 import { allDelegates } from 'modules/gql/queries/allDelegates';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { getContracts } from 'modules/web3/helpers/getContracts';
-import { fetchDelegationEventsByAddresses } from './fetchDelegationEventsByAddresses';
 
 export async function fetchChainDelegates(
   network: SupportedNetworks
@@ -22,14 +21,11 @@ export async function fetchChainDelegates(
       // Get MKR delegated to each contract
       const mkr = await contracts.chief.deposits(delegate.voteDelegate);
 
-      const delegationEvents = await fetchDelegationEventsByAddresses([delegate.voteDelegate], network);
-
       const chainDelegate: DelegateContractInformation = {
         ...delegate,
         address: delegate.delegate,
         voteDelegateAddress: delegate.voteDelegate,
-        mkrDelegated: formatValue(mkr, 'wad', 18, false),
-        mkrLockedDelegate: delegationEvents
+        mkrDelegated: formatValue(mkr, 'wad', 18, false)
       };
 
       return chainDelegate;

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -69,6 +69,13 @@ export async function fetchDelegate(
     return Promise.resolve(undefined);
   }
 
+  const delegationEvents = await fetchDelegationEventsByAddresses(
+    [onChainDelegate.voteDelegateAddress],
+    network || SupportedNetworks.MAINNET
+  );
+
+  onChainDelegate.mkrLockedDelegate = delegationEvents;
+
   const { data: githubDelegate } = await fetchGithubDelegate(
     onChainDelegate.voteDelegateAddress,
     currentNetwork
@@ -106,6 +113,7 @@ export async function fetchDelegates(
 ): Promise<DelegatesAPIResponse> {
   const currentNetwork = network ? network : DEFAULT_NETWORK.network;
 
+  // This contains all the delegates including info merged with recognized delegates
   const delegatesInfo = await fetchDelegatesInformation(currentNetwork);
 
   const contracts = getContracts(networkNameToChainId(currentNetwork));
@@ -126,12 +134,18 @@ export async function fetchDelegates(
         votedProposals?.find(vp => vp.toLowerCase() === proposal?.address?.toLowerCase())
       );
 
+      // Filter the lock events to get only the ones for this delegate address
+      const mkrLockedDelegate = lockEvents.filter(
+        ({ immediateCaller }) => immediateCaller.toLowerCase() === delegate.voteDelegateAddress.toLowerCase()
+      );
+
       const lastVote = await fetchLastPollVote(delegate.voteDelegateAddress, currentNetwork);
       return {
         ...delegate,
         proposalsSupported,
         execSupported,
-        lastVoteDate: lastVote ? lastVote.blockTimestamp : null
+        lastVoteDate: lastVote ? lastVote.blockTimestamp : null,
+        mkrLockedDelegate
       };
     })
   );

--- a/modules/delegates/api/fetchDelegationEventsByAddresses.ts
+++ b/modules/delegates/api/fetchDelegationEventsByAddresses.ts
@@ -1,5 +1,5 @@
 import { gqlRequest } from 'modules/gql/gqlRequest';
-import { mkrLockedDelegateArray } from 'modules/gql/queries/mkrLockedDelegateArray';
+import { mkrLockedDelegateArrayTotals } from 'modules/gql/queries/mkrLockedDelegateArray';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { MKRLockedDelegateAPIResponse } from '../types';
@@ -11,7 +11,7 @@ export async function fetchDelegationEventsByAddresses(
   try {
     const data = await gqlRequest({
       chainId: networkNameToChainId(network),
-      query: mkrLockedDelegateArray,
+      query: mkrLockedDelegateArrayTotals,
       variables: {
         argAddress: addresses,
         argUnixTimeStart: 0,
@@ -19,7 +19,7 @@ export async function fetchDelegationEventsByAddresses(
       }
     });
 
-    const addressData: MKRLockedDelegateAPIResponse[] = data.mkrLockedDelegateArray.nodes;
+    const addressData: MKRLockedDelegateAPIResponse[] = data.mkrLockedDelegateArrayTotals.nodes;
 
     return addressData;
   } catch (e) {

--- a/modules/delegates/helpers/formatDelegationHistoryChart.ts
+++ b/modules/delegates/helpers/formatDelegationHistoryChart.ts
@@ -44,11 +44,11 @@ export const formatDelegationHistoryChart = (
     });
 
     if (existingItem && existingItem.length > 0) {
-      // If we have multiple items for the same day, use the final one because the lockTotal will be accurate.
+      // If we have multiple items for the same day, use the final one because the callerLockTotal will be accurate.
       const mostRecent = existingItem[existingItem.length - 1];
       output.push({
         date: subDays(new Date(), end - i),
-        MKR: new BigNumber(mostRecent.lockTotal).toNumber()
+        MKR: new BigNumber(mostRecent.callerLockTotal).toNumber()
       });
     } else {
       output.push({

--- a/modules/delegates/types/delegate.d.ts
+++ b/modules/delegates/types/delegate.d.ts
@@ -42,7 +42,7 @@ export type Delegate = {
   mkrDelegated: string;
   proposalsSupported: number;
   execSupported: CMSProposal | undefined;
-  mkrLockedDelegate: MKRLockedDelegateAPIResponse[];
+  mkrLockedDelegate?: MKRLockedDelegateAPIResponse[];
   blockTimestamp: string;
 };
 
@@ -60,10 +60,12 @@ export type DelegationHistoryEvent = {
 
 export type MKRLockedDelegateAPIResponse = {
   fromAddress: string;
+  immediateCaller: string;
   lockAmount: string;
   blockNumber: number;
   blockTimestamp: string;
   lockTotal: string;
+  callerLockTotal: string;
   hash: string;
 };
 

--- a/modules/delegates/types/delegate.d.ts
+++ b/modules/delegates/types/delegate.d.ts
@@ -42,7 +42,7 @@ export type Delegate = {
   mkrDelegated: string;
   proposalsSupported: number;
   execSupported: CMSProposal | undefined;
-  mkrLockedDelegate?: MKRLockedDelegateAPIResponse[];
+  mkrLockedDelegate: MKRLockedDelegateAPIResponse[];
   blockTimestamp: string;
 };
 

--- a/modules/gql/queries/mkrLockedDelegateArray.ts
+++ b/modules/gql/queries/mkrLockedDelegateArray.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
-export const mkrLockedDelegateArray = gql`
-  query mkrLockedDelegateArray($argAddress: [String]!, $argUnixTimeStart: Int!, $argUnixTimeEnd: Int!) {
-    mkrLockedDelegateArray(
+export const mkrLockedDelegateArrayTotals = gql`
+  query mkrLockedDelegateArrayTotals($argAddress: [String]!, $argUnixTimeStart: Int!, $argUnixTimeEnd: Int!) {
+    mkrLockedDelegateArrayTotals(
       argAddress: $argAddress
       unixtimeStart: $argUnixTimeStart
       unixtimeEnd: $argUnixTimeEnd
@@ -14,6 +14,7 @@ export const mkrLockedDelegateArray = gql`
         blockNumber
         blockTimestamp
         lockTotal
+        callerLockTotal
         hash
       }
     }


### PR DESCRIPTION
### What does this PR do?

- Removes a call to fetch lock events from inside a loop (when fetching all delegates) because we can fetch the events all at once with an array. 
- Updates other areas that depended on the original implementation

~~Blocked by this update to gov polling db, which must be merged first~~ merged: https://github.com/makerdao/gov-polling-db/pull/107/files