### PR TITLE
create a wrapper for bignumber.js, add 'no exponent' config option

### DIFF
--- a/lib/__tests__/bigNumber.spec.js
+++ b/lib/__tests__/bigNumber.spec.js
@@ -1,0 +1,30 @@
+import glob from 'glob';
+import path from 'path';
+import fs from 'fs';
+
+it('ensure bignumber.js is not used directly', () => {
+  const cwd = process.cwd();
+  const files = glob.sync('**/*', {
+    cwd,
+    ignore: [
+      'lib/bigNumberJs.ts', //ignore the file that wraps bignumber
+      'node_modules/**',
+      'dist/**',
+      '.github/**',
+      '.husky/**',
+      '.next/**',
+      '.yalc/**',
+      'cache/**',
+      'coverage/**',
+      'cypress/**'
+    ],
+    nodir: true
+  });
+  const filesWithBigNumber = files.filter(f => {
+    const extension = path.extname(f);
+    const data = fs.readFileSync(f, 'utf8');
+    if (['.js', '.ts'].includes(extension) && data.includes('bignumber.js')) return f;
+  });
+  //the only non-ignored file that should contain bignumber.js is this file
+  expect(filesWithBigNumber.length).toBe(1);
+});

--- a/lib/bigNumberJs.ts
+++ b/lib/bigNumberJs.ts
@@ -1,0 +1,9 @@
+import { BigNumber as BNJS } from 'bignumber.js';
+
+// Wrapper to enable config options globally for BigNumber.js
+export default class BigNumber extends BNJS.clone({
+  // never use scientific notation when converting BigNumber toString
+  EXPONENTIAL_AT: 1e9
+}) {}
+
+export { BigNumber };

--- a/lib/bigNumberJs.ts
+++ b/lib/bigNumberJs.ts
@@ -1,9 +1,9 @@
-import { BigNumber as BNJS } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 // Wrapper to enable config options globally for BigNumber.js
-export default class BigNumber extends BNJS.clone({
+export default class BigNumberJS extends BigNumber.clone({
   // never use scientific notation when converting BigNumber toString
   EXPONENTIAL_AT: 1e9
 }) {}
 
-export { BigNumber };
+export { BigNumberJS };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,7 +2,7 @@ import invariant from 'tiny-invariant';
 import { cloneElement } from 'react';
 import { jsx } from 'theme-ui';
 import { css, ThemeUIStyleObject } from '@theme-ui/css';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { CurrencyObject } from 'modules/app/types/currency';
 import { hexZeroPad, stripZeros } from 'ethers/lib/utils';
 
@@ -164,8 +164,6 @@ export const fromBuffer = (buf, opts) => {
 
     hex.push(chunk.map(c => (c < 16 ? '0' : '') + c.toString(16)).join(''));
   }
-  //never use scientific notation when converting BigNumber toString
-  BigNumber.config({ EXPONENTIAL_AT: 1e9 });
   return new BigNumber(hex.join(''), 16);
 };
 

--- a/modules/address/components/AddressDelegatedTo.tsx
+++ b/modules/address/components/AddressDelegatedTo.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, Flex, IconButton, Heading } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import { Icon } from '@makerdao/dai-ui-icons';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { useActiveWeb3React } from 'modules/web3/hooks/useActiveWeb3React';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { DelegationHistory } from 'modules/delegates/types';

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -3,7 +3,7 @@ import { DelegateStatusEnum } from 'modules/delegates/delegates.constants';
 import { fetchGithubDelegate, fetchGithubDelegates } from './fetchGithubDelegates';
 import { fetchDelegationEventsByAddresses } from './fetchDelegationEventsByAddresses';
 import { add, isBefore } from 'date-fns';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import {
   DelegatesAPIResponse,

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -3,7 +3,7 @@ import { DelegateStatusEnum } from 'modules/delegates/delegates.constants';
 import { fetchGithubDelegate, fetchGithubDelegates } from './fetchGithubDelegates';
 import { fetchDelegationEventsByAddresses } from './fetchDelegationEventsByAddresses';
 import { add, isBefore } from 'date-fns';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import {
   DelegatesAPIResponse,

--- a/modules/delegates/components/DelegateDetail.tsx
+++ b/modules/delegates/components/DelegateDetail.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Box, Text, Flex, Divider } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 import Tabs from 'modules/app/components/Tabs';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import {
   DelegatePicture,
   DelegateContractExpiration,

--- a/modules/delegates/components/DelegateMKRChart.tsx
+++ b/modules/delegates/components/DelegateMKRChart.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, Flex, useThemeUI } from 'theme-ui';
 import { Delegate } from '../types';
 import { MenuItem } from '@reach/menu-button';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 
 import {
   CartesianGrid,

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { Box, Flex } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { useMkrDelegated } from 'modules/mkr/hooks/useMkrDelegated';

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -14,7 +14,7 @@ import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import AddressIconBox from 'modules/address/components/AddressIconBox';
 
 type DelegatedByAddressProps = {

--- a/modules/delegates/components/DelegatedByAddress.tsx
+++ b/modules/delegates/components/DelegatedByAddress.tsx
@@ -14,7 +14,7 @@ import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import AddressIconBox from 'modules/address/components/AddressIconBox';
 
 type DelegatedByAddressProps = {

--- a/modules/delegates/components/DelegatesSystemInfo.tsx
+++ b/modules/delegates/components/DelegatesSystemInfo.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import StackLayout from 'modules/app/components/layout/layouts/Stack';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { formatAddress } from 'lib/utils';

--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { parseUnits } from 'ethers/lib/utils';
 import { formatValue } from 'lib/string';
 import { Card, Box, Text, Flex, Button, Heading, Container, Divider } from 'theme-ui';

--- a/modules/delegates/helpers/formatDelegationHistoryChart.ts
+++ b/modules/delegates/helpers/formatDelegationHistoryChart.ts
@@ -2,7 +2,7 @@ import { MKRLockedDelegateAPIResponse } from '../types/delegate';
 import { formatIsoDateConversion } from 'lib/datetime';
 import { MKRWeightHisory } from '../types/mkrWeight';
 import { format } from 'date-fns';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { differenceInCalendarYears, subDays } from 'date-fns';
 
 export const formatDelegationHistoryChart = (

--- a/modules/esm/components/ESMHistory.tsx
+++ b/modules/esm/components/ESMHistory.tsx
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { Card, Text, Spinner } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import { useActiveWeb3React } from 'modules/web3/hooks/useActiveWeb3React';

--- a/modules/executive/components/OnChainFx.tsx
+++ b/modules/executive/components/OnChainFx.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react';
 import { Grid, Text, Box, Link as ExternalLink } from 'theme-ui';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import { SpellStateDiff } from '../types/spellStateDiff';

--- a/modules/home/api/fetchAllLocksSummed.ts
+++ b/modules/home/api/fetchAllLocksSummed.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { format } from 'date-fns';
 import logger from 'lib/logger';
 import { gqlRequest } from 'modules/gql/gqlRequest';

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { Stats } from 'modules/home/components/Stats';
 import { Poll } from 'modules/polling/types';

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { Stats } from 'modules/home/components/Stats';
 import { Poll } from 'modules/polling/types';

--- a/modules/mkr/components/MKRInput.tsx
+++ b/modules/mkr/components/MKRInput.tsx
@@ -3,7 +3,7 @@ import { Input, Text, Button, Box, Flex } from 'theme-ui';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
 import { parseUnits } from 'ethers/lib/utils';
 import logger from 'lib/logger';
 

--- a/modules/mkr/components/MKRInput.tsx
+++ b/modules/mkr/components/MKRInput.tsx
@@ -3,7 +3,7 @@ import { Input, Text, Button, Box, Flex } from 'theme-ui';
 import Skeleton from 'modules/app/components/SkeletonThemed';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
-import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { parseUnits } from 'ethers/lib/utils';
 import logger from 'lib/logger';
 
@@ -38,7 +38,7 @@ export function MKRInput({
 
     try {
       // Use bignumberjs to validate the number
-      const newValue = new BigNumberJs(newValueStr || '0');
+      const newValue = new BigNumberJS(newValueStr || '0');
 
       const invalidValue =
         newValue.isLessThan(min.toNumber()) || (max && newValue.isGreaterThan(max.toNumber()));

--- a/modules/polling/api/__tests__/fetchTallyRanked.spec.ts
+++ b/modules/polling/api/__tests__/fetchTallyRanked.spec.ts
@@ -1,7 +1,7 @@
 import { gqlRequest } from '../../../../modules/gql/gqlRequest';
 import { fetchSpockPollById } from '../fetchPollBy';
 import { fetchTallyRankedChoice } from '../fetchTallyRankedChoice';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 jest.mock('modules/gql/gqlRequest');
 jest.mock('../fetchPollBy');

--- a/modules/polling/api/fetchTallyPlurality.ts
+++ b/modules/polling/api/fetchTallyPlurality.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { gqlRequest } from 'modules/gql/gqlRequest';
 import { voteMkrWeightsAtTimeRankedChoice } from 'modules/gql/queries/voteMkrWeightsAtTimeRankedChoice';
 import { SupportedNetworks } from 'modules/web3/constants/networks';

--- a/modules/polling/api/fetchTallyRankedChoice.ts
+++ b/modules/polling/api/fetchTallyRankedChoice.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { paddedArray, toBuffer } from 'lib/utils';
 import { gqlRequest } from 'modules/gql/gqlRequest';
 import { voteMkrWeightsAtTimeRankedChoice } from 'modules/gql/queries/voteMkrWeightsAtTimeRankedChoice';

--- a/modules/polling/api/fetchVotesByAddress.ts
+++ b/modules/polling/api/fetchVotesByAddress.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { PollTallyVote } from '../types';
 import { gqlRequest } from 'modules/gql/gqlRequest';

--- a/modules/polling/components/PollingParticipationOverview.tsx
+++ b/modules/polling/components/PollingParticipationOverview.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from 'theme-ui';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { PollVoteHistory } from '../types/pollVoteHistory';
 import { YesNoAbstainBar } from './YesNoAbstainBar';
 import { isPluralityVictoryConditionPoll } from '../helpers/utils';

--- a/modules/polling/components/VoteBreakdown.tsx
+++ b/modules/polling/components/VoteBreakdown.tsx
@@ -5,7 +5,7 @@ import Delay from 'modules/app/components/Delay';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { PollTally, Poll, RankedChoiceResult, PluralityResult } from 'modules/polling/types';
 import { getVoteColor } from 'modules/polling/helpers/getVoteColor';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
 import { isResultDisplayInstantRunoffBreakdown } from '../helpers/utils';

--- a/modules/polling/components/VoteBreakdown.tsx
+++ b/modules/polling/components/VoteBreakdown.tsx
@@ -5,7 +5,7 @@ import Delay from 'modules/app/components/Delay';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { PollTally, Poll, RankedChoiceResult, PluralityResult } from 'modules/polling/types';
 import { getVoteColor } from 'modules/polling/helpers/getVoteColor';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import { formatValue } from 'lib/string';
 import { parseUnits } from 'ethers/lib/utils';
 import { isResultDisplayInstantRunoffBreakdown } from '../helpers/utils';
@@ -19,9 +19,6 @@ export default function VoteBreakdown({
   shownOptions: number;
   tally: PollTally | undefined;
 }): JSX.Element {
-  //never use scientific notation when converting BigNumber toString
-  BigNumberJS.config({ EXPONENTIAL_AT: 1e9 });
-
   if (isResultDisplayInstantRunoffBreakdown(poll.parameters)) {
     return (
       <Box key={2} sx={{ p: [3, 4] }} data-testid="vote-breakdown">

--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { PollTally, Poll } from 'modules/polling/types';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import { getVoteColor } from 'modules/polling/helpers/getVoteColor';

--- a/modules/polling/helpers/__tests__/getPollTally.spec.ts
+++ b/modules/polling/helpers/__tests__/getPollTally.spec.ts
@@ -2,7 +2,7 @@ import { getPollTally } from '../getPollTally';
 import { fetchRawPollTally } from '../../api/fetchRawPollTally';
 import { fetchVotesByAddressForPoll } from '../../api/fetchVotesByAddress';
 import { PluralityResult, Poll } from '../../types';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import * as PRT from '../parseRawTally';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { PollInputFormat, PollResultDisplay, PollVictoryConditions } from 'modules/polling/polling.constants';

--- a/modules/polling/helpers/__tests__/parseRawTally.spec.ts
+++ b/modules/polling/helpers/__tests__/parseRawTally.spec.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { PollInputFormat, PollResultDisplay, PollVictoryConditions } from '../../polling.constants';
 import { Poll, RawPollTally } from '../../types';
 import { parseRawPollTally } from '../parseRawTally';

--- a/modules/polling/helpers/getPollTally.ts
+++ b/modules/polling/helpers/getPollTally.ts
@@ -1,6 +1,6 @@
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { backoffRetry } from 'lib/utils';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { cacheDel, cacheGet, cacheSet } from 'lib/cache';
 import { fetchRawPollTally } from 'modules/polling/api/fetchRawPollTally';
 import { fetchVotesByAddressForPoll } from 'modules/polling/api/fetchVotesByAddress';

--- a/modules/polling/helpers/parseRawTally.ts
+++ b/modules/polling/helpers/parseRawTally.ts
@@ -1,6 +1,6 @@
 import invariant from 'tiny-invariant';
 import { Poll, PollTally, RawPollTally, PluralityResult, RankedChoiceResult } from '../types';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { isPluralityVictoryConditionPoll, isRankedChoiceVictoryConditionPoll } from './utils';
 
 export function getRankedChoiceResults(rawTally: RawPollTally, poll: Poll): RankedChoiceResult[] {

--- a/modules/polling/types/pollTally.d.ts
+++ b/modules/polling/types/pollTally.d.ts
@@ -1,4 +1,4 @@
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { PollParameters } from './poll';
 import { PollVoteType } from './pollVoteType';
 

--- a/modules/web3/constants/numbers.ts
+++ b/modules/web3/constants/numbers.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
 
 export const WAD = BigNumber.from('1000000000000000000');
 export const RAY = BigNumber.from('1000000000000000000000000000');

--- a/modules/web3/constants/numbers.ts
+++ b/modules/web3/constants/numbers.ts
@@ -1,10 +1,10 @@
 import { BigNumber } from 'ethers';
-import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 
 export const WAD = BigNumber.from('1000000000000000000');
 export const RAY = BigNumber.from('1000000000000000000000000000');
 export const RAD = BigNumber.from('1000000000000000000000000000000000000000000000');
 
-export const BigNumberWAD = new BigNumberJs('1e18');
-export const BigNumberRAY = new BigNumberJs('1e27');
-export const BigNumberRAD = new BigNumberJs('1e45');
+export const BigNumberWAD = new BigNumberJS('1e18');
+export const BigNumberRAY = new BigNumberJS('1e27');
+export const BigNumberRAD = new BigNumberJS('1e45');

--- a/modules/web3/hooks/useDaiSavingsRate.ts
+++ b/modules/web3/hooks/useDaiSavingsRate.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 import { useContracts } from 'modules/web3/hooks/useContracts';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
 import { SECONDS_PER_YEAR } from 'lib/datetime';
 import { BigNumberRAY } from '../constants/numbers';
 

--- a/modules/web3/hooks/useDaiSavingsRate.ts
+++ b/modules/web3/hooks/useDaiSavingsRate.ts
@@ -1,13 +1,13 @@
 import useSWR from 'swr';
 import { useContracts } from 'modules/web3/hooks/useContracts';
-import { BigNumber as BigNumberJs } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { SECONDS_PER_YEAR } from 'lib/datetime';
 import { BigNumberRAY } from '../constants/numbers';
 
-BigNumberJs.config({ POW_PRECISION: 100 });
+BigNumberJS.config({ POW_PRECISION: 100 });
 
 type DaiSavingsRateResponse = {
-  data?: BigNumberJs | undefined;
+  data?: BigNumberJS | undefined;
   loading: boolean;
   error?: Error;
 };
@@ -17,7 +17,7 @@ export const useDaiSavingsRate = (): DaiSavingsRateResponse => {
 
   const { data, error } = useSWR(`${pot.address}/dai-savings-rate`, async () => {
     const dsr = await pot.dsr();
-    const annualDsr = new BigNumberJs(dsr._hex).div(BigNumberRAY).pow(SECONDS_PER_YEAR).minus(1).times(100);
+    const annualDsr = new BigNumberJS(dsr._hex).div(BigNumberRAY).pow(SECONDS_PER_YEAR).minus(1).times(100);
 
     return annualDsr;
   });

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.20.5",
     "eslint-plugin-testing-library": "^4.10.1",
+    "glob": "^8.0.3",
     "graphql": "^16.2.0",
     "husky": "^6.0.0",
     "jest": "^26.0.1",

--- a/pages/api/address/[address]/delegated-to.ts
+++ b/pages/api/address/[address]/delegated-to.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { isSupportedNetwork } from 'modules/web3/helpers/networks';
 import { fetchDelegatedTo } from 'modules/delegates/api/fetchDelegatedTo';
 import { DelegationHistory } from 'modules/delegates/types';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
 import { resolveENS } from 'modules/web3/helpers/ens';

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Heading, Box, Flex, Card, Text, Button } from 'theme-ui';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import shallow from 'zustand/shallow';
 import { Icon } from '@makerdao/dai-ui-icons';

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Heading, Box, Flex, Card, Text, Button } from 'theme-ui';
 import { GetStaticProps } from 'next';
 import ErrorPage from 'next/error';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import shallow from 'zustand/shallow';
 import { Icon } from '@makerdao/dai-ui-icons';

--- a/pages/esmodule.tsx
+++ b/pages/esmodule.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Button, Text, Card } from 'theme-ui';
 import { useState, useRef } from 'react';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
 import { formatDateWithTime } from 'lib/datetime';

--- a/pages/esmodule.tsx
+++ b/pages/esmodule.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Button, Text, Card } from 'theme-ui';
 import { useState, useRef } from 'react';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import { BigNumber } from 'ethers';
 import { formatValue } from 'lib/string';
 import { formatDateWithTime } from 'lib/datetime';

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -3,7 +3,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import ErrorPage from 'next/error';
 import { Badge, Button, Card, Flex, Heading, Spinner, Box, Text, Divider } from 'theme-ui';
-import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
+import { BigNumberJS } from 'lib/bigNumberJs';
 import useSWR, { useSWRConfig } from 'swr';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { useBreakpointIndex } from '@theme-ui/match-media';

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -3,7 +3,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import ErrorPage from 'next/error';
 import { Badge, Button, Card, Flex, Heading, Spinner, Box, Text, Divider } from 'theme-ui';
-import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { BigNumber as BigNumberJS } from 'lib/bigNumberJs';
 import useSWR, { useSWRConfig } from 'swr';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { useBreakpointIndex } from '@theme-ui/match-media';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ import useSWR, { useSWRConfig } from 'swr';
 import TopDelegates from 'modules/delegates/components/TopDelegates';
 import { ResourcesLanding } from 'modules/home/components/ResourcesLanding/ResourcesLanding';
 import { PollsOverviewLanding } from 'modules/home/components/PollsOverviewLanding';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import { getCategories } from 'modules/polling/helpers/getCategories';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import MeetDelegates from 'modules/delegates/components/MeetDelegates';

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -31,7 +31,7 @@ import MobileVoteSheet from 'modules/polling/components/MobileVoteSheet';
 import VotesByAddress from 'modules/polling/components/VotesByAddress';
 import { PollCategoryTag } from 'modules/polling/components/PollCategoryTag';
 import { HeadComponent } from 'modules/app/components/layout/Head';
-import BigNumber from 'bignumber.js';
+import BigNumber from 'lib/bigNumberJs';
 import PollWinningOptionBox from 'modules/polling/components/PollWinningOptionBox';
 import { usePollTally } from 'modules/polling/hooks/usePollTally';
 import { usePollComments } from 'modules/comments/hooks/usePollComments';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,6 +4737,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
@@ -7568,6 +7575,17 @@ glob@7.2.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glo
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 global-dirs@^3.0.0:
   version "3.0.0"
@@ -10620,6 +10638,13 @@ minimatch@^4.0.0:
   integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
+  integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
### What does this PR do?

- Clone bignumber and add a global config option to prevent exponent notation
- adds a named export `BigNumberJS` to alleviate confusion with ethers `BigNumber`
- adds test to prevent files from importing BigNumber directly from 'bignumber.js' package

### Steps for testing:
Check vote breakdown page on polls and make sure it doesn't break. This is the one that errored this morning: `https://<previewURL>/polling/Qmbs5Kx5`

### Any additional helpful information?:
https://github.com/MikeMcl/bignumber.js/issues/315#issuecomment-1020673911

