### PR TITLE
use grey for ranked choice voter visual

### DIFF
--- a/modules/comments/components/PollCommentItem.tsx
+++ b/modules/comments/components/PollCommentItem.tsx
@@ -8,6 +8,7 @@ import { PollCommentsAPIResponseItemWithWeight } from '../types/comments';
 import CommentItem from './CommentItem';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
+import { RankedChoiceVoteSummary } from 'modules/polling/components/RankedChoiceVoteSummary';
 
 export default function PollCommentItem({
   comment,
@@ -46,9 +47,9 @@ export default function PollCommentItem({
           {poll.options[commentVote.optionId]}
         </Text>
       ) : (
-        (commentVote.rankedChoiceOption || [])
-          .map((choice, index) => `${index + 1} - ${poll.options[choice]}`)
-          .join(', ')
+        <Box>
+          <RankedChoiceVoteSummary choices={commentVote.rankedChoiceOption || []} poll={poll} />
+        </Box>
       );
 
     return (

--- a/modules/delegates/hooks/useDelegateAddressMap.ts
+++ b/modules/delegates/hooks/useDelegateAddressMap.ts
@@ -14,6 +14,8 @@ export const useDelegateAddressMap = (): DelegateAddressMapResponse => {
   const dataKey = `/api/delegates/names?network=${network}`;
 
   const { data: delegates, error } = useSWR<Delegate[]>(dataKey, null, {
+    // refresh every 30 mins
+    refreshInterval: 1800000,
     revalidateIfStale: false,
     revalidateOnFocus: false,
     revalidateOnMount: !cache.get(dataKey),

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -24,6 +24,7 @@ import { usePollComments } from 'modules/comments/hooks/usePollComments';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
 import useUiFiltersStore from 'modules/app/stores/uiFilters';
+import { RankedChoiceVoteSummary } from './RankedChoiceVoteSummary';
 
 type Props = {
   poll: Poll;
@@ -201,41 +202,48 @@ export default function PollOverviewCard({
                   </Box>
                 )}
 
-                {poll.voteType === POLL_VOTE_TYPE.PLURALITY_VOTE && (
-                  <Box sx={{ width: bpi > 0 ? '265px' : '100%', p: bpi > 0 ? 0 : 2 }}>
-                    {tally && tally.totalMkrParticipation > 0 && (
-                      <InternalLink
-                        href={`/polling/${poll.slug}`}
-                        hash="vote-breakdown"
-                        title="View poll vote breakdown"
-                      >
-                        <Box sx={{ mt: 3 }}>
-                          <ErrorBoundary componentName="Poll Results">
+                <Box sx={{ width: bpi > 0 ? '265px' : '100%', p: bpi > 0 ? 0 : 2 }}>
+                  {tally && tally.totalMkrParticipation > 0 && (
+                    <InternalLink
+                      href={`/polling/${poll.slug}`}
+                      hash="vote-breakdown"
+                      title="View poll vote breakdown"
+                    >
+                      <Box sx={{ mt: 3 }}>
+                        <ErrorBoundary componentName="Poll Results">
+                          {poll.voteType === POLL_VOTE_TYPE.PLURALITY_VOTE && (
                             <PollVotePluralityResultsCompact tally={tally} showTitles={false} />
-                          </ErrorBoundary>
-                        </Box>
-                      </InternalLink>
-                    )}
-                    {!tally && isValidating && !errorTally && (
-                      <SkeletonThemed width={'265px'} height={'30px'} />
-                    )}
-                    {errorTally && !isValidating && (
-                      <Badge
-                        variant="warning"
-                        sx={{
-                          color: 'warning',
-                          borderColor: 'warning',
-                          textTransform: 'uppercase',
-                          display: 'inline-flex',
-                          alignItems: 'center',
-                          m: 1
-                        }}
-                      >
-                        Error loading votes
-                      </Badge>
-                    )}
-                  </Box>
-                )}
+                          )}
+                          {poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE && (
+                            <RankedChoiceVoteSummary
+                              choices={tally.results.map(i => parseInt(i.optionId))}
+                              poll={poll}
+                              limit={3}
+                            />
+                          )}
+                        </ErrorBoundary>
+                      </Box>
+                    </InternalLink>
+                  )}
+                  {!tally && isValidating && !errorTally && (
+                    <SkeletonThemed width={'265px'} height={'30px'} />
+                  )}
+                  {errorTally && !isValidating && (
+                    <Badge
+                      variant="warning"
+                      sx={{
+                        color: 'warning',
+                        borderColor: 'warning',
+                        textTransform: 'uppercase',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        m: 1
+                      }}
+                    >
+                      Error loading votes
+                    </Badge>
+                  )}
+                </Box>
               </Flex>
             </Box>
 

--- a/modules/polling/components/PollVoteHistoryItem.tsx
+++ b/modules/polling/components/PollVoteHistoryItem.tsx
@@ -10,6 +10,7 @@ import { usePollTally } from '../hooks/usePollTally';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { getVoteColor } from '../helpers/getVoteColor';
 import { limitString } from 'lib/string';
+import { RankedChoiceVoteSummary } from './RankedChoiceVoteSummary';
 
 export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.ReactElement {
   const voteDate = formatDateWithTime(vote.blockTimestamp);
@@ -94,16 +95,11 @@ export function PollVoteHistoryItem({ vote }: { vote: PollVoteHistory }): React.
               fontWeight: 'semiBold'
             }}
           >
-            {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE
-              ? vote.rankedChoiceOption?.map((choice, index) => (
-                  <Box
-                    key={`voter-${vote.pollId}-option-${choice}`}
-                    sx={{ fontSize: index === 0 ? 2 : 1, color: index === 0 ? 'text' : '#708390' }}
-                  >
-                    {limitString(vote.poll.options[choice], 30, '...')} - {index + 1}
-                  </Box>
-                ))
-              : vote.optionValue}
+            {vote.poll.voteType === POLL_VOTE_TYPE.RANKED_VOTE ? (
+              <RankedChoiceVoteSummary choices={vote.rankedChoiceOption || []} poll={vote.poll} />
+            ) : (
+              vote.optionValue
+            )}
           </Text>
         </Box>
       </Box>

--- a/modules/polling/components/QuickVote.tsx
+++ b/modules/polling/components/QuickVote.tsx
@@ -50,7 +50,8 @@ const QuickVote = ({
     voteDelegateContractAddress ? voteDelegateContractAddress : account
   );
 
-  const { addVoteToBallot, removeVoteFromBallot, ballot, transaction } = useContext(BallotContext);
+  const { addVoteToBallot, removeVoteFromBallot, ballot, transaction, updateVoteFromBallot } =
+    useContext(BallotContext);
 
   const addedChoice = ballot[poll.pollId];
 
@@ -79,7 +80,9 @@ const QuickVote = ({
     if (currentVote && isEqual(currentVote, choice)) {
       removeVoteFromBallot(poll.pollId);
     } else {
-      addVoteToBallot(poll.pollId, { option: choice as number | number[] });
+      editing
+        ? updateVoteFromBallot(poll.pollId, { option: choice as number | number[] })
+        : addVoteToBallot(poll.pollId, { option: choice as number | number[] });
     }
     setEditing(false);
   };

--- a/modules/polling/components/RankedChoiceVoteSummary.tsx
+++ b/modules/polling/components/RankedChoiceVoteSummary.tsx
@@ -1,0 +1,38 @@
+import { limitString } from 'lib/string';
+import { Box } from 'theme-ui';
+import { Poll } from '../types';
+
+export function RankedChoiceVoteSummary({
+  choices,
+  poll,
+  limit = 0
+}: {
+  choices: number[];
+  poll: Poll;
+  limit?: number;
+}): React.ReactElement {
+  return (
+    <Box>
+      {choices
+        .filter((item, index) => {
+          if (limit === 0) {
+            return true;
+          } else {
+            return index < limit;
+          }
+        })
+        .map((choice, index) => (
+          <Box
+            key={`voter-${poll.pollId}-option-${choice}-${index}`}
+            sx={{
+              fontSize: index === 0 ? 2 : 1,
+              color: index === 0 ? 'text' : '#708390',
+              textAlign: 'right'
+            }}
+          >
+            {limitString(poll.options[choice], 30, '...')} - {index + 1}
+          </Box>
+        ))}
+    </Box>
+  );
+}

--- a/modules/polling/components/VoteWeightVisual.tsx
+++ b/modules/polling/components/VoteWeightVisual.tsx
@@ -72,7 +72,7 @@ export const CirclesSvg = ({ poll, tally, diameter }: CircleProps): JSX.Element 
         return d.r;
       })
       .style('fill', d => {
-        return getVoteColor(d.data.optionId, poll.voteType);
+        return getVoteColor(d.data.optionId, poll.voteType, false);
       })
       .style('cursor', 'pointer')
       .on('click', handleVoterClick);

--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from 'theme-ui';
+import { Box, Flex, Text } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import BigNumber from 'bignumber.js';
 import { PollTally, Poll } from 'modules/polling/types';
@@ -142,7 +142,10 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
             <>
               {sortedVotes.map((v, i) => (
                 <tr key={`voter-${v.voter}-${i}`} data-testid="vote-by-address">
-                  <Text as="td" sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3, verticalAlign: 'top' }}>
+                  <Text
+                    as="td"
+                    sx={{ pb: 2, fontSize: bpi < 1 ? 1 : 3, verticalAlign: 'top', wordBreak: 'break-word' }}
+                  >
                     <InternalLink href={`/address/${v.voter}`} title="View address detail">
                       <AddressIconBox
                         address={v.voter}
@@ -153,7 +156,10 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
                   </Text>
                   <Box
                     as="td"
-                    sx={{ color: getVoteColor(v.optionId, poll.voteType), pb: 2, verticalAlign: 'top' }}
+                    sx={{
+                      color: getVoteColor(v.optionId, poll.voteType),
+                      pb: 2
+                    }}
                   >
                     {v.rankedChoiceOption && v.rankedChoiceOption.length > 1 ? (
                       v.rankedChoiceOption.map((choice, index) => (
@@ -161,14 +167,17 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
                           key={`voter-${v.voter}-option-${choice}`}
                           sx={{
                             color: index === 0 ? 'inherit' : '#708390',
-                            fontSize: bpi < 1 ? 1 : index === 0 ? 3 : 2
+                            fontSize: bpi < 1 ? 1 : index === 0 ? 3 : 2,
+                            mb: 1
                           }}
                         >
                           {index + 1} - {poll.options[choice]}
                         </Box>
                       ))
                     ) : (
-                      <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>{poll.options[v.optionId]}</Text>
+                      <Text as="p" sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
+                        {poll.options[v.optionId]}
+                      </Text>
                     )}
                   </Box>
                   <Text as="td" sx={{ pb: 2, verticalAlign: 'top' }}>

--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -86,7 +86,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
             </Text>
             <Text
               as="th"
-              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '30%' }}
+              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '40%' }}
               variant="caps"
               onClick={() => changeSort('option')}
             >
@@ -103,7 +103,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
             </Text>
             <Text
               as="th"
-              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '20%' }}
+              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '15%' }}
               variant="caps"
               onClick={() => changeSort('mkr')}
             >
@@ -120,7 +120,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
             </Text>
             <Text
               as="th"
-              sx={{ textAlign: 'right', cursor: 'pointer', pb: 2, width: '20%' }}
+              sx={{ textAlign: 'right', cursor: 'pointer', pb: 2, width: '15%' }}
               variant="caps"
               onClick={() => changeSort('mkr')}
             >
@@ -175,18 +175,16 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
                         </Box>
                       ))
                     ) : (
-                      <Text as="p" sx={{ fontSize: bpi < 1 ? 1 : 3 }}>
-                        {poll.options[v.optionId]}
-                      </Text>
+                      <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>{poll.options[v.optionId]}</Text>
                     )}
                   </Box>
-                  <Text as="td" sx={{ pb: 2, verticalAlign: 'top' }}>
+                  <Text as="td" sx={{ textAlign: 'right', pb: 2 }}>
                     {`${new BigNumber(v.mkrSupport).div(totalMkrParticipation).times(100).toFormat(1)}%`}
                   </Text>
                   <Text
                     as="td"
                     data-testid={`vote-mkr-${v.voter}`}
-                    sx={{ textAlign: 'right', pb: 2, fontSize: bpi < 1 ? 1 : 3, verticalAlign: 'top' }}
+                    sx={{ textAlign: 'right', pb: 2, fontSize: bpi < 1 ? 1 : 3 }}
                   >
                     {`${
                       new BigNumber(v.mkrSupport).lte(0.01)

--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -69,7 +69,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
           <tr>
             <Text
               as="th"
-              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '30%' }}
+              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '32%' }}
               variant="caps"
               onClick={() => changeSort('address')}
             >
@@ -86,7 +86,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
             </Text>
             <Text
               as="th"
-              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '40%' }}
+              sx={{ textAlign: 'left', cursor: 'pointer', pb: 2, width: '38%' }}
               variant="caps"
               onClick={() => changeSort('option')}
             >
@@ -178,7 +178,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
                       <Text sx={{ fontSize: bpi < 1 ? 1 : 3 }}>{poll.options[v.optionId]}</Text>
                     )}
                   </Box>
-                  <Text as="td" sx={{ textAlign: 'right', pb: 2 }}>
+                  <Text as="td" sx={{ textAlign: 'left', pb: 2 }}>
                     {`${new BigNumber(v.mkrSupport).div(totalMkrParticipation).times(100).toFormat(1)}%`}
                   </Text>
                   <Text

--- a/modules/polling/helpers/getVoteColor.ts
+++ b/modules/polling/helpers/getVoteColor.ts
@@ -2,6 +2,9 @@ import { POLL_VOTE_TYPE } from 'modules/polling/polling.constants';
 
 export const getVoteColor = (optionId: number, voteType: string, text = true): string => {
   if (voteType === POLL_VOTE_TYPE.RANKED_VOTE || voteType === POLL_VOTE_TYPE.UNKNOWN) {
+    if (optionId === 0) {
+      return '#708390';
+    }
     if (text) return 'text';
     return '#708390';
   }

--- a/modules/polling/helpers/getVoteColor.ts
+++ b/modules/polling/helpers/getVoteColor.ts
@@ -1,8 +1,9 @@
 import { POLL_VOTE_TYPE } from 'modules/polling/polling.constants';
 
-export const getVoteColor = (optionId: number, voteType: string): string => {
+export const getVoteColor = (optionId: number, voteType: string, text = true): string => {
   if (voteType === POLL_VOTE_TYPE.RANKED_VOTE || voteType === POLL_VOTE_TYPE.UNKNOWN) {
-    return 'text';
+    if (text) return 'text';
+    return '#708390';
   }
 
   const colors = {

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -171,7 +171,7 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
         )}
         <SidebarLayout>
           <Box>
-            <Stack gap={2}>
+            <Stack gap={3}>
               <InternalLink href={'/polling'} title="View polling page">
                 <Button variant="smallOutline" sx={{ width: 'max-content' }}>
                   <Icon name="chevron_left" size="2" mr={2} />
@@ -258,21 +258,23 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
                   <Stack sx={{ display: activePolls.length ? undefined : 'none' }}>
                     {votedPolls.map(poll => {
                       return (
-                        <PollOverviewCard key={poll.slug} poll={poll} reviewPage={true} showVoting={true}>
-                          <Box sx={{ pt: 2 }}>
-                            <CommentTextBox
-                              onChange={(val: string) => {
-                                updateVoteFromBallot(poll.pollId, {
-                                  comment: val
-                                });
-                              }}
-                              value={ballot[poll.pollId].comment || ''}
-                              disabled={
-                                transactionStatus === 'pending' || transactionStatus === 'initialized'
-                              }
-                            />
-                          </Box>
-                        </PollOverviewCard>
+                        <Box key={poll.slug} sx={{ mb: 3 }}>
+                          <PollOverviewCard poll={poll} reviewPage={true} showVoting={true}>
+                            <Box sx={{ pt: 2 }}>
+                              <CommentTextBox
+                                onChange={(val: string) => {
+                                  updateVoteFromBallot(poll.pollId, {
+                                    comment: val
+                                  });
+                                }}
+                                value={ballot[poll.pollId].comment || ''}
+                                disabled={
+                                  transactionStatus === 'pending' || transactionStatus === 'initialized'
+                                }
+                              />
+                            </Box>
+                          </PollOverviewCard>
+                        </Box>
                       );
                     })}
                   </Stack>


### PR DESCRIPTION
Hotfix includes:
[Increase refresh interval for delegate mapping, cache proxy info](https://github.com/makerdao/governance-portal-v2/pull/513/commits/703cc426f31f73f4cb76174332606e56848a25cc)

[Update vote instead of add if editing](https://github.com/makerdao/governance-portal-v2/pull/513/commits/c9be57f7ada7602863b61955fccff6ad6ec207cb)

[display ranked choices](https://github.com/makerdao/governance-portal-v2/pull/513/commits/7dfa8048618cab6ff25d19dee9fd354a2de6e9c4)

[Add margin on poll cards on review page](https://github.com/makerdao/governance-portal-v2/pull/513/commits/626fa89a9f73cbca6bd0bd92aee51c6a3bfa06b2)

[Add margin on votes by address](https://github.com/makerdao/governance-portal-v2/pull/513/commits/32401b16728b83ca05ca8ba426bc17ae6ed6d771)

---
Original PR:
### What does this PR do?

Fixes voter visualization color for ranked choice polls

### Screenshots (if relevant):

Before:
<img width="745" alt="Screen Shot 2022-06-15 at 12 45 49 PM" src="https://user-images.githubusercontent.com/3388550/173914842-0304bca6-c4f2-4151-b57a-df0cabca0b37.png">

<img width="766" alt="Screen Shot 2022-06-15 at 12 46 02 PM" src="https://user-images.githubusercontent.com/3388550/173913960-1787167d-557d-4f46-8fab-6e755c21ed0c.png">

After:
<img width="760" alt="Screen Shot 2022-06-15 at 12 50 11 PM" src="https://user-images.githubusercontent.com/3388550/173914694-3ee9749a-a271-431f-b614-70bb7b66d768.png">
<img width="754" alt="Screen Shot 2022-06-15 at 12 50 02 PM" src="https://user-images.githubusercontent.com/3388550/173914724-ddaf2e57-c400-4ca8-8a5c-1b0ad3adf05d.png">


