### PR TITLE
filter comments by txHash when fetching them instead of when saving them

### DIFF
--- a/modules/comments/api/getExecutiveComments.ts
+++ b/modules/comments/api/getExecutiveComments.ts
@@ -62,5 +62,5 @@ export async function getExecutiveComments(
 
   const response = await Promise.all(promises);
 
-  return response as ExecutiveCommentsAPIResponseItem[];
+  return response.filter(i => i.isValid) as ExecutiveCommentsAPIResponseItem[];
 }

--- a/modules/comments/api/getPollComments.ts
+++ b/modules/comments/api/getPollComments.ts
@@ -5,6 +5,9 @@ import invariant from 'tiny-invariant';
 import { PollComment, PollCommentFromDB, PollCommentsAPIResponseItem } from '../types/comments';
 import uniqBy from 'lodash/uniqBy';
 import { markdownToHtml } from 'lib/markdown';
+import { networkNameToChainId } from 'modules/web3/helpers/chain';
+import { getRPCFromChainID } from 'modules/web3/helpers/getRPC';
+import { ethers } from 'ethers';
 export async function getPollComments(
   pollId: number,
   network: SupportedNetworks
@@ -35,10 +38,18 @@ export async function getPollComments(
   // only return the latest comment from each address
   const uniqueComments = uniqBy(comments, 'voterAddress');
 
+  const rpcUrl = getRPCFromChainID(networkNameToChainId(network));
+  const provider = await new ethers.providers.JsonRpcProvider(rpcUrl);
   const promises = uniqueComments.map(async (comment: PollComment) => {
+    // verify tx ownership
+    const { from } = await provider.getTransaction(comment.txHash as string);
+
+    const isValid =
+      ethers.utils.getAddress(from).toLowerCase() ===
+      ethers.utils.getAddress(comment.hotAddress).toLowerCase();
     return {
       comment,
-
+      isValid,
       address: await getAddressInfo(comment.voterAddress, network)
     };
   });

--- a/modules/comments/api/getPollComments.ts
+++ b/modules/comments/api/getPollComments.ts
@@ -56,5 +56,5 @@ export async function getPollComments(
 
   const response = await Promise.all(promises);
 
-  return response as PollCommentsAPIResponseItem[];
+  return response.filter(i => i.isValid) as PollCommentsAPIResponseItem[];
 }

--- a/modules/comments/api/verifyCommentParameters.ts
+++ b/modules/comments/api/verifyCommentParameters.ts
@@ -3,7 +3,6 @@ import { SupportedNetworks } from 'modules/web3/constants/networks';
 import invariant from 'tiny-invariant';
 import { getNonce, removeNonces } from './nonce';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
-import { getRPCFromChainID } from 'modules/web3/helpers/getRPC';
 import { getContracts } from 'modules/web3/helpers/getContracts';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 
@@ -18,23 +17,12 @@ export async function verifyCommentParameters(
   invariant(network && network.length > 0, 'Network not supported');
   invariant(txHash && txHash.length > 0, 'Missing verification data');
 
-  const rpcUrl = getRPCFromChainID(networkNameToChainId(network));
-  const provider = await new ethers.providers.JsonRpcProvider(rpcUrl);
-
   // Check nonce exist in db
   // Returns the address + uuid
   const nonceDB = await getNonce(hotAddress);
 
   // Missing nonce means that someone is trying to send a message without the api generating a valid nonce first
   invariant(!!nonceDB, 'Invalid data');
-
-  // verify tx ownership
-  const { from } = await provider.getTransaction(txHash);
-
-  invariant(
-    ethers.utils.getAddress(from).toLowerCase() === ethers.utils.getAddress(hotAddress).toLowerCase(),
-    "invalid 'from' address"
-  );
 
   // verify signature ownership and check that the signed nonce corresponds to the one in db
   invariant(


### PR DESCRIPTION
We were checking that the txHash was correct when saving a comment, but since some people can put a really slow tx, we might want to verify the txHash when fetching the comments. 

We should test if this is enough or we need to do more changes

Comments are still saved on txPending