### PR TITLE
Delegates alchemy key

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,7 @@
 type SystemConfig = {
   USE_CACHE: string;
   ALCHEMY_KEY: string;
+  ALCHEMY_KEY_DELEGATES: string;
   INFURA_KEY: string;
   ETHERSCAN_KEY: string;
   POCKET_KEY: string;
@@ -21,6 +22,7 @@ type SystemConfig = {
 export const config: SystemConfig = {
   USE_CACHE: process.env.USE_CACHE || '',
   ALCHEMY_KEY: process.env.ALCHEMY_KEY || '',
+  ALCHEMY_KEY_DELEGATES: process.env.ALCHEMY_KEY_DELEGATES || '',
   INFURA_KEY: process.env.INFURA_KEY || '',
   ETHERSCAN_KEY: process.env.ETHERSCAN_KEY || '',
   POCKET_KEY: process.env.POCKET_KEY || '',

--- a/modules/delegates/api/fetchChainDelegates.ts
+++ b/modules/delegates/api/fetchChainDelegates.ts
@@ -6,6 +6,7 @@ import { allDelegates } from 'modules/gql/queries/allDelegates';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { getContracts } from 'modules/web3/helpers/getContracts';
 import { Query } from 'modules/gql/generated/graphql';
+import { config } from 'lib/config';
 
 export async function fetchChainDelegates(
   network: SupportedNetworks
@@ -15,7 +16,7 @@ export async function fetchChainDelegates(
 
   const delegates = data.allDelegates.nodes;
 
-  const contracts = getContracts(chainId, undefined, undefined, true);
+  const contracts = getContracts(chainId, undefined, undefined, true, config.ALCHEMY_KEY_DELEGATES);
 
   const delegatesWithMkrStaked: DelegateContractInformation[] = await Promise.all(
     delegates.map(async (delegate): Promise<DelegateContractInformation> => {

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -23,6 +23,7 @@ import { getDelegateTags } from './getDelegateTags';
 import { Tag } from 'modules/app/types/tag';
 import { isAboutToExpireCheck } from 'modules/migration/helpers/expirationChecks';
 import { getNewOwnerFromPrevious, getPreviousOwnerFromNew } from 'modules/migration/delegateAddressLinks';
+import { config } from 'lib/config';
 
 function mergeDelegateInfo({
   onChainDelegate,
@@ -192,7 +193,13 @@ export async function fetchDelegates(
   // This contains all the delegates including info merged with recognized delegates
   const delegatesInfo = await fetchDelegatesInformation(currentNetwork);
 
-  const contracts = getContracts(networkNameToChainId(currentNetwork), undefined, undefined, true);
+  const contracts = getContracts(
+    networkNameToChainId(currentNetwork),
+    undefined,
+    undefined,
+    true,
+    config.ALCHEMY_KEY_DELEGATES
+  );
   const executives = await getGithubExecutives(currentNetwork);
 
   const delegateAddresses = delegatesInfo.map(d => d.voteDelegateAddress.toLowerCase());

--- a/modules/delegates/hooks/useVoteDelegateAddress.ts
+++ b/modules/delegates/hooks/useVoteDelegateAddress.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import { useContracts } from 'modules/web3/hooks/useContracts';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
+import { config } from 'lib/config';
 
 type VoteDelegateAddressResponse = {
   data?: string | undefined;
@@ -11,7 +12,7 @@ type VoteDelegateAddressResponse = {
 
 // Returns the vote delegate contract address for a account
 export const useVoteDelegateAddress = (account?: string): VoteDelegateAddressResponse => {
-  const { voteDelegateFactory } = useContracts();
+  const { voteDelegateFactory } = useContracts(config.ALCHEMY_KEY_DELEGATES);
 
   const { data, error, mutate } = useSWR(account ? `${account}/vote-delegate-address` : null, async () => {
     const vdAddress = await voteDelegateFactory.delegates(account as string);

--- a/modules/web3/helpers/getContracts.ts
+++ b/modules/web3/helpers/getContracts.ts
@@ -20,16 +20,25 @@ const sdks: Sdks = {
   goerli: getGoerliSdk
 };
 
+export const replaceApiKey = (rpcUrl: string, newKey: string): string =>
+  `${rpcUrl.substring(0, rpcUrl.lastIndexOf('/'))}/${newKey}`;
+
 // this name doesn't feel right, maybe getSdk? or getContractLibrary?
 export const getContracts = (
   chainId?: SupportedChainId,
   library?: Web3Provider,
   account?: string | null,
-  readOnly?: boolean
+  readOnly?: boolean,
+  apiKey?: string
 ): EthSdk => {
-  const { network, rpcUrl } = chainId
+  const networkInfo = chainId
     ? { network: CHAIN_INFO[chainId].network, rpcUrl: getRPCFromChainID(chainId) }
     : { network: DEFAULT_NETWORK.network, rpcUrl: DEFAULT_NETWORK.defaultRpc };
+
+  // If a custom API key is provided, replace it in the URL
+  if (apiKey) networkInfo.rpcUrl = replaceApiKey(networkInfo.rpcUrl, apiKey);
+
+  const { network, rpcUrl } = networkInfo;
 
   const provider = readOnly ? new providers.JsonRpcBatchProvider(rpcUrl) : getDefaultProvider(rpcUrl);
 

--- a/modules/web3/hooks/useContracts.ts
+++ b/modules/web3/hooks/useContracts.ts
@@ -10,11 +10,11 @@ type Props = {
   account?: string | null;
 };
 
-export const useContracts = (): EthSdk => {
+export const useContracts = (apiKey?: string): EthSdk => {
   const { chainId, library, account }: Props = useActiveWeb3React();
 
   const sdk = useMemo(
-    () => getContracts(chainId ?? SupportedChainId.MAINNET, library, account, false),
+    () => getContracts(chainId ?? SupportedChainId.MAINNET, library, account, false, apiKey),
     [chainId, library, account]
   );
 

--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,9 @@ const moduleExports = {
   env: {
     INFURA_KEY: process.env.INFURA_KEY || '84842078b09946638c03157f83405213', // ethers default infura key
     ALCHEMY_KEY: process.env.ALCHEMY_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC', // ethers default alchemy key
+    ALCHEMY_KEY_DELEGATES:
+      // if ALCHEMY_KEY_DELEGATES is not set, fall back to ALCHEMY_KEY
+      process.env.ALCHEMY_KEY_DELEGATES || process.env.ALCHEMY_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
     POCKET_KEY: process.env.POCKET_KEY,
     ETHERSCAN_KEY: process.env.ETHERSCAN_KEY
   },


### PR DESCRIPTION
### What does this PR do?
For delegate-related calls, use a new Alchemy API key so we can begin tracking our RPC calls for delegate activity.

### Steps for testing:
check the Alchemy dashboard and make sure that the key is being used

### Any additional helpful information?:
I added the key to our vercel prod ENV already, but not to staging/preview because I think we only want to track calls from prod for now.

I didn't add it for write calls because we use the `library` provider from web3-react hook, but I don't think write calls are a major contributor to our RPC calls.
