### PR TITLE
exclude expired and duplicate delegates in stats

### DIFF
--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -275,12 +275,17 @@ export async function fetchDelegates(
     }
   });
 
+  // Exclude expired, and dedupe migrated delegates for stats purposes
+  const dedupedDelegates = sortedDelegates
+    .filter(({ status }) => status !== DelegateStatusEnum.expired)
+    .filter(({ next }) => !next);
+
   const delegatesResponse: DelegatesAPIResponse = {
     delegates: sortedDelegates,
     stats: {
-      total: sortedDelegates.length,
-      shadow: sortedDelegates.filter(d => d.status === DelegateStatusEnum.shadow).length,
-      recognized: sortedDelegates.filter(d => d.status === DelegateStatusEnum.recognized).length,
+      total: dedupedDelegates.length,
+      shadow: dedupedDelegates.filter(d => d.status === DelegateStatusEnum.shadow).length,
+      recognized: dedupedDelegates.filter(d => d.status === DelegateStatusEnum.recognized).length,
       totalMKRDelegated: new BigNumberJS(
         delegates.reduce((prev, next) => {
           const mkrDelegated = new BigNumberJS(next.mkrDelegated);


### PR DESCRIPTION
### What does this PR do?
don't count expired or duplicate delegates in stats 

### Screenshots (if relevant):
OLD
![Screen Shot 2022-07-28 at 3 08 42 PM](https://user-images.githubusercontent.com/13105602/181637999-91233cc8-9163-4a4b-87a0-6cf904bb316d.png)


NEW
![Screen Shot 2022-07-28 at 3 10 13 PM](https://user-images.githubusercontent.com/13105602/181638035-ec010191-8a5a-4be5-85cd-1b3bbbf2bcc1.png)

### Any additional helpful information?:

### Add a GIF:


