### PR TITLE
add option tooltip to statsbox and include tooltips for account/addre…

### DIFF
--- a/modules/address/components/AddressMKRDelegatedStats.tsx
+++ b/modules/address/components/AddressMKRDelegatedStats.tsx
@@ -1,7 +1,10 @@
-import { Flex } from 'theme-ui';
+import { Box, Flex } from 'theme-ui';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { StatBox } from 'modules/app/components/StatBox';
 import { useMKRVotingWeight } from 'modules/mkr/hooks/useMKRVotingWeight';
 import { formatValue } from 'lib/string';
+import Tooltip from 'modules/app/components/Tooltip';
+import { getDescription } from 'modules/polling/components/VotingWeight';
 
 export function AddressMKRDelegatedStats({
   totalMKRDelegated,
@@ -22,7 +25,17 @@ export function AddressMKRDelegatedStats({
         marginBottom: 1
       }}
     >
-      <StatBox value={votingWeight ? formatValue(votingWeight.total) : '0.000'} label={'Total MKR Balance'} />
+      <StatBox
+        value={votingWeight ? formatValue(votingWeight.total) : '0.000'}
+        label={'Total MKR Balance'}
+        tooltip={
+          <Tooltip label={getDescription({ votingWeight, isDelegate: false })}>
+            <Box>
+              <Icon sx={{ ml: 1 }} name="question" />
+            </Box>
+          </Tooltip>
+        }
+      />
 
       <StatBox
         styles={{

--- a/modules/app/components/StatBox.tsx
+++ b/modules/app/components/StatBox.tsx
@@ -5,9 +5,10 @@ type Props = {
   value?: string | JSX.Element;
   label: string;
   styles?: ThemeUIStyleObject;
+  tooltip?: string | JSX.Element;
 };
 
-export const StatBox = ({ value, label, styles }: Props): JSX.Element => {
+export const StatBox = ({ value, label, tooltip, styles }: Props): JSX.Element => {
   return (
     <Flex
       sx={{
@@ -35,15 +36,18 @@ export const StatBox = ({ value, label, styles }: Props): JSX.Element => {
           </Box>
         )}
       </Box>
-      <Text
-        as="p"
-        sx={{
-          color: 'secondaryEmphasis',
-          fontSize: [1, 3]
-        }}
-      >
-        {label}
-      </Text>
+      <Flex sx={{ alignItems: 'center' }}>
+        <Text
+          as="p"
+          sx={{
+            color: 'secondaryEmphasis',
+            fontSize: [1, 3]
+          }}
+        >
+          {label}
+        </Text>
+        {tooltip}
+      </Flex>
     </Flex>
   );
 };

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -1,11 +1,15 @@
 import BigNumber from 'bignumber.js';
-import { Flex } from 'theme-ui';
+import { Box, Flex } from 'theme-ui';
+import { Icon } from '@makerdao/dai-ui-icons';
 import { useMkrDelegated } from 'modules/mkr/hooks/useMkrDelegated';
 import { Delegate } from 'modules/delegates/types';
 import { StatBox } from 'modules/app/components/StatBox';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
+import Tooltip from 'modules/app/components/Tooltip';
+import { getDescription } from 'modules/polling/components/VotingWeight';
+import { useMKRVotingWeight } from 'modules/mkr/hooks/useMKRVotingWeight';
 
 export function DelegateMKRDelegatedStats({
   delegate,
@@ -18,6 +22,7 @@ export function DelegateMKRDelegatedStats({
   // TODO: Fetch addresses suporting through API fetching
 
   const { data: mkrStaked } = useMkrDelegated(account, delegate.voteDelegateAddress);
+  const { data: votingWeight } = useMKRVotingWeight(delegate.voteDelegateAddress);
 
   return (
     <Flex
@@ -32,6 +37,13 @@ export function DelegateMKRDelegatedStats({
       <StatBox
         value={formatValue(parseUnits(delegate.mkrDelegated)) ?? 'Untracked'}
         label={'Total MKR Delegated'}
+        tooltip={
+          <Tooltip label={getDescription({ votingWeight, isDelegate: true })}>
+            <Box>
+              <Icon sx={{ ml: 1 }} name="question" />
+            </Box>
+          </Tooltip>
+        }
       />
       <StatBox
         value={typeof delegatorCount !== 'undefined' ? new BigNumber(delegatorCount).toFormat(0) : '--'}


### PR DESCRIPTION
### What does this PR do?
- Adds an optional tooltip prop to the StatsBox
- Passes a voting weight breakdown tooltip to account/address stats box

### Screenshots (if relevant):
![Screen Shot 2022-05-26 at 3 15 14 PM](https://user-images.githubusercontent.com/13105602/170762821-52227f9b-a2d0-4c89-ae3c-b678fe9e0401.png)
