### PR TITLE
Update vote instead of add if editing

### DIFF
--- a/modules/polling/components/QuickVote.tsx
+++ b/modules/polling/components/QuickVote.tsx
@@ -50,7 +50,8 @@ const QuickVote = ({
     voteDelegateContractAddress ? voteDelegateContractAddress : account
   );
 
-  const { addVoteToBallot, removeVoteFromBallot, ballot, transaction } = useContext(BallotContext);
+  const { addVoteToBallot, removeVoteFromBallot, ballot, transaction, updateVoteFromBallot } =
+    useContext(BallotContext);
 
   const addedChoice = ballot[poll.pollId];
 
@@ -79,7 +80,9 @@ const QuickVote = ({
     if (currentVote && isEqual(currentVote, choice)) {
       removeVoteFromBallot(poll.pollId);
     } else {
-      addVoteToBallot(poll.pollId, { option: choice as number | number[] });
+      editing
+        ? updateVoteFromBallot(poll.pollId, { option: choice as number | number[] })
+        : addVoteToBallot(poll.pollId, { option: choice as number | number[] });
     }
     setEditing(false);
   };


### PR DESCRIPTION
If editing a vote option on review page, don't overwrite comments. Use ballot `update` function instead of `add`.
