### PR TITLE
invalidate cache and reduce ttl tally

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -114,9 +114,10 @@ export const cacheSet = (
   try {
     if (isRedisCache && redis) {
       // If redis cache is enabled, store in redis, with a TTL in seconds
-      logger.debug(`Redis cache set for ${path}`);
+      const expirySeconds = Math.round(expiryMs / 1000);
+      logger.debug(`Redis cache set for ${path}, with TTL ${expirySeconds} seconds`);
 
-      redis.set(path, data, 'EX', expiryMs / 1000);
+      redis.set(path, data, 'EX', expirySeconds);
     } else {
       // File cache
       if (Object.keys(fs).length === 0) return;

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -24,9 +24,19 @@ function getFilePath(name: string, network: string): string {
 }
 
 export const cacheDel = (path: string): void => {
-  logger.debug('Delete cache', path);
-  fs.unlinkSync(path);
-  memoryCache[path] = null;
+  const isRedisCache = !!config.REDIS_URL;
+
+  if (isRedisCache && redis) {
+    redis?.del(path);
+  } else {
+    try {
+      logger.debug('cacheDel: ', path);
+      memoryCache[path] = null;
+      fs.unlinkSync(path);
+    } catch (e) {
+      logger.error(`cacheDel: ${e.message}`);
+    }
+  }
 };
 
 export const cacheGet = async (

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -234,7 +234,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
 
           // Invalidate tally cache for each voted poll
           Object.keys(ballot).forEach(pollId => {
-            fetchJson(`/api/polling/tally/${pollId}/invalidate-cache`);
+            fetchJson(`/api/polling/tally/${pollId}/invalidate-cache?network=${network}`);
           });
         }
       },

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -234,7 +234,9 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
 
           // Invalidate tally cache for each voted poll
           Object.keys(ballot).forEach(pollId => {
-            fetchJson(`/api/polling/tally/${pollId}/invalidate-cache?network=${network}`);
+            setTimeout(() => {
+              fetchJson(`/api/polling/tally/${pollId}/invalidate-cache?network=${network}`);
+            }, 60000);
           });
         }
       },

--- a/modules/polling/helpers/utils.ts
+++ b/modules/polling/helpers/utils.ts
@@ -1,9 +1,14 @@
 import { PollInputFormat, PollResultDisplay, PollVictoryConditions } from '../polling.constants';
 import { Poll, PollParameters, PollVote } from '../types';
 
+export function pollHasEnded(poll: Poll): boolean {
+  const now = Date.now();
+  return new Date(poll.endDate).getTime() < now;
+}
+
 export function isActivePoll(poll: Poll): boolean {
   const now = Date.now();
-  if (new Date(poll.endDate).getTime() < now) return false;
+  if (pollHasEnded(poll)) return false;
   if (new Date(poll.startDate).getTime() > now) return false;
   return true;
 }

--- a/modules/polling/helpers/utils.ts
+++ b/modules/polling/helpers/utils.ts
@@ -6,11 +6,13 @@ export function pollHasEnded(poll: Poll): boolean {
   return new Date(poll.endDate).getTime() < now;
 }
 
-export function isActivePoll(poll: Poll): boolean {
+export function pollHasStarted(poll: Poll): boolean {
   const now = Date.now();
-  if (pollHasEnded(poll)) return false;
-  if (new Date(poll.startDate).getTime() > now) return false;
-  return true;
+  return new Date(poll.startDate).getTime() < now;
+}
+
+export function isActivePoll(poll: Poll): boolean {
+  return !pollHasEnded(poll) && pollHasStarted(poll);
 }
 
 export function isRankedChoiceVictoryConditionPoll(parameters: PollParameters): boolean {

--- a/pages/api/polling/tally/[poll-id].ts
+++ b/pages/api/polling/tally/[poll-id].ts
@@ -3,6 +3,8 @@ import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/netwo
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { getPollTally } from 'modules/polling/helpers/getPollTally';
 import { fetchPollById } from 'modules/polling/api/fetchPollBy';
+import { pollHasStarted } from 'modules/polling/helpers/utils';
+import { PollTally } from 'modules/polling/types';
 
 // Returns a PollTally given a pollID
 
@@ -130,6 +132,20 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
     });
 
     return;
+  }
+
+  if (!pollHasStarted(poll)) {
+    const emptyTally: PollTally = {
+      parameters: poll.parameters,
+      numVoters: 0,
+      results: [],
+      totalMkrParticipation: 0,
+      winner: null,
+      winningOptionName: '',
+      votesByAddress: []
+    };
+
+    return res.status(200).json(emptyTally);
   }
 
   const tally = await getPollTally(poll, network);

--- a/pages/api/polling/tally/[poll-id]/invalidate-cache.ts
+++ b/pages/api/polling/tally/[poll-id]/invalidate-cache.ts
@@ -1,0 +1,18 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
+import withApiHandler from 'modules/app/api/withApiHandler';
+import { deleteCachedPollTally } from 'modules/polling/helpers/getPollTally';
+
+// Deletes cache for a tally
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  const network = (req.query.network as SupportedNetworks) || DEFAULT_NETWORK.network;
+
+  const pollId = parseInt(req.query['poll-id'] as string, 10);
+  deleteCachedPollTally(pollId, network);
+
+  res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
+  return res.status(200).json({
+    invalidated: true,
+    pollId
+  });
+});

--- a/pages/api/polling/tally/[poll-id]/invalidate-cache.ts
+++ b/pages/api/polling/tally/[poll-id]/invalidate-cache.ts
@@ -2,17 +2,25 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { deleteCachedPollTally } from 'modules/polling/helpers/getPollTally';
+import logger from 'lib/logger';
 
 // Deletes cache for a tally
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
   const network = (req.query.network as SupportedNetworks) || DEFAULT_NETWORK.network;
 
   const pollId = parseInt(req.query['poll-id'] as string, 10);
-  deleteCachedPollTally(pollId, network);
+  try {
+    deleteCachedPollTally(pollId, network);
 
-  res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');
-  return res.status(200).json({
-    invalidated: true,
-    pollId
-  });
+    return res.status(200).json({
+      invalidated: true,
+      pollId
+    });
+  } catch (e) {
+    logger.error(`invalidate-cache: ${e.message}`);
+    return res.status(200).json({
+      invalidated: false,
+      pollId
+    });
+  }
 });


### PR DESCRIPTION
Reduce TTL of poll tally to 5 mins, if poll is expired leave it to 1 day.

Add endpoint to invalidate cache for tally, call it after voting:

PS: invalidating cache after voting won't do much because spock didn't ingest the data yet, so a future request to the tally will still bring innacurate results, but at least it will include the new tally with only 5 mins ttl