### PR TITLE
prevent tooltip text overflow

### DIFF
--- a/modules/polling/components/PollOverviewCard/PollVoteTypeIndicator.tsx
+++ b/modules/polling/components/PollOverviewCard/PollVoteTypeIndicator.tsx
@@ -21,17 +21,13 @@ export function PollVoteTypeIndicator({ poll }: { poll: Poll }): React.ReactElem
           <Text variant="caps">Ranked-choice poll</Text>
           <TooltipComponent
             label={
-              <Text>
+              <Text sx={{ whiteSpace: 'normal' }}>
                 Ranked choice voting polls require multiple-choice ballots in ranked order,
-                <br />
                 and determines the winning vote option by finding the one with an absolute majority in MKR
                 voting weight
-                <br />
                 for first-choice votes, being &gt;50% of the total participating MKR (excluding abstains).
-                <br />
                 In case no vote option meets the victory requirements, the least popular vote option (except
                 abstain)
-                <br />
                 is omitted and another round of logic is applied until the victory conditions have been met by
                 one vote option.
               </Text>
@@ -48,10 +44,10 @@ export function PollVoteTypeIndicator({ poll }: { poll: Poll }): React.ReactElem
           <Text variant="caps">Plurality poll</Text>
           <TooltipComponent
             label={
-              <Text>
+              <Text sx={{ whiteSpace: 'normal' }}>
                 Plurality voting polls require single-choice ballots
-                <br /> and determines the winning vote option by finding the one with
-                <br /> the highest MKR voting weight in relative terms.
+                and determines the winning vote option by finding the one with
+                the highest MKR voting weight in relative terms.
               </Text>
             }
           >
@@ -66,17 +62,13 @@ export function PollVoteTypeIndicator({ poll }: { poll: Poll }): React.ReactElem
           <Text variant="caps">Approval poll</Text>
           <TooltipComponent
             label={
-              <Text>
+              <Text sx={{ whiteSpace: 'normal' }}>
                 Approval voting polls require multiple-choice ballots in unranked order,
-                <br />
                 and determines the winning vote option by finding the one with a relative majority
-                <br />
                 in MKR voting weight. When used in situations where no winner is required, an absolute
                 majority
-                <br />
                 (ie. &gt;50% of the total participating MKR excluding abstains) victory condition may also be
                 applied
-                <br />
                 as opposed to a relative majority.
               </Text>
             }
@@ -93,11 +85,9 @@ export function PollVoteTypeIndicator({ poll }: { poll: Poll }): React.ReactElem
           <Text variant="caps">Majority poll</Text>
           <TooltipComponent
             label={
-              <Text>
+              <Text sx={{ whiteSpace: 'normal' }}>
                 Majority voting polls require single-choice ballots and determines the winning
-                <br />
                 vote option by finding the one with an absolute majority in MKR voting weight,
-                <br />
                 being &gt;50% of the total participating MKR (excluding abstains).
               </Text>
             }

--- a/modules/tags/constants/poll-tags-mapping.json
+++ b/modules/tags/constants/poll-tags-mapping.json
@@ -819,5 +819,9 @@
   "846": ["high-impact", "ratification", "mips", "budget"],
   "847": ["medium-impact", "ratification", "mips", "d3m"],
   "848": ["high-impact", "misc-funding", "ratification", "mips"],
-  "849": ["high-impact", "ratification", "mips", "core-unit-offboard"]
+  "849": ["high-impact", "ratification", "mips", "core-unit-offboard"],
+  "850": ["medium-impact", "greenlight"],
+  "851": ["medium-impact", "greenlight"],
+  "852": ["medium-impact", "greenlight"],
+  "853": ["medium-impact", "risk-parameter", "bridge"]
 }


### PR DESCRIPTION
Update tooltips to prevent text overflow out of the screen / off of the page

Before:
<img width="682" alt="Screen Shot 2022-08-16 at 4 16 20 PM" src="https://user-images.githubusercontent.com/3388550/185004312-854bdcab-14a4-48ed-af6d-e603f9cac604.png">

<img width="699" alt="Screen Shot 2022-08-16 at 4 06 58 PM" src="https://user-images.githubusercontent.com/3388550/185004346-e23db058-725b-4c93-a343-a58bd3e5aa1e.png">

After: 

<img width="698" alt="Screen Shot 2022-08-16 at 4 07 05 PM" src="https://user-images.githubusercontent.com/3388550/185004320-1d58b025-0324-40a9-b22c-e9f1f85e6a8b.png">



