### PR TITLE
Move expired delegates out of status filter and add checkbox filter

### DIFF
--- a/lib/theme/forms.js
+++ b/lib/theme/forms.js
@@ -4,6 +4,11 @@ export const forms = {
     fontWeight: 'bold',
     py: 2
   },
+  thinLabel: {
+    fontSize: 2,
+    fontWeight: 'semiBold',
+    py: 2
+  },
   input: {
     outline: 'none',
     borderRadius: 'small',

--- a/modules/delegates/components/filters/DelegatesShowExpiredFilter.tsx
+++ b/modules/delegates/components/filters/DelegatesShowExpiredFilter.tsx
@@ -1,0 +1,23 @@
+import { Box, Label, Checkbox, ThemeUIStyleObject } from 'theme-ui';
+import shallow from 'zustand/shallow';
+import useDelegatesFiltersStore from 'modules/delegates/stores/delegatesFiltersStore';
+
+export function DelegatesShowExpiredFilter({ ...props }: { sx?: ThemeUIStyleObject }): JSX.Element {
+  const [showExpired, setShowExpiredFilter] = useDelegatesFiltersStore(
+    state => [state.filters.showExpired, state.setShowExpiredFilter],
+    shallow
+  );
+
+  const handleChecked = () => {
+    setShowExpiredFilter(!showExpired);
+  };
+
+  return (
+    <Box {...props}>
+      <Label variant="thinLabel" sx={{ fontSize: 2, alignItems: 'center' }}>
+        <Checkbox checked={showExpired} onChange={handleChecked} />
+        Show Expired Delegates
+      </Label>
+    </Box>
+  );
+}

--- a/modules/delegates/components/filters/DelegatesStatusFilter.tsx
+++ b/modules/delegates/components/filters/DelegatesStatusFilter.tsx
@@ -8,34 +8,24 @@ import { useMemo } from 'react';
 import { filterDelegates } from 'modules/delegates/helpers/filterDelegates';
 
 export function DelegatesStatusFilter({ delegates }: { delegates: Delegate[] }): JSX.Element {
-  const [
-    showRecognized,
-    showShadow,
-    showExpired,
-    name,
-    delegateTags,
-    setShowRecognizedFilter,
-    setShowShadowFilter,
-    setShowExpiredFilter
-  ] = useDelegatesFiltersStore(
-    state => [
-      state.filters.showRecognized,
-      state.filters.showShadow,
-      state.filters.showExpired,
-      state.filters.name,
-      state.filters.tags,
-      state.setShowRecognizedFilter,
-      state.setShowShadowFilter,
-      state.setShowExpiredFilter
-    ],
-    shallow
-  );
+  const [showRecognized, showShadow, name, delegateTags, setShowRecognizedFilter, setShowShadowFilter] =
+    useDelegatesFiltersStore(
+      state => [
+        state.filters.showRecognized,
+        state.filters.showShadow,
+        state.filters.name,
+        state.filters.tags,
+        state.setShowRecognizedFilter,
+        state.setShowShadowFilter
+      ],
+      shallow
+    );
 
-  const itemsSelected = [showRecognized, showShadow, showExpired].filter(i => !!i).length;
+  const itemsSelected = [showRecognized, showShadow].filter(i => !!i).length;
 
   // Use filtered delegates to show the right amount of each type of delegates (ignoring the current filter ones)
   const filteredDelegates = useMemo(() => {
-    return filterDelegates(delegates, true, true, true, name, delegateTags);
+    return filterDelegates(delegates, true, true, false, name, delegateTags);
   }, [delegates, name, delegateTags]);
 
   return (
@@ -48,6 +38,7 @@ export function DelegatesStatusFilter({ delegates }: { delegates: Delegate[] }):
       <Box p={2}>
         <Flex>
           <Label
+            variant="thinLabel"
             sx={{ py: 1, fontSize: 2, alignItems: 'center' }}
             data-testid="delegate-type-filter-show-recognized"
           >
@@ -66,6 +57,7 @@ export function DelegatesStatusFilter({ delegates }: { delegates: Delegate[] }):
         </Flex>
         <Flex>
           <Label
+            variant="thinLabel"
             sx={{ py: 1, fontSize: 2, alignItems: 'center' }}
             data-testid="delegate-type-filter-show-shadow"
           >
@@ -78,24 +70,6 @@ export function DelegatesStatusFilter({ delegates }: { delegates: Delegate[] }):
               <Text>Shadow Delegates</Text>
               <Text sx={{ color: 'mutedAlt', ml: 3 }}>
                 {filteredDelegates.filter(p => p.status === DelegateStatusEnum.shadow).length}
-              </Text>
-            </Flex>
-          </Label>
-        </Flex>
-        <Flex>
-          <Label
-            sx={{ py: 1, fontSize: 2, alignItems: 'center' }}
-            data-testid="delegate-type-filter-show-expired"
-          >
-            <Checkbox
-              sx={{ width: 3, height: 3 }}
-              checked={showExpired}
-              onChange={event => setShowExpiredFilter(event.target.checked)}
-            />
-            <Flex sx={{ justifyContent: 'space-between', width: '100%' }}>
-              <Text>Expired Delegates</Text>
-              <Text sx={{ color: 'mutedAlt', ml: 3 }}>
-                {filteredDelegates.filter(p => p.status === DelegateStatusEnum.expired).length}
               </Text>
             </Flex>
           </Label>

--- a/modules/delegates/components/filters/DelegatesTagFilter.tsx
+++ b/modules/delegates/components/filters/DelegatesTagFilter.tsx
@@ -46,7 +46,7 @@ export function DelegatesTagFilter({
         <Flex sx={{ flexDirection: 'column' }}>
           {tags.map(tag => (
             <Flex key={tag.id}>
-              <Label sx={{ py: 1, fontSize: 2, alignItems: 'center' }}>
+              <Label variant="thinLabel" sx={{ py: 1, fontSize: 2, alignItems: 'center' }}>
                 <Checkbox
                   sx={{ width: 3, height: 3 }}
                   checked={(delegateFilters.tags && delegateFilters.tags[tag.id]) || false}

--- a/modules/delegates/helpers/filterDelegates.ts
+++ b/modules/delegates/helpers/filterDelegates.ts
@@ -18,8 +18,13 @@ export function filterDelegates(
         return delegate.name.toLowerCase().includes(name.toLowerCase());
       })
       .filter(delegate => {
-        // Return all if unchecked
-        if (!showShadow && !showRecognized && !showExpired) {
+        // filter out expired if show expired not checked
+        if (!showExpired && delegate.expired === true) {
+          return false;
+        }
+
+        // return all if show shadow and show recognized are both unchecked
+        if (!showShadow && !showRecognized) {
           return true;
         }
 
@@ -28,10 +33,6 @@ export function filterDelegates(
         }
 
         if (!showRecognized && delegate.status === DelegateStatusEnum.recognized) {
-          return false;
-        }
-
-        if (!showExpired && delegate.expired === true) {
           return false;
         }
 

--- a/modules/delegates/stores/delegatesFiltersStore.ts
+++ b/modules/delegates/stores/delegatesFiltersStore.ts
@@ -29,8 +29,8 @@ type StoreDelegates = {
 const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
   filters: {
     creationDate: null,
-    showShadow: true,
-    showRecognized: true,
+    showShadow: false,
+    showRecognized: false,
     showExpired: false,
     name: null,
     tags: {}

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -21,6 +21,7 @@ import { DelegatesSystemInfo } from 'modules/delegates/components/DelegatesSyste
 import { DelegatesStatusFilter } from 'modules/delegates/components/filters/DelegatesStatusFilter';
 import { DelegatesSortFilter } from 'modules/delegates/components/filters/DelegatesSortFilter';
 import { DelegatesTagFilter } from 'modules/delegates/components/filters/DelegatesTagFilter';
+import { DelegatesShowExpiredFilter } from 'modules/delegates/components/filters/DelegatesShowExpiredFilter';
 import { filterDelegates } from 'modules/delegates/helpers/filterDelegates';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { useActiveWeb3React } from 'modules/web3/hooks/useActiveWeb3React';
@@ -114,6 +115,7 @@ const Delegates = ({ delegates, stats, tags }: DelegatesPageData) => {
                 <DelegatesSortFilter />
                 <DelegatesTagFilter tags={tags} delegates={delegates} sx={{ m: 2 }} />
                 <DelegatesStatusFilter delegates={delegates} />
+                <DelegatesShowExpiredFilter sx={{ ml: 2 }} />
               </Flex>
               <Button
                 variant={'outline'}


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/1618/add-show-expired-delegates-button-as-replacement-for-expired-delegates-filter-option

### What does this PR do?
Move expired delegates out of status filter and add checkbox filter

### Steps for testing:
Go to delegates page and test out expired delegates checkbox

### Screenshots (if relevant):
<img width="1308" alt="Screen Shot 2022-07-29 at 9 53 57 AM" src="https://user-images.githubusercontent.com/5225766/181712593-169c2af5-ae96-4919-ab7d-369187c24962.png">
<img width="1055" alt="Screen Shot 2022-07-29 at 9 54 25 AM" src="https://user-images.githubusercontent.com/5225766/181712613-849a90e9-e5da-4b2e-ad6b-f8f0d83ea198.png">
