### PR TITLE
Only show MKR delegated by account when account is connected

### DIFF
--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -49,10 +49,12 @@ export function DelegateMKRDelegatedStats({
         value={typeof delegatorCount !== 'undefined' ? new BigNumber(delegatorCount).toFormat(0) : '--'}
         label={'Total Active Delegators'}
       />
-      <StatBox
-        value={typeof mkrStaked !== 'undefined' ? formatValue(mkrStaked) : '0'}
-        label={'MKR Delegated by you'}
-      />
+      {account && (
+        <StatBox
+          value={typeof mkrStaked !== 'undefined' ? formatValue(mkrStaked) : '0'}
+          label={'MKR delegated by you'}
+        />
+      )}
     </Flex>
   );
 }

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -188,25 +188,27 @@ export function DelegateOverviewCard({ delegate }: PropTypes): React.ReactElemen
                 </InternalLink>
               </Flex>
               <Flex sx={{ justifyContent: 'flex-end', mt: '3' }}>
-                <Box>
-                  <Text
-                    as="p"
-                    variant="microHeading"
-                    sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
-                    data-testid="mkr-delegated-by-you"
-                  >
-                    {mkrDelegated ? formatValue(mkrDelegated) : '0'}
-                  </Text>
-                  <Text
-                    as="p"
-                    variant="secondary"
-                    color="onSecondary"
-                    sx={{ fontSize: [2, 3], textAlign: 'right' }}
-                  >
-                    MKR delegated by you
-                  </Text>
-                </Box>
-                <Box sx={{ ml: '4' }}>
+                {account && (
+                  <Box>
+                    <Text
+                      as="p"
+                      variant="microHeading"
+                      sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
+                      data-testid="mkr-delegated-by-you"
+                    >
+                      {mkrDelegated ? formatValue(mkrDelegated) : '0'}
+                    </Text>
+                    <Text
+                      as="p"
+                      variant="secondary"
+                      color="onSecondary"
+                      sx={{ fontSize: [2, 3], textAlign: 'right' }}
+                    >
+                      MKR delegated by you
+                    </Text>
+                  </Box>
+                )}
+                <Box sx={{ ml: account ? 4 : 0 }}>
                   <Text
                     as="p"
                     variant="microHeading"


### PR DESCRIPTION
### What does this PR do?
As discussed in discord, this removes "MKR delegated by you" stats from the delegate overview card and delegate detail header when there is no account connected. This frees up some space and removes redundant information (MKR delegated by you is always 0 when no account is connected).

### Screenshots (if relevant):

<img width="980" alt="Screen Shot 2022-06-28 at 7 34 59 AM" src="https://user-images.githubusercontent.com/5225766/176101935-dfa7f661-e1e7-46cc-9a2f-1f5c8c6c820d.png">

