### PR TITLE
make subheader active item border green

### DIFF
--- a/modules/home/components/TabsNavigation.tsx
+++ b/modules/home/components/TabsNavigation.tsx
@@ -41,7 +41,8 @@ export default function TabsNavigation({ activeTab }: { activeTab: string }): Re
               key={`link-${link.href}`}
               sx={{
                 ml: [2, 4],
-                mr: [2, 4]
+                mr: [2, 4],
+                mb: '-1px'
               }}
             >
               <a
@@ -57,11 +58,12 @@ export default function TabsNavigation({ activeTab }: { activeTab: string }): Re
                 <Box
                   sx={{
                     borderBottom: activeTab === link.href ? '1px solid' : 'none',
-                    borderColor: 'onBackground',
+                    borderColor: activeTab === link.href ? 'primary' : 'onBackground',
                     pb: 2,
                     pt: 1,
                     '&:hover': {
-                      borderBottom: '1px solid'
+                      borderBottom: '1px solid',
+                      borderColor: 'primary'
                     }
                   }}
                 >


### PR DESCRIPTION
### What does this PR do?
Makes the active and hover bottom border of the subheader the primary color

### Screenshots (if relevant):
![Screen Shot 2022-05-05 at 6 00 39 PM](https://user-images.githubusercontent.com/13105602/167045999-df86a612-9cb1-49a3-935a-42b5bde762d6.png)

