### PR TITLE
Fix double link wrapping of avatar + name

### DIFF
--- a/modules/delegates/components/DelegateAvatarName.tsx
+++ b/modules/delegates/components/DelegateAvatarName.tsx
@@ -1,9 +1,8 @@
 import { Delegate } from '../types';
 import { Box, Flex, Text } from 'theme-ui';
-
 import { limitString } from 'lib/string';
 import { DelegatePicture } from 'modules/delegates/components';
-
+import { InternalLink } from 'modules/app/components/InternalLink';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { Address } from 'modules/address/components/Address';
 
@@ -12,34 +11,36 @@ export default function DelegateAvatarName({ delegate }: { delegate: Delegate })
   const isOwner = account?.toLowerCase() === delegate.address.toLowerCase();
 
   return (
-    <Flex>
-      <DelegatePicture delegate={delegate} />
+    <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="View profile details">
+      <Flex>
+        <DelegatePicture delegate={delegate} />
 
-      <Box sx={{ ml: 2 }}>
-        <Flex sx={{ alignItems: 'center' }}>
-          <Text as="p" variant="microHeading" sx={{ fontSize: [3, 4], overflowWrap: 'break-word' }}>
-            {delegate.name
-              ? limitString(delegate.name, isOwner ? 23 : 43, '...')
-              : limitString('Unknown', isOwner ? 12 : 43, '...')}
-          </Text>
-          {isOwner && (
-            <Flex
-              sx={{
-                display: 'inline-flex',
-                backgroundColor: 'tagColorSevenBg',
-                borderRadius: 'roundish',
-                padding: '3px 6px',
-                alignItems: 'center',
-                color: 'tagColorSeven',
-                ml: 2
-              }}
-            >
-              <Text sx={{ fontSize: 1 }}>Owner</Text>
-            </Flex>
-          )}
-        </Flex>
-        {delegate.voteDelegateAddress && <Address address={delegate.voteDelegateAddress} />}
-      </Box>
-    </Flex>
+        <Box sx={{ ml: 2 }}>
+          <Flex sx={{ alignItems: 'center' }}>
+            <Text as="p" variant="microHeading" sx={{ fontSize: [3, 4], overflowWrap: 'break-word' }}>
+              {delegate.name
+                ? limitString(delegate.name, isOwner ? 23 : 43, '...')
+                : limitString('Unknown', isOwner ? 12 : 43, '...')}
+            </Text>
+            {isOwner && (
+              <Flex
+                sx={{
+                  display: 'inline-flex',
+                  backgroundColor: 'tagColorSevenBg',
+                  borderRadius: 'roundish',
+                  padding: '3px 6px',
+                  alignItems: 'center',
+                  color: 'tagColorSeven',
+                  ml: 2
+                }}
+              >
+                <Text sx={{ fontSize: 1 }}>Owner</Text>
+              </Flex>
+            )}
+          </Flex>
+          {delegate.voteDelegateAddress && <Address address={delegate.voteDelegateAddress} />}
+        </Box>
+      </Flex>
+    </InternalLink>
   );
 }

--- a/modules/delegates/components/DelegateAvatarNameLight.tsx
+++ b/modules/delegates/components/DelegateAvatarNameLight.tsx
@@ -1,13 +1,15 @@
 import { Delegate } from '../types';
 import { Flex, Text } from 'theme-ui';
-
+import { InternalLink } from 'modules/app/components/InternalLink';
 import { DelegatePicture } from 'modules/delegates/components';
 
 export default function DelegateAvatarNameLight({ delegate }: { delegate: Delegate }): React.ReactElement {
   return (
-    <Flex sx={{ alignItems: 'center', gap: 2 }}>
-      <DelegatePicture delegate={delegate} />
-      <Text sx={{ color: 'primary', fontWeight: 'semiBold' }}>{delegate.name}</Text>
-    </Flex>
+    <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="View profile details">
+      <Flex sx={{ alignItems: 'center', gap: 2 }}>
+        <DelegatePicture delegate={delegate} />
+        <Text sx={{ color: 'primary', fontWeight: 'semiBold' }}>{delegate.name}</Text>
+      </Flex>
+    </InternalLink>
   );
 }

--- a/modules/delegates/components/DelegatePicture.tsx
+++ b/modules/delegates/components/DelegatePicture.tsx
@@ -5,7 +5,6 @@ import { Delegate } from 'modules/delegates/types';
 import { DelegateStatusEnum } from 'modules/delegates/delegates.constants';
 import Tooltip from 'modules/app/components/Tooltip';
 import { Address } from 'modules/address/components/Address';
-import { InternalLink } from 'modules/app/components/InternalLink';
 
 export function DelegatePicture({
   delegate,
@@ -132,24 +131,22 @@ export function DelegatePicture({
       <Box>
         <Tooltip label={delegateMetrics}>
           <Box>
-            <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="View profile details">
-              {delegate.picture ? (
-                <Image
-                  src={delegate.picture}
-                  key={delegate.id}
-                  sx={{
-                    objectFit: 'cover',
-                    width: '100%',
-                    borderRadius: '100%',
-                    maxHeight: width
-                  }}
-                />
-              ) : (
-                <Box>
-                  <Davatar size={width} address={delegate.address} />
-                </Box>
-              )}
-            </InternalLink>
+            {delegate.picture ? (
+              <Image
+                src={delegate.picture}
+                key={delegate.id}
+                sx={{
+                  objectFit: 'cover',
+                  width: '100%',
+                  borderRadius: '100%',
+                  maxHeight: width
+                }}
+              />
+            ) : (
+              <Box>
+                <Davatar size={width} address={delegate.address} />
+              </Box>
+            )}
 
             {delegate.status === DelegateStatusEnum.recognized && (
               <Icon

--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -96,9 +96,7 @@ export default function TopDelegates({
                   <Text pr={2} sx={{ display: ['none', 'block'] }}>
                     {index + 1}
                   </Text>
-                  <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="Profile details">
-                    <DelegateAvatarNameLight delegate={delegate} />
-                  </InternalLink>
+                  <DelegateAvatarNameLight delegate={delegate} />
                 </Flex>
                 <Box sx={{ width: '15%', display: ['none', 'block'] }}>
                   <Text>

--- a/modules/home/components/Participation.tsx
+++ b/modules/home/components/Participation.tsx
@@ -166,9 +166,7 @@ export default function Participation({
                 >
                   <Flex sx={{ alignItems: 'center', gap: 2 }}>
                     <Text>{i + 1}</Text>
-                    <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="Profile details">
-                      <DelegateAvatarNameLight delegate={delegate} />
-                    </InternalLink>
+                    <DelegateAvatarNameLight delegate={delegate} />
                   </Flex>
                   <Text>{delegate.combinedParticipation}</Text>
                 </Flex>


### PR DESCRIPTION
### What does this PR do?

Gets rid of double-wrapping of avatar + name with InternalLink and removes the console warning seen below
<img width="533" alt="Screen Shot 2022-08-11 at 1 10 25 PM" src="https://user-images.githubusercontent.com/5225766/184121452-2d3f233d-a383-4e70-8f9c-571d644fd60b.png">

