### PR TITLE
Refactor header badge calls

### DIFF
--- a/modules/app/components/layout/Header.tsx
+++ b/modules/app/components/layout/Header.tsx
@@ -177,7 +177,7 @@ const Header = ({ activePollCount, activeProposalsCount }: HeaderProps): JSX.Ele
             >
               Polling
             </NavLink>
-            {bpi > 1 && activePollCount && (
+            {bpi > 1 && activePollCount && activePollCount > 0 && (
               <NavLink href={'/polling'} title="View polling page" p={0}>
                 <Badge
                   variant="solidCircle"
@@ -208,7 +208,7 @@ const Header = ({ activePollCount, activeProposalsCount }: HeaderProps): JSX.Ele
             >
               Executive
             </NavLink>
-            {bpi > 1 && activeProposalsCount && (
+            {bpi > 1 && activeProposalsCount && activeProposalsCount > 0 && (
               <NavLink href={'/executive'} title="View executive page" p={0}>
                 <Badge
                   sx={{

--- a/modules/app/components/layout/layouts/Primary.tsx
+++ b/modules/app/components/layout/layouts/Primary.tsx
@@ -1,33 +1,41 @@
 import { Box, Flex, ThemeUIStyleObject } from 'theme-ui';
 import { fadeIn } from 'lib/keyframes';
+import Header from 'modules/app/components/layout/Header';
 import Footer from 'modules/home/components/Footer';
 
 type Props = {
+  activePollCount?: number;
+  activeProposalsCount?: number;
   fade?: boolean;
   sx?: ThemeUIStyleObject;
 };
 
 const PrimaryLayout = ({
+  activePollCount,
+  activeProposalsCount,
   children,
   fade = true,
   ...props
 }: React.PropsWithChildren<Props>): React.ReactElement => {
   return (
-    <Flex
-      sx={{
-        mx: 'auto',
-        width: '100%',
-        flexDirection: 'column',
-        minHeight: '100vh',
-        animation: fade ? `${fadeIn} 350ms ease` : undefined
-      }}
-      {...props}
-    >
-      <Box as="main" sx={{ width: '100%', flex: '1 1 auto', variant: 'layout.main' }}>
-        {children}
-      </Box>
-      <Footer />
-    </Flex>
+    <>
+      <Header activePollCount={activePollCount} activeProposalsCount={activeProposalsCount} />
+      <Flex
+        sx={{
+          mx: 'auto',
+          width: '100%',
+          flexDirection: 'column',
+          minHeight: '100vh',
+          animation: fade ? `${fadeIn} 350ms ease` : undefined
+        }}
+        {...props}
+      >
+        <Box as="main" sx={{ width: '100%', flex: '1 1 auto', variant: 'layout.main' }}>
+          {children}
+        </Box>
+        <Footer />
+      </Flex>
+    </>
   );
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,6 @@ import '@reach/tabs/styles.css';
 import '@reach/tooltip/styles.css';
 import { fetchJson } from 'lib/fetchJson';
 import theme from 'lib/theme';
-import Header from 'modules/app/components/layout/Header';
 import Cookies from 'modules/app/components/Cookies';
 import { AnalyticsProvider } from 'modules/app/client/analytics/AnalyticsContext';
 import { CookiesProvider } from 'modules/app/client/cookies/CookiesContext';
@@ -90,7 +89,6 @@ const MyApp = ({ Component, pageProps }: AppProps): React.ReactElement => {
                         overflowX: 'hidden'
                       }}
                     >
-                      <Header />
                       <Component {...pageProps} />
                       <Cookies />
                     </Flex>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,7 +92,7 @@ const LandingPage = ({
   const address = voteDelegateContractAddress || voteProxyContractAddress || account;
 
   // polls
-  const activePolls = useMemo(() => polls.filter(poll => isActivePoll(poll)).slice(0, 4), [polls]);
+  const activePolls = useMemo(() => polls.filter(poll => isActivePoll(poll)), [polls]);
   const pollCategories = getCategories(polls);
 
   // delegates
@@ -179,7 +179,11 @@ const LandingPage = ({
       />
       <VideoModal isOpen={videoOpen} onDismiss={() => setVideoOpen(false)} url={VIDEO_URLS.howToVote} />
       <StickyContainer>
-        <PrimaryLayout sx={{ maxWidth: 'page' }}>
+        <PrimaryLayout
+          activePollCount={activePolls.length}
+          activeProposalsCount={proposals.length}
+          sx={{ maxWidth: 'page' }}
+        >
           <Stack gap={[5, 6]} separationType="p">
             <section>
               <Flex sx={{ flexDirection: ['column', 'column', 'row'], justifyContent: 'space-between' }}>
@@ -259,7 +263,7 @@ const LandingPage = ({
               </Sticky>
               <Box ref={voteRef} />
               <Box sx={{ mt: 3 }}>
-                <PollsOverviewLanding activePolls={activePolls} allPolls={polls} />
+                <PollsOverviewLanding activePolls={activePolls.slice(0, 4)} allPolls={polls} />
               </Box>
               <PollCategoriesLanding pollCategories={pollCategories} />
             </section>


### PR DESCRIPTION
Moves poll and exec fetching out of header as this causes a lot of heavy requests

Instead we can use data fetching by static props

In order to do this, `<Header />` is moved out of `_app.tsx` and into the primary page layout (arguably where it belongs anyways IMO)