### PR TITLE
Refactor stats fetching to static props

### DIFF
--- a/modules/executive/api/fetchMkrInChief.ts
+++ b/modules/executive/api/fetchMkrInChief.ts
@@ -1,0 +1,15 @@
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { networkNameToChainId } from 'modules/web3/helpers/chain';
+import { getContracts } from 'modules/web3/helpers/getContracts';
+import { Tokens } from 'modules/web3/constants/tokens';
+import { BigNumber } from 'ethers';
+
+export async function fetchMkrInChief(network?: SupportedNetworks): Promise<BigNumber> {
+  const chainId = network ? networkNameToChainId(network) : networkNameToChainId(SupportedNetworks.MAINNET);
+  const contracts = getContracts(chainId, undefined, undefined, true);
+  const chiefAddress = await contracts.chief.address;
+  const tokenContract = contracts[Tokens.MKR];
+  const mkrInChief = await tokenContract.balanceOf(chiefAddress);
+
+  return mkrInChief;
+}

--- a/modules/executive/api/fetchMkrOnHat.ts
+++ b/modules/executive/api/fetchMkrOnHat.ts
@@ -1,0 +1,19 @@
+import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { networkNameToChainId } from 'modules/web3/helpers/chain';
+import { getContracts } from 'modules/web3/helpers/getContracts';
+import { getChiefApprovals } from 'modules/web3/api/getChiefApprovals';
+import { BigNumber } from 'ethers';
+
+type MkrOnHatResponse = {
+  hat: string;
+  mkrOnHat: BigNumber;
+};
+
+export async function fetchMkrOnHat(network?: SupportedNetworks): Promise<MkrOnHatResponse> {
+  const chainId = network ? networkNameToChainId(network) : networkNameToChainId(SupportedNetworks.MAINNET);
+  const contracts = getContracts(chainId, undefined, undefined, true);
+  const hat = await contracts.chief.hat();
+  const mkrOnHat = await getChiefApprovals(hat, network);
+
+  return { hat, mkrOnHat };
+}

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 import { BigNumber as BigNumberJS } from 'bignumber.js';
-import { BigNumber } from 'ethers';
-import { formatValue } from 'lib/string';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { Stats } from 'modules/home/components/Stats';
 import { Poll } from 'modules/polling/types';
@@ -13,8 +11,8 @@ type Props = {
   polls: Poll[];
   delegates: Delegate[];
   totalMKRDelegated: string;
-  mkrOnHat?: BigNumber;
-  mkrInChief?: BigNumber;
+  mkrOnHat?: string;
+  mkrInChief?: string;
 };
 
 export function GovernanceStats({
@@ -35,7 +33,7 @@ export function GovernanceStats({
   const infoUnits = [
     {
       title: 'MKR on Hat',
-      value: mkrOnHat ? `${formatValue(mkrOnHat)} MKR` : <Skeleton />
+      value: mkrOnHat ? `${mkrOnHat} MKR` : <Skeleton />
     },
     {
       title: 'Active Polls',
@@ -55,7 +53,7 @@ export function GovernanceStats({
     },
     {
       title: 'MKR in Chief',
-      value: mkrInChief ? `${formatValue(mkrInChief)} MKR` : <Skeleton />
+      value: mkrInChief ? `${mkrInChief} MKR` : <Skeleton />
     }
   ];
 


### PR DESCRIPTION
Moves mkr in chief and mkr in hat fetching to static props

This gets rid of some initial loading state on the home page and removes the page shifting