### PR TITLE
make pre > code text wrap in markdown

### DIFF
--- a/lib/theme/markdown.js
+++ b/lib/theme/markdown.js
@@ -57,6 +57,9 @@ export const markdown = {
       ':nth-of-type(2n)': {
         backgroundColor: 'background'
       }
+    },
+    'pre > code': {
+      whiteSpace: 'pre-wrap'
     }
   }
 };


### PR DESCRIPTION
### Link to Shortcut ticket:

### What does this PR do?
text in `pre` doesn't wrap by default, so add a style to our markdown theme to wrap long code text.
### Screenshots (if relevant):
Before:
![Screen Shot 2022-07-29 at 1 34 11 PM](https://user-images.githubusercontent.com/13105602/181831591-ac7b0c1c-5300-4112-8b40-283b98ec0bb5.png)

After:
![Screen Shot 2022-07-29 at 1 33 46 PM](https://user-images.githubusercontent.com/13105602/181831521-2c1a558a-a1b8-4c3e-b00d-36f5129dc95e.png)

