### PR TITLE
Fix davatar api path

### DIFF
--- a/lib/davatar/Image.tsx
+++ b/lib/davatar/Image.tsx
@@ -223,7 +223,7 @@ export default function Avatar({
             const tokenURI = await erc721Contract.tokenURI(tokenId);
             const gatewayUrl = getGatewayUrl(tokenURI, new BigNumber(tokenId).toString(16));
             try {
-              const data = await fetchJson(`api/delegates/davatar/image?gatewayUrl=${gatewayUrl}`);
+              const data = await fetchJson(`/api/delegates/davatar/image?gatewayUrl=${gatewayUrl}`);
               setUrl(getGatewayUrl(data.image));
             } catch (e) {
               console.error(`Error fetching image from ${gatewayUrl}`, e);


### PR DESCRIPTION
The path should be `/api/delegates/davatar/image?gatewayUrl...` but we have don't have a `/` before api, so it's sending the request to `polling/api/delegates/davatar...` when on polling page, `address/api/delegates/davatar...` when on address page etc resulting in 404s