### PR TITLE
deprecate the custom apiKey in get contracts fixing wrong signer bug

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,6 @@
 type SystemConfig = {
   USE_CACHE: string;
   ALCHEMY_KEY: string;
-  ALCHEMY_KEY_DELEGATES: string;
   INFURA_KEY: string;
   ETHERSCAN_KEY: string;
   POCKET_KEY: string;
@@ -22,7 +21,6 @@ type SystemConfig = {
 export const config: SystemConfig = {
   USE_CACHE: process.env.USE_CACHE || '',
   ALCHEMY_KEY: process.env.ALCHEMY_KEY || '',
-  ALCHEMY_KEY_DELEGATES: process.env.ALCHEMY_KEY_DELEGATES || '',
   INFURA_KEY: process.env.INFURA_KEY || '',
   ETHERSCAN_KEY: process.env.ETHERSCAN_KEY || '',
   POCKET_KEY: process.env.POCKET_KEY || '',

--- a/modules/delegates/api/fetchChainDelegates.ts
+++ b/modules/delegates/api/fetchChainDelegates.ts
@@ -6,7 +6,6 @@ import { allDelegates } from 'modules/gql/queries/allDelegates';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { getContracts } from 'modules/web3/helpers/getContracts';
 import { Query } from 'modules/gql/generated/graphql';
-import { config } from 'lib/config';
 
 export async function fetchChainDelegates(
   network: SupportedNetworks
@@ -16,7 +15,7 @@ export async function fetchChainDelegates(
 
   const delegates = data.allDelegates.nodes;
 
-  const contracts = getContracts(chainId, undefined, undefined, true, config.ALCHEMY_KEY_DELEGATES);
+  const contracts = getContracts(chainId, undefined, undefined, true);
 
   const delegatesWithMkrStaked: DelegateContractInformation[] = await Promise.all(
     delegates.map(async (delegate): Promise<DelegateContractInformation> => {

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -202,13 +202,7 @@ export async function fetchDelegates(
   // This contains all the delegates including info merged with recognized delegates
   const delegatesInfo = await fetchDelegatesInformation(currentNetwork);
 
-  const contracts = getContracts(
-    networkNameToChainId(currentNetwork),
-    undefined,
-    undefined,
-    true,
-    config.ALCHEMY_KEY_DELEGATES
-  );
+  const contracts = getContracts(networkNameToChainId(currentNetwork), undefined, undefined, true);
   const executives = await getGithubExecutives(currentNetwork);
 
   const delegateAddresses = delegatesInfo.map(d => d.voteDelegateAddress.toLowerCase());

--- a/modules/delegates/hooks/useVoteDelegateAddress.ts
+++ b/modules/delegates/hooks/useVoteDelegateAddress.ts
@@ -1,7 +1,6 @@
 import useSWR from 'swr';
 import { useContracts } from 'modules/web3/hooks/useContracts';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
-import { config } from 'lib/config';
 
 type VoteDelegateAddressResponse = {
   data?: string | undefined;
@@ -12,7 +11,7 @@ type VoteDelegateAddressResponse = {
 
 // Returns the vote delegate contract address for a account
 export const useVoteDelegateAddress = (account?: string): VoteDelegateAddressResponse => {
-  const { voteDelegateFactory } = useContracts(config.ALCHEMY_KEY_DELEGATES);
+  const { voteDelegateFactory } = useContracts();
 
   const { data, error, mutate } = useSWR(account ? `${account}/vote-delegate-address` : null, async () => {
     const vdAddress = await voteDelegateFactory.delegates(account as string);

--- a/modules/web3/helpers/getReadOnlyContracts.ts
+++ b/modules/web3/helpers/getReadOnlyContracts.ts
@@ -9,37 +9,22 @@ const sdkGenerators: SdkGenerators = {
   goerli: getGoerliSdk
 };
 
-export const replaceApiKey = (rpcUrl: string, newKey: string): string =>
-  `${rpcUrl.substring(0, rpcUrl.lastIndexOf('/'))}/${newKey}`;
-
 let currentNetwork: string | undefined;
 
-const readOnlyContracts: Record<string, EthSdk | null> = {
-  default: null
-};
+let readOnlyContracts: EthSdk | null = null;
 
 export const getReadOnlyContracts = (
   rpcUrl: string,
-  network: SupportedNetworks.MAINNET | SupportedNetworks.GOERLI,
-  apiKey?: string
+  network: SupportedNetworks.MAINNET | SupportedNetworks.GOERLI
 ): EthSdk => {
-  let contractsKey = 'default';
-
-  if (apiKey) {
-    contractsKey = apiKey;
-
-    // If a custom API key is provided, replace it in the URL
-    rpcUrl = replaceApiKey(rpcUrl, apiKey);
-  }
-
   const changeNetwork = network !== currentNetwork;
 
-  if (!readOnlyContracts[contractsKey] || changeNetwork) {
+  if (!readOnlyContracts || changeNetwork) {
     const batchProvider = new providers.JsonRpcBatchProvider(rpcUrl);
 
     if (changeNetwork) currentNetwork = network;
-    readOnlyContracts[contractsKey] = sdkGenerators[network](batchProvider);
+    readOnlyContracts = sdkGenerators[network](batchProvider);
   }
 
-  return readOnlyContracts[contractsKey] as EthSdk;
+  return readOnlyContracts as EthSdk;
 };

--- a/modules/web3/hooks/useContracts.ts
+++ b/modules/web3/hooks/useContracts.ts
@@ -12,18 +12,12 @@ type Props = {
   account?: string | null;
 };
 
-export const useContracts = (apiKey?: string): EthSdk => {
+export const useContracts = (): EthSdk => {
   const { chainId, provider, account }: Props = useWeb3();
 
   const sdk = useMemo(
     () =>
-      getContracts(
-        isSupportedChain(chainId) ? chainId : SupportedChainId.MAINNET,
-        provider,
-        account,
-        false,
-        apiKey
-      ),
+      getContracts(isSupportedChain(chainId) ? chainId : SupportedChainId.MAINNET, provider, account, false),
     [chainId, provider, account]
   );
 

--- a/next.config.js
+++ b/next.config.js
@@ -51,9 +51,6 @@ const moduleExports = {
   env: {
     INFURA_KEY: process.env.INFURA_KEY || '84842078b09946638c03157f83405213', // ethers default infura key
     ALCHEMY_KEY: process.env.ALCHEMY_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC', // ethers default alchemy key
-    ALCHEMY_KEY_DELEGATES:
-      // if ALCHEMY_KEY_DELEGATES is not set, fall back to ALCHEMY_KEY
-      process.env.ALCHEMY_KEY_DELEGATES || process.env.ALCHEMY_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC',
     POCKET_KEY: process.env.POCKET_KEY,
     ETHERSCAN_KEY: process.env.ETHERSCAN_KEY,
     GITHUB_TOKEN: process.env.GITHUB_TOKEN


### PR DESCRIPTION
### What does this PR do?
- Removes the custom alchemy api key for delegates and drastically simplifies `getContracts`.
- Fixes a bug where the signer was getting cached in an unintended way, causing an issue when switching accounts.

The custom apiKey was intended to help us separate and identify specific calls to delegate contracts in order to learn more about our Alchemy usage. Ultimately this method was kind of shoe-horned in, and only complicated things when we refactored `getContracts` into a singleton.

Probably an even better way to get granular data about our Alchemy usage and contract calls is to use a new Axiom library [next-axiom](https://github.com/axiomhq/next-axiom). Here we can add logging after the calls are made sending data to alchemy about the RPC call, and later do some data analytics.
