### PR TITLE
POC to filter active polls at the gql level

### DIFF
--- a/modules/gql/gql.constants.ts
+++ b/modules/gql/gql.constants.ts
@@ -3,3 +3,9 @@ export const LOCAL_SPOCK_URL = 'http://localhost:3001/v1';
 export const GOERLI_SPOCK_URL = 'https://polling-db-goerli.makerdux.com/api/v1';
 export const STAGING_MAINNET_SPOCK_URL = 'https://polling-db-staging.makerdux.com/api/v1';
 export const MAINNET_SPOCK_URL = 'https://polling-db-prod.makerdux.com/api/v1';
+
+export enum QueryFilterNames {
+  Active = 'active',
+  PollId = 'pollId',
+  Range = 'range'
+}

--- a/modules/gql/gqlFilters.ts
+++ b/modules/gql/gqlFilters.ts
@@ -1,0 +1,7 @@
+export const queryFilters = {
+  active: { filter: { endDate: { greaterThanOrEqualTo: Math.floor(Date.now() / 1000) } } }
+};
+export const getQueryFilter = (filterName: string | undefined) => {
+  if (!filterName) return null;
+  return queryFilters[filterName];
+};

--- a/modules/gql/gqlFilters.ts
+++ b/modules/gql/gqlFilters.ts
@@ -1,7 +1,33 @@
-export const queryFilters = {
-  active: { filter: { endDate: { greaterThanOrEqualTo: Math.floor(Date.now() / 1000) } } }
+import { QueryFilterNames } from './gql.constants';
+import { PollsQuery, QueryFilterList } from './types';
+
+export const queryFilters: QueryFilterList = {
+  active: () => ({
+    filter: { endDate: { greaterThanOrEqualTo: Math.floor(Date.now() / 1000) } }
+  }),
+  range: (start, end) => ({
+    filter: {
+      and: [{ pollId: { greaterThanOrEqualTo: start } }, { pollId: { lessThanOrEqualTo: end } }]
+    }
+  }),
+  pollId: pollId => ({ filter: { pollId: { equalTo: pollId } } })
 };
-export const getQueryFilter = (filterName: string | undefined) => {
-  if (!filterName) return null;
-  return queryFilters[filterName];
+
+export const getQueryFilter = (filterName: QueryFilterNames | undefined, ...args: any): PollsQuery | null => {
+  if (filterName && queryFilters[filterName]) {
+    switch (filterName) {
+      case QueryFilterNames.Active:
+        return queryFilters.active();
+
+      case QueryFilterNames.Range:
+        return queryFilters.range(args[0], args[1]);
+
+      case QueryFilterNames.PollId:
+        return queryFilters.pollId(args[0]);
+
+      default:
+        break;
+    }
+  }
+  return null;
 };

--- a/modules/gql/gqlRequest.ts
+++ b/modules/gql/gqlRequest.ts
@@ -1,16 +1,19 @@
-import { request } from 'graphql-request';
+import { request, Variables, RequestDocument } from 'graphql-request';
 import { SupportedChainId } from 'modules/web3/constants/chainID';
 import { CHAIN_INFO } from 'modules/web3/constants/networks';
 
-export const gqlRequest = async ({
+type GqlRequestProps = {
+  chainId?: SupportedChainId;
+  query: RequestDocument;
+  variables?: Variables | null;
+};
+
+// TODO we'll be able to remove the "any" if we update all the instances of gqlRequest to pass <Query>
+export const gqlRequest = async <Query = any>({
   chainId,
   query,
   variables
-}: {
-  chainId?: SupportedChainId;
-  query: any;
-  variables?: Record<any, any>;
-}): Promise<any> => {
+}: GqlRequestProps): Promise<Query> => {
   const id = chainId ?? SupportedChainId.MAINNET;
   const url = CHAIN_INFO[id].spockUrl;
 

--- a/modules/gql/queries/filteredWhitelistedPolls.ts
+++ b/modules/gql/queries/filteredWhitelistedPolls.ts
@@ -1,0 +1,17 @@
+import { gql } from 'graphql-request';
+
+export const filteredWhitelistedPolls = gql`
+  query ActivePolls($endDate: Int) {
+    activePolls(filter: { endDate: { greaterThanOrEqualTo: $endDate } }) {
+      nodes {
+        creator
+        pollId
+        blockCreated
+        startDate
+        endDate
+        multiHash
+        url
+      }
+    }
+  }
+`;

--- a/modules/gql/queries/filteredWhitelistedPolls.ts
+++ b/modules/gql/queries/filteredWhitelistedPolls.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
 export const filteredWhitelistedPolls = gql`
-  query ActivePolls($endDate: Int) {
-    activePolls(filter: { endDate: { greaterThanOrEqualTo: $endDate } }) {
+  query ActivePolls($filter: ActivePollsRecordFilter) {
+    activePolls(filter: $filter) {
       nodes {
         creator
         pollId

--- a/modules/gql/types/index.d.ts
+++ b/modules/gql/types/index.d.ts
@@ -1,6 +1,19 @@
 import { ActivePollsRecordFilter } from '../generated/graphql';
 
+export type QueryFilterObject = Record<any, any>;
+export type QueryFilter<T> = T;
+
 // More filter types can be included here as we add them
 export type PollsQuery = {
   filter: ActivePollsRecordFilter;
+};
+
+export type ActiveQueryFn = () => PollsQuery;
+export type RangeQueryFn = (start: number, end: number) => PollsQuery;
+export type PollIdQueryFn = (pollId: number) => PollsQuery;
+
+export type QueryFilterList = {
+  active: ActiveQueryFn;
+  range: RangeQueryFn;
+  pollId: PollIdQueryFn;
 };

--- a/modules/gql/types/index.d.ts
+++ b/modules/gql/types/index.d.ts
@@ -1,0 +1,6 @@
+import { ActivePollsRecordFilter } from '../generated/graphql';
+
+// More filter types can be included here as we add them
+export type PollsQuery = {
+  filter: ActivePollsRecordFilter;
+};

--- a/modules/polling/api/fetchPollBy.ts
+++ b/modules/polling/api/fetchPollBy.ts
@@ -1,6 +1,8 @@
 import { config } from 'lib/config';
 import { fsCacheGet, fsCacheSet } from 'lib/fscache';
 import { markdownToHtml } from 'lib/markdown';
+import { QueryFilterNames } from 'modules/gql/gql.constants';
+import { getQueryFilter } from 'modules/gql/gqlFilters';
 // import { gqlRequest } from 'modules/gql/gqlRequest';
 // import { activePollByMultihash, activePollById } from 'modules/gql/queries/activePollBy';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
@@ -15,8 +17,9 @@ export async function fetchSpockPollById(
   pollId: number,
   network: SupportedNetworks
 ): Promise<PollSpock | undefined> {
-  const polls = await fetchSpockPolls(network);
-  return polls.find(poll => poll.pollId === pollId);
+  const filter = getQueryFilter(QueryFilterNames.PollId, pollId);
+  const [poll] = await fetchSpockPolls(network, filter);
+  return poll;
 
   // TODO : this is the new query
   // const data: PollSpock = await gqlRequest({

--- a/modules/polling/api/fetchPollBy.ts
+++ b/modules/polling/api/fetchPollBy.ts
@@ -1,51 +1,51 @@
 import { config } from 'lib/config';
 import { fsCacheGet, fsCacheSet } from 'lib/fscache';
 import { markdownToHtml } from 'lib/markdown';
-import { gqlRequest } from 'modules/gql/gqlRequest';
-import { activePollByMultihash, activePollById } from 'modules/gql/queries/activePollBy';
+// import { gqlRequest } from 'modules/gql/gqlRequest';
+// import { activePollByMultihash, activePollById } from 'modules/gql/queries/activePollBy';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
-import { networkNameToChainId } from 'modules/web3/helpers/chain';
+// import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { spockPollToPartialPoll } from '../helpers/parsePollMetadata';
 import { Poll } from '../types';
 import { PollSpock } from '../types/pollSpock';
 import { fetchPollMetadata } from './fetchPollMetadata';
-import { fetchAllSpockPolls } from './fetchPolls';
+import { fetchSpockPolls } from './fetchPolls';
 
 export async function fetchSpockPollById(
   pollId: number,
   network: SupportedNetworks
 ): Promise<PollSpock | undefined> {
-  const polls = await fetchAllSpockPolls(network);
+  const polls = await fetchSpockPolls(network);
   return polls.find(poll => poll.pollId === pollId);
 
   // TODO : this is the new query
-  const data: PollSpock = await gqlRequest({
-    chainId: networkNameToChainId(network),
-    query: activePollById,
-    variables: {
-      argPollId: pollId
-    }
-  });
+  // const data: PollSpock = await gqlRequest({
+  //   chainId: networkNameToChainId(network),
+  //   query: activePollById,
+  //   variables: {
+  //     argPollId: pollId
+  //   }
+  // });
 
-  return data;
+  // return data;
 }
 
 export async function fetchSpockPollBySlug(slug: string, network: SupportedNetworks): Promise<PollSpock> {
-  const polls = await fetchAllSpockPolls(network);
+  const polls = await fetchSpockPolls(network);
 
   const pollIndex = polls.findIndex(poll => poll.multiHash.slice(0, 8) === slug);
   return polls[pollIndex] as PollSpock;
 
   // TODO : This is the new query
-  const data: PollSpock = await gqlRequest({
-    chainId: networkNameToChainId(network),
-    query: activePollByMultihash,
-    variables: {
-      argPollMultihash: `${slug}%`
-    }
-  });
+  // const data: PollSpock = await gqlRequest({
+  //   chainId: networkNameToChainId(network),
+  //   query: activePollByMultihash,
+  //   variables: {
+  //     argPollMultihash: `${slug}%`
+  //   }
+  // });
 
-  return data;
+  // return data;
 }
 
 export async function fetchPollById(pollId: number, network: SupportedNetworks): Promise<Poll | null> {

--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -85,9 +85,12 @@ export async function fetchSpockPolls(
   return pollList as PollSpock[];
 }
 
-// Returns all the polls and caches them in the file system.
-export async function _getCachedPolls(network?: SupportedNetworks): Promise<Poll[] | null> {
-  const cacheKey = 'polls';
+
+export async function _getAllPolls(
+  network?: SupportedNetworks,
+  queryFilter?: PollsQuery | null
+): Promise<Poll[]> {
+  const cacheKey = `polls-${queryFilter ? JSON.stringify(queryFilter): 'all'}`;
 
   if (config.USE_FS_CACHE) {
     const cachedPolls = fsCacheGet(cacheKey, network);
@@ -95,15 +98,6 @@ export async function _getCachedPolls(network?: SupportedNetworks): Promise<Poll
       return JSON.parse(cachedPolls);
     }
   }
-
-  return null;
-}
-
-export async function _getAllPolls(
-  network?: SupportedNetworks,
-  queryFilter?: PollsQuery | null
-): Promise<Poll[]> {
-  const cacheKey = 'polls';
 
   const pollList = await fetchSpockPolls(network || DEFAULT_NETWORK.network, queryFilter);
 
@@ -128,8 +122,7 @@ export async function getPolls(
   network?: SupportedNetworks,
   filterName?: QueryFilterNames
 ): Promise<PollsResponse> {
-  const cachedPolls = await _getCachedPolls(network);
-  const allPolls = cachedPolls ?? (await _getAllPolls(network, getQueryFilter(filterName)));
+  const allPolls = await _getAllPolls(network, getQueryFilter(filterName));
 
   const filteredPolls = allPolls.filter(poll => {
     // check date filters first

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -486,12 +486,11 @@ export default function ExecutiveOverviewPage({
 }
 
 export const getStaticProps: GetStaticProps = async () => {
-  const endDate = Math.floor(Date.now() / 1000);
   // fetch proposals at build-time if on the default network
   const EXEC_PAGE_SIZE = 10;
   const [proposals, polls] = await Promise.all([
     getExecutiveProposals(0, EXEC_PAGE_SIZE, 'active'),
-    getPolls(undefined, SupportedNetworks.MAINNET, endDate)
+    getPolls(undefined, SupportedNetworks.MAINNET, 'active')
   ]);
 
   const activePollCount = polls.polls.length;

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -51,6 +51,7 @@ import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
 import useSWRInfinite from 'swr/infinite';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { getPolls } from 'modules/polling/api/fetchPolls';
+import { SupportedNetworks } from 'modules/web3/constants/networks';
 
 const MigrationBadge = ({ children, py = [2, 3] }) => (
   <Badge
@@ -485,14 +486,15 @@ export default function ExecutiveOverviewPage({
 }
 
 export const getStaticProps: GetStaticProps = async () => {
+  const endDate = Math.floor(Date.now() / 1000);
   // fetch proposals at build-time if on the default network
   const EXEC_PAGE_SIZE = 10;
   const [proposals, polls] = await Promise.all([
     getExecutiveProposals(0, EXEC_PAGE_SIZE, 'active'),
-    getPolls()
+    getPolls(undefined, SupportedNetworks.MAINNET, endDate)
   ]);
 
-  const activePollCount = polls.polls.filter(poll => isActivePoll(poll)).length;
+  const activePollCount = polls.polls.length;
 
   return {
     revalidate: 60 * 30, // allow revalidation every half an hour in seconds

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -52,6 +52,7 @@ import useSWRInfinite from 'swr/infinite';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { getPolls } from 'modules/polling/api/fetchPolls';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { QueryFilterNames } from 'modules/gql/gql.constants';
 
 const MigrationBadge = ({ children, py = [2, 3] }) => (
   <Badge
@@ -490,7 +491,7 @@ export const getStaticProps: GetStaticProps = async () => {
   const EXEC_PAGE_SIZE = 10;
   const [proposals, polls] = await Promise.all([
     getExecutiveProposals(0, EXEC_PAGE_SIZE, 'active'),
-    getPolls(undefined, SupportedNetworks.MAINNET, 'active')
+    getPolls(undefined, SupportedNetworks.MAINNET, QueryFilterNames.Active)
   ]);
 
   const activePollCount = polls.polls.length;


### PR DESCRIPTION
### Link to Shortcut ticket:

### What does this PR do?

Adds better support for using graphql filters with our requests. We can now create filters using the `ActivePollsRecordFilter` schema in (`/generated`) and pass to our graphql requests.
To add a new filter follow the pattern in `gqlFilters.ts` and add the type.