### PR TITLE
pass ref object into intersectionObserver

### DIFF
--- a/modules/app/hooks/useIntersectionObserver.tsx
+++ b/modules/app/hooks/useIntersectionObserver.tsx
@@ -1,13 +1,13 @@
-import { useEffect } from 'react';
+import { RefObject, useEffect } from 'react';
 
 export function useIntersectionObserver(
-  element: HTMLElement | null,
+  ref: RefObject<HTMLElement> | null,
   callback: () => void,
   rootMarging = '600px'
 ): void {
   useEffect(() => {
     let observer;
-    if (element) {
+    if (ref?.current) {
       observer = new IntersectionObserver(
         entries => {
           if (entries.pop()?.isIntersecting) {
@@ -16,12 +16,12 @@ export function useIntersectionObserver(
         },
         { root: null, rootMargin: rootMarging }
       );
-      observer.observe(element);
+      observer.observe(ref.current);
     }
     return () => {
-      if (element) {
-        observer?.unobserve(element);
+      if (ref?.current) {
+        observer?.unobserve(ref.current);
       }
     };
-  }, [element, callback]);
+  }, [ref, callback]);
 }

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -117,7 +117,7 @@ const PollingOverview = ({ polls, categories }: Props) => {
   };
 
   // Load more on scroll
-  useIntersectionObserver(loader.current, loadMore, '600px');
+  useIntersectionObserver(loader, loadMore);
 
   useEffect(() => {
     setNumHistoricalGroupingsLoaded(3); // reset inifite scroll if a new filter is applied


### PR DESCRIPTION
### What does this PR do?
Pass the loader reference into the intersectionObserver hook. Before, the ref wasn't updating, so it didn't trigger the loadMore function.
