### PR TITLE
Updated delegate queries

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://polling-db-staging.makerdux.com/api/v1'
+schema: 'https://polling-db-prod.makerdux.com/api/v1'
 # documents: 'src/**/*.graphql'
 generates:
   modules/gql/generated/graphql.tsx:

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'https://polling-db-prod.makerdux.com/api/v1'
+schema: 'https://polling-db-staging.makerdux.com/api/v1'
 # documents: 'src/**/*.graphql'
 generates:
   modules/gql/generated/graphql.tsx:

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5659,6 +5659,338 @@
       },
       {
         "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Connection",
+        "description": "A connection to a list of `MkrDelegatedToV2Record` values.",
+        "fields": [
+          {
+            "name": "edges",
+            "description": "A list of edges which contains the `MkrDelegatedToV2Record` and cursor to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrDelegatedToV2Edge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": "A list of `MkrDelegatedToV2Record` objects.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrDelegatedToV2Record",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Edge",
+        "description": "A `MkrDelegatedToV2Record` edge in the connection.",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Cursor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The `MkrDelegatedToV2Record` at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrDelegatedToV2Record",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Record",
+        "description": "The return type of our `mkrDelegatedToV2` query.",
+        "fields": [
+          {
+            "name": "blockNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Datetime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delegateContractAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fromAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "immediateCaller",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockAmount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigFloat",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MkrDelegatedToV2RecordFilter",
+        "description": "A filter to be used against `MkrDelegatedToV2Record` object types. All fields are combined with a logical ‘and.’",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "and",
+            "description": "Checks for all expressions in this list.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrDelegatedToV2RecordFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockNumber",
+            "description": "Filter by the object’s `blockNumber` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IntFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockTimestamp",
+            "description": "Filter by the object’s `blockTimestamp` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delegateContractAddress",
+            "description": "Filter by the object’s `delegateContractAddress` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fromAddress",
+            "description": "Filter by the object’s `fromAddress` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hash",
+            "description": "Filter by the object’s `hash` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "immediateCaller",
+            "description": "Filter by the object’s `immediateCaller` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockAmount",
+            "description": "Filter by the object’s `lockAmount` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BigFloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "not",
+            "description": "Negates the expression.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "MkrDelegatedToV2RecordFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": "Checks for any expressions in this list.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrDelegatedToV2RecordFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "MkrLockedDelegateArrayConnection",
         "description": "A connection to a list of `MkrLockedDelegateArrayRecord` values.",
         "fields": [
@@ -6332,6 +6664,386 @@
                 "ofType": {
                   "kind": "INPUT_OBJECT",
                   "name": "MkrLockedDelegateArrayTotalsRecordFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Connection",
+        "description": "A connection to a list of `MkrLockedDelegateArrayTotalsV2Record` values.",
+        "fields": [
+          {
+            "name": "edges",
+            "description": "A list of edges which contains the `MkrLockedDelegateArrayTotalsV2Record` and cursor to aid in pagination.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrLockedDelegateArrayTotalsV2Edge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": "A list of `MkrLockedDelegateArrayTotalsV2Record` objects.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsV2Record",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Edge",
+        "description": "A `MkrLockedDelegateArrayTotalsV2Record` edge in the connection.",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "A cursor for use in pagination.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Cursor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "The `MkrLockedDelegateArrayTotalsV2Record` at the end of the edge.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrLockedDelegateArrayTotalsV2Record",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Record",
+        "description": "The return type of our `mkrLockedDelegateArrayTotalsV2` query.",
+        "fields": [
+          {
+            "name": "blockNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockTimestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Datetime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "callerLockTotal",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigFloat",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delegateContractAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fromAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hash",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "immediateCaller",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockAmount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigFloat",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockTotal",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigFloat",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2RecordFilter",
+        "description": "A filter to be used against `MkrLockedDelegateArrayTotalsV2Record` object types. All fields are combined with a logical ‘and.’",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "and",
+            "description": "Checks for all expressions in this list.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsV2RecordFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockNumber",
+            "description": "Filter by the object’s `blockNumber` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "IntFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "blockTimestamp",
+            "description": "Filter by the object’s `blockTimestamp` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "DatetimeFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "callerLockTotal",
+            "description": "Filter by the object’s `callerLockTotal` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BigFloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delegateContractAddress",
+            "description": "Filter by the object’s `delegateContractAddress` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fromAddress",
+            "description": "Filter by the object’s `fromAddress` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hash",
+            "description": "Filter by the object’s `hash` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "immediateCaller",
+            "description": "Filter by the object’s `immediateCaller` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockAmount",
+            "description": "Filter by the object’s `lockAmount` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BigFloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lockTotal",
+            "description": "Filter by the object’s `lockTotal` field.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BigFloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "not",
+            "description": "Negates the expression.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "MkrLockedDelegateArrayTotalsV2RecordFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "or",
+            "description": "Checks for any expressions in this list.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsV2RecordFilter",
                   "ofType": null
                 }
               }
@@ -8804,6 +9516,111 @@
             "deprecationReason": null
           },
           {
+            "name": "mkrDelegatedToV2",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "argAddress",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": "A filter to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrDelegatedToV2RecordFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrDelegatedToV2Connection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "mkrLockedDelegate",
             "description": null,
             "args": [
@@ -9216,6 +10033,147 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "MkrLockedDelegateArrayTotalsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mkrLockedDelegateArrayTotalsV2",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": "Read all values in the set after (below) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "argAddress",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": "Read all values in the set before (above) this cursor.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Cursor",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": "A filter to be used in determining which values should be returned by the collection.",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsV2RecordFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": "Only read the first `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": "Only read the last `n` values of the set.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "Skip the first `n` values from our `after` cursor, an alternative to cursor based pagination. May not be used with `last`.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "unixtimeEnd",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "unixtimeStart",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrLockedDelegateArrayTotalsV2Connection",
                 "ofType": null
               }
             },
@@ -13675,11 +14633,14 @@
         "name": "deprecated",
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "isRepeatable": false,
-        "locations": ["ARGUMENT_DEFINITION", "ENUM_VALUE", "FIELD_DEFINITION", "INPUT_FIELD_DEFINITION"],
+        "locations": [
+          "ENUM_VALUE",
+          "FIELD_DEFINITION"
+        ],
         "args": [
           {
             "name": "reason",
-            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).",
+            "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax (as specified by [CommonMark](https://commonmark.org/).",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -13695,7 +14656,11 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -13719,7 +14684,11 @@
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -13730,30 +14699,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ]
-      },
-      {
-        "name": "specifiedBy",
-        "description": "Exposes a URL that specifies the behavior of this scalar.",
-        "isRepeatable": false,
-        "locations": ["SCALAR"],
-        "args": [
-          {
-            "name": "url",
-            "description": "The URL that specifies the behavior of this scalar.",
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },

--- a/modules/delegates/api/fetchDelegatedTo.ts
+++ b/modules/delegates/api/fetchDelegatedTo.ts
@@ -31,8 +31,8 @@ export async function fetchDelegatedTo(
 
     const res: MKRDelegatedToDAIResponse[] = data.mkrDelegatedTo.nodes;
 
-    const delegatedTo = res.reduce((acc, { immediateCaller, lockAmount, blockTimestamp, hash }) => {
-      const existing = acc.find(({ address }) => address === immediateCaller) as
+    const delegatedTo = res.reduce((acc, { delegateContractAddress, lockAmount, blockTimestamp, hash }) => {
+      const existing = acc.find(({ address }) => address === delegateContractAddress) as
         | DelegationHistoryWithExpirationDate
         | undefined;
 
@@ -44,7 +44,7 @@ export async function fetchDelegatedTo(
         existing.events.push({ lockAmount, blockTimestamp, hash });
       } else {
         const delegatingTo = delegates.find(
-          i => i?.voteDelegate?.toLowerCase() === immediateCaller.toLowerCase()
+          i => i?.voteDelegate?.toLowerCase() === delegateContractAddress.toLowerCase()
         );
 
         const delegatingToWalletAddress = delegatingTo?.delegate?.toLowerCase();
@@ -63,7 +63,7 @@ export async function fetchDelegatedTo(
           : null;
 
         acc.push({
-          address: immediateCaller,
+          address: delegateContractAddress,
           expirationDate,
           isExpired,
           isAboutToExpire: !isExpired && isAboutToExpire,

--- a/modules/delegates/api/fetchDelegatedTo.ts
+++ b/modules/delegates/api/fetchDelegatedTo.ts
@@ -4,7 +4,7 @@ import logger from 'lib/logger';
 import { Query } from 'modules/gql/generated/graphql';
 import { gqlRequest } from 'modules/gql/gqlRequest';
 import { allDelegates } from 'modules/gql/queries/allDelegates';
-import { mkrDelegatedTo } from 'modules/gql/queries/mkrDelegatedTo';
+import { mkrDelegatedToV2 } from 'modules/gql/queries/mkrDelegatedTo';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { isAboutToExpireCheck, isExpiredCheck } from 'modules/migration/helpers/expirationChecks';
@@ -19,18 +19,18 @@ export async function fetchDelegatedTo(
     // Returns the records with the aggregated delegated data
     const data = await gqlRequest({
       chainId: networkNameToChainId(network),
-      query: mkrDelegatedTo,
+      query: mkrDelegatedToV2,
       variables: { argAddress: address.toLowerCase() }
     });
-
+    console.log('data', data);
     // We fetch the delegates information from the DB to extract the expiry date of each delegate
     // TODO: This information could be aggregated in the "mkrDelegatedTo" query in gov-polling-db, and returned there, as an improvement.
     const chainId = networkNameToChainId(network);
     const delegatesData = await gqlRequest<Query>({ chainId, query: allDelegates });
     const delegates = delegatesData.allDelegates.nodes;
 
-    const res: MKRDelegatedToDAIResponse[] = data.mkrDelegatedTo.nodes;
-
+    const res: MKRDelegatedToDAIResponse[] = data.mkrDelegatedToV2.nodes;
+    console.log('res', res);
     const delegatedTo = res.reduce((acc, { delegateContractAddress, lockAmount, blockTimestamp, hash }) => {
       const existing = acc.find(({ address }) => address === delegateContractAddress) as
         | DelegationHistoryWithExpirationDate

--- a/modules/delegates/api/fetchDelegatedTo.ts
+++ b/modules/delegates/api/fetchDelegatedTo.ts
@@ -22,7 +22,6 @@ export async function fetchDelegatedTo(
       query: mkrDelegatedToV2,
       variables: { argAddress: address.toLowerCase() }
     });
-    console.log('data', data);
     // We fetch the delegates information from the DB to extract the expiry date of each delegate
     // TODO: This information could be aggregated in the "mkrDelegatedTo" query in gov-polling-db, and returned there, as an improvement.
     const chainId = networkNameToChainId(network);
@@ -30,7 +29,6 @@ export async function fetchDelegatedTo(
     const delegates = delegatesData.allDelegates.nodes;
 
     const res: MKRDelegatedToDAIResponse[] = data.mkrDelegatedToV2.nodes;
-    console.log('res', res);
     const delegatedTo = res.reduce((acc, { delegateContractAddress, lockAmount, blockTimestamp, hash }) => {
       const existing = acc.find(({ address }) => address === delegateContractAddress) as
         | DelegationHistoryWithExpirationDate

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -222,7 +222,7 @@ export async function fetchDelegates(
 
       // Filter the lock events to get only the ones for this delegate address
       const mkrLockedDelegate = lockEvents.filter(
-        ({ immediateCaller }) => immediateCaller.toLowerCase() === delegate.voteDelegateAddress.toLowerCase()
+        ({ delegateContractAddress }) => delegateContractAddress.toLowerCase() === delegate.voteDelegateAddress.toLowerCase()
       );
 
       const lastVote = await fetchLastPollVote(delegate.voteDelegateAddress, currentNetwork);

--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -222,7 +222,8 @@ export async function fetchDelegates(
 
       // Filter the lock events to get only the ones for this delegate address
       const mkrLockedDelegate = lockEvents.filter(
-        ({ delegateContractAddress }) => delegateContractAddress.toLowerCase() === delegate.voteDelegateAddress.toLowerCase()
+        ({ delegateContractAddress }) =>
+          delegateContractAddress.toLowerCase() === delegate.voteDelegateAddress.toLowerCase()
       );
 
       const lastVote = await fetchLastPollVote(delegate.voteDelegateAddress, currentNetwork);

--- a/modules/delegates/api/fetchDelegationEventsByAddresses.ts
+++ b/modules/delegates/api/fetchDelegationEventsByAddresses.ts
@@ -1,6 +1,6 @@
 import logger from 'lib/logger';
 import { gqlRequest } from 'modules/gql/gqlRequest';
-import { mkrLockedDelegateArrayTotals } from 'modules/gql/queries/mkrLockedDelegateArray';
+import { mkrLockedDelegateArrayTotalsV2 } from 'modules/gql/queries/mkrLockedDelegateArray';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { MKRLockedDelegateAPIResponse } from '../types';
@@ -10,18 +10,19 @@ export async function fetchDelegationEventsByAddresses(
   network: SupportedNetworks
 ): Promise<MKRLockedDelegateAPIResponse[]> {
   try {
+    console.log('about to call mkrLockedDelegateArrayTotalsV2!');
     const data = await gqlRequest({
       chainId: networkNameToChainId(network),
-      query: mkrLockedDelegateArrayTotals,
+      query: mkrLockedDelegateArrayTotalsV2,
       variables: {
         argAddress: addresses,
         argUnixTimeStart: 0,
         argUnixTimeEnd: Math.floor(Date.now() / 1000)
       }
     });
-
-    const addressData: MKRLockedDelegateAPIResponse[] = data.mkrLockedDelegateArrayTotals.nodes;
-
+    console.log('data', data);
+    const addressData: MKRLockedDelegateAPIResponse[] = data.mkrLockedDelegateArrayTotalsV2.nodes;
+    console.log('addressData', addressData);
     return addressData;
   } catch (e) {
     logger.error('fetchDelegationEventsByAddresses: Error fetching delegation events', e.message);

--- a/modules/delegates/api/fetchDelegationEventsByAddresses.ts
+++ b/modules/delegates/api/fetchDelegationEventsByAddresses.ts
@@ -10,7 +10,6 @@ export async function fetchDelegationEventsByAddresses(
   network: SupportedNetworks
 ): Promise<MKRLockedDelegateAPIResponse[]> {
   try {
-    console.log('about to call mkrLockedDelegateArrayTotalsV2!');
     const data = await gqlRequest({
       chainId: networkNameToChainId(network),
       query: mkrLockedDelegateArrayTotalsV2,
@@ -20,9 +19,7 @@ export async function fetchDelegationEventsByAddresses(
         argUnixTimeEnd: Math.floor(Date.now() / 1000)
       }
     });
-    console.log('data', data);
     const addressData: MKRLockedDelegateAPIResponse[] = data.mkrLockedDelegateArrayTotalsV2.nodes;
-    console.log('addressData', addressData);
     return addressData;
   } catch (e) {
     logger.error('fetchDelegationEventsByAddresses: Error fetching delegation events', e.message);

--- a/modules/delegates/helpers/formatDelegationHistory.ts
+++ b/modules/delegates/helpers/formatDelegationHistory.ts
@@ -3,8 +3,8 @@ import { DelegationHistory, MKRLockedDelegateAPIResponse } from '../types/delega
 
 export const formatDelegationHistory = (lockEvents: MKRLockedDelegateAPIResponse[]): DelegationHistory[] => {
   const delegators = lockEvents.reduce<DelegationHistory[]>(
-    (acc, { fromAddress, lockAmount, blockTimestamp, hash }) => {
-      const existing = acc.find(({ address }) => address === fromAddress);
+    (acc, { immediateCaller, lockAmount, blockTimestamp, hash }) => {
+      const existing = acc.find(({ address }) => address === immediateCaller);
       if (existing) {
         existing.lockAmount = utils.formatEther(
           utils.parseEther(existing.lockAmount).add(utils.parseEther(lockAmount))
@@ -12,7 +12,7 @@ export const formatDelegationHistory = (lockEvents: MKRLockedDelegateAPIResponse
         existing.events.push({ lockAmount, blockTimestamp, hash });
       } else {
         acc.push({
-          address: fromAddress,
+          address: immediateCaller,
           lockAmount: utils.formatEther(utils.parseEther(lockAmount)),
           events: [{ lockAmount, blockTimestamp, hash }]
         });

--- a/modules/delegates/types/delegate.d.ts
+++ b/modules/delegates/types/delegate.d.ts
@@ -81,6 +81,7 @@ export type DelegationHistoryEvent = {
 export type MKRLockedDelegateAPIResponse = {
   fromAddress: string;
   immediateCaller: string;
+  delegateContractAddress: string;
   lockAmount: string;
   blockNumber: number;
   blockTimestamp: string;

--- a/modules/gql/generated/graphql.tsx
+++ b/modules/gql/generated/graphql.tsx
@@ -10,13 +10,9 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** A floating point number that requires more precision than IEEE 754 binary 64 */
   BigFloat: any;
-  /** A signed eight-byte integer. The upper big integer values are greater than the max value for a JavaScript number. Therefore all big integers will be output as strings and not numbers. */
   BigInt: any;
-  /** A location in a connection that can be used for resuming pagination. */
   Cursor: any;
-  /** A point in time as described by the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone. */
   Datetime: any;
 };
 
@@ -986,6 +982,60 @@ export type MkrDelegatedToRecordFilter = {
   or?: InputMaybe<Array<MkrDelegatedToRecordFilter>>;
 };
 
+/** A connection to a list of `MkrDelegatedToV2Record` values. */
+export type MkrDelegatedToV2Connection = {
+  __typename?: 'MkrDelegatedToV2Connection';
+  /** A list of edges which contains the `MkrDelegatedToV2Record` and cursor to aid in pagination. */
+  edges: Array<MkrDelegatedToV2Edge>;
+  /** A list of `MkrDelegatedToV2Record` objects. */
+  nodes: Array<Maybe<MkrDelegatedToV2Record>>;
+};
+
+/** A `MkrDelegatedToV2Record` edge in the connection. */
+export type MkrDelegatedToV2Edge = {
+  __typename?: 'MkrDelegatedToV2Edge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `MkrDelegatedToV2Record` at the end of the edge. */
+  node?: Maybe<MkrDelegatedToV2Record>;
+};
+
+/** The return type of our `mkrDelegatedToV2` query. */
+export type MkrDelegatedToV2Record = {
+  __typename?: 'MkrDelegatedToV2Record';
+  blockNumber?: Maybe<Scalars['Int']>;
+  blockTimestamp?: Maybe<Scalars['Datetime']>;
+  delegateContractAddress?: Maybe<Scalars['String']>;
+  fromAddress?: Maybe<Scalars['String']>;
+  hash?: Maybe<Scalars['String']>;
+  immediateCaller?: Maybe<Scalars['String']>;
+  lockAmount?: Maybe<Scalars['BigFloat']>;
+};
+
+/** A filter to be used against `MkrDelegatedToV2Record` object types. All fields are combined with a logical ‘and.’ */
+export type MkrDelegatedToV2RecordFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<MkrDelegatedToV2RecordFilter>>;
+  /** Filter by the object’s `blockNumber` field. */
+  blockNumber?: InputMaybe<IntFilter>;
+  /** Filter by the object’s `blockTimestamp` field. */
+  blockTimestamp?: InputMaybe<DatetimeFilter>;
+  /** Filter by the object’s `delegateContractAddress` field. */
+  delegateContractAddress?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `fromAddress` field. */
+  fromAddress?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `hash` field. */
+  hash?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `immediateCaller` field. */
+  immediateCaller?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `lockAmount` field. */
+  lockAmount?: InputMaybe<BigFloatFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<MkrDelegatedToV2RecordFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<MkrDelegatedToV2RecordFilter>>;
+};
+
 /** A connection to a list of `MkrLockedDelegateArrayRecord` values. */
 export type MkrLockedDelegateArrayConnection = {
   __typename?: 'MkrLockedDelegateArrayConnection';
@@ -1097,6 +1147,66 @@ export type MkrLockedDelegateArrayTotalsRecordFilter = {
   or?: InputMaybe<Array<MkrLockedDelegateArrayTotalsRecordFilter>>;
 };
 
+/** A connection to a list of `MkrLockedDelegateArrayTotalsV2Record` values. */
+export type MkrLockedDelegateArrayTotalsV2Connection = {
+  __typename?: 'MkrLockedDelegateArrayTotalsV2Connection';
+  /** A list of edges which contains the `MkrLockedDelegateArrayTotalsV2Record` and cursor to aid in pagination. */
+  edges: Array<MkrLockedDelegateArrayTotalsV2Edge>;
+  /** A list of `MkrLockedDelegateArrayTotalsV2Record` objects. */
+  nodes: Array<Maybe<MkrLockedDelegateArrayTotalsV2Record>>;
+};
+
+/** A `MkrLockedDelegateArrayTotalsV2Record` edge in the connection. */
+export type MkrLockedDelegateArrayTotalsV2Edge = {
+  __typename?: 'MkrLockedDelegateArrayTotalsV2Edge';
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `MkrLockedDelegateArrayTotalsV2Record` at the end of the edge. */
+  node?: Maybe<MkrLockedDelegateArrayTotalsV2Record>;
+};
+
+/** The return type of our `mkrLockedDelegateArrayTotalsV2` query. */
+export type MkrLockedDelegateArrayTotalsV2Record = {
+  __typename?: 'MkrLockedDelegateArrayTotalsV2Record';
+  blockNumber?: Maybe<Scalars['Int']>;
+  blockTimestamp?: Maybe<Scalars['Datetime']>;
+  callerLockTotal?: Maybe<Scalars['BigFloat']>;
+  delegateContractAddress?: Maybe<Scalars['String']>;
+  fromAddress?: Maybe<Scalars['String']>;
+  hash?: Maybe<Scalars['String']>;
+  immediateCaller?: Maybe<Scalars['String']>;
+  lockAmount?: Maybe<Scalars['BigFloat']>;
+  lockTotal?: Maybe<Scalars['BigFloat']>;
+};
+
+/** A filter to be used against `MkrLockedDelegateArrayTotalsV2Record` object types. All fields are combined with a logical ‘and.’ */
+export type MkrLockedDelegateArrayTotalsV2RecordFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<MkrLockedDelegateArrayTotalsV2RecordFilter>>;
+  /** Filter by the object’s `blockNumber` field. */
+  blockNumber?: InputMaybe<IntFilter>;
+  /** Filter by the object’s `blockTimestamp` field. */
+  blockTimestamp?: InputMaybe<DatetimeFilter>;
+  /** Filter by the object’s `callerLockTotal` field. */
+  callerLockTotal?: InputMaybe<BigFloatFilter>;
+  /** Filter by the object’s `delegateContractAddress` field. */
+  delegateContractAddress?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `fromAddress` field. */
+  fromAddress?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `hash` field. */
+  hash?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `immediateCaller` field. */
+  immediateCaller?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `lockAmount` field. */
+  lockAmount?: InputMaybe<BigFloatFilter>;
+  /** Filter by the object’s `lockTotal` field. */
+  lockTotal?: InputMaybe<BigFloatFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<MkrLockedDelegateArrayTotalsV2RecordFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<MkrLockedDelegateArrayTotalsV2RecordFilter>>;
+};
+
 /** A connection to a list of `MkrLockedDelegateRecord` values. */
 export type MkrLockedDelegateConnection = {
   __typename?: 'MkrLockedDelegateConnection';
@@ -1180,9 +1290,11 @@ export type Query = Node & {
   hotOrColdWeightAtTime: HotOrColdWeightAtTimeConnection;
   hotOrColdWeightCurrently: HotOrColdWeightCurrentlyConnection;
   mkrDelegatedTo: MkrDelegatedToConnection;
+  mkrDelegatedToV2: MkrDelegatedToV2Connection;
   mkrLockedDelegate: MkrLockedDelegateConnection;
   mkrLockedDelegateArray: MkrLockedDelegateArrayConnection;
   mkrLockedDelegateArrayTotals: MkrLockedDelegateArrayTotalsConnection;
+  mkrLockedDelegateArrayTotalsV2: MkrLockedDelegateArrayTotalsV2Connection;
   /** Fetches an object given its globally unique `ID`. */
   node?: Maybe<Node>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
@@ -1201,6 +1313,7 @@ export type Query = Node & {
   voteOptionMkrWeightsCurrently: VoteOptionMkrWeightsCurrentlyConnection;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollByIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1211,6 +1324,7 @@ export type QueryActivePollByIdArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollByMultihashArgs = {
@@ -1223,6 +1337,7 @@ export type QueryActivePollByMultihashArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1232,6 +1347,7 @@ export type QueryActivePollsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllCurrentVotesArgs = {
@@ -1244,6 +1360,7 @@ export type QueryAllCurrentVotesArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAllCurrentVotesArrayArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1255,6 +1372,7 @@ export type QueryAllCurrentVotesArrayArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAllDelegatesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1264,6 +1382,7 @@ export type QueryAllDelegatesArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllEsmJoinsArgs = {
@@ -1275,6 +1394,7 @@ export type QueryAllEsmJoinsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryAllEsmV2JoinsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1284,6 +1404,7 @@ export type QueryAllEsmV2JoinsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllLocksSummedArgs = {
@@ -1297,6 +1418,7 @@ export type QueryAllLocksSummedArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryBuggyVoteAddressMkrWeightsAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1308,6 +1430,7 @@ export type QueryBuggyVoteAddressMkrWeightsAtTimeArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryBuggyVoteMkrWeightsAtTimeRankedChoiceArgs = {
@@ -1321,6 +1444,7 @@ export type QueryBuggyVoteMkrWeightsAtTimeRankedChoiceArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1331,6 +1455,7 @@ export type QueryCombinedChiefAndMkrBalancesArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesAtTimeArgs = {
@@ -1343,6 +1468,7 @@ export type QueryCombinedChiefAndMkrBalancesAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1352,6 +1478,7 @@ export type QueryCombinedChiefAndMkrBalancesCurrentlyArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryCurrentVoteArgs = {
@@ -1365,6 +1492,7 @@ export type QueryCurrentVoteArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryCurrentVoteRankedChoiceArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1377,6 +1505,7 @@ export type QueryCurrentVoteRankedChoiceArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1387,6 +1516,7 @@ export type QueryHotOrColdWeightArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightAtTimeArgs = {
@@ -1399,6 +1529,7 @@ export type QueryHotOrColdWeightAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1408,6 +1539,7 @@ export type QueryHotOrColdWeightCurrentlyArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrDelegatedToArgs = {
@@ -1419,6 +1551,19 @@ export type QueryMkrDelegatedToArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryMkrDelegatedToV2Args = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  argAddress: Scalars['String'];
+  before?: InputMaybe<Scalars['Cursor']>;
+  filter?: InputMaybe<MkrDelegatedToV2RecordFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArgs = {
@@ -1433,6 +1578,7 @@ export type QueryMkrLockedDelegateArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArrayArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1445,6 +1591,7 @@ export type QueryMkrLockedDelegateArrayArgs = {
   unixtimeEnd: Scalars['Int'];
   unixtimeStart: Scalars['Int'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArrayTotalsArgs = {
@@ -1459,10 +1606,26 @@ export type QueryMkrLockedDelegateArrayTotalsArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
+
+/** The root query type which gives access points into the data universe. */
+export type QueryMkrLockedDelegateArrayTotalsV2Args = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  argAddress: Array<InputMaybe<Scalars['String']>>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  filter?: InputMaybe<MkrLockedDelegateArrayTotalsV2RecordFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  unixtimeEnd: Scalars['Int'];
+  unixtimeStart: Scalars['Int'];
+};
+
+
 /** The root query type which gives access points into the data universe. */
 export type QueryNodeArgs = {
   nodeId: Scalars['ID'];
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryTimeToBlockNumberArgs = {
@@ -1474,6 +1637,7 @@ export type QueryTimeToBlockNumberArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressArgs = {
@@ -1487,6 +1651,7 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1499,6 +1664,7 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1510,6 +1676,7 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressCurrentlyArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryUniqueVotersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1519,6 +1686,7 @@ export type QueryUniqueVotersArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteAddressMkrWeightsAtTimeArgs = {
@@ -1532,6 +1700,7 @@ export type QueryVoteAddressMkrWeightsAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteMkrWeightsAtTimeRankedChoiceArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1543,6 +1712,7 @@ export type QueryVoteMkrWeightsAtTimeRankedChoiceArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsArgs = {
@@ -1556,6 +1726,7 @@ export type QueryVoteOptionMkrWeightsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
+
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1567,6 +1738,7 @@ export type QueryVoteOptionMkrWeightsAtTimeArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
+
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsCurrentlyArgs = {
@@ -2000,5615 +2172,6038 @@ export type VoteOptionMkrWeightsRecordFilter = {
 
 import { IntrospectionQuery } from 'graphql';
 export default {
-  __schema: {
-    queryType: {
-      name: 'Query'
+  "__schema": {
+    "queryType": {
+      "name": "Query"
     },
-    mutationType: null,
-    subscriptionType: null,
-    types: [
+    "mutationType": null,
+    "subscriptionType": null,
+    "types": [
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByIdConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByIdConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'ActivePollByIdEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivePollByIdEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'ActivePollByIdRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ActivePollByIdRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByIdEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByIdEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'ActivePollByIdRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ActivePollByIdRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByIdRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByIdRecord",
+        "fields": [
           {
-            name: 'blockCreated',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockCreated",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'creator',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "creator",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'endDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "endDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'multiHash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "multiHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'pollId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "pollId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'startDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "startDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'url',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByMultihashConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByMultihashConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'ActivePollByMultihashEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivePollByMultihashEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'ActivePollByMultihashRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ActivePollByMultihashRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByMultihashEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByMultihashEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'ActivePollByMultihashRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ActivePollByMultihashRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollByMultihashRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollByMultihashRecord",
+        "fields": [
           {
-            name: 'blockCreated',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockCreated",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'creator',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "creator",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'endDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "endDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'multiHash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "multiHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'pollId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "pollId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'startDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "startDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'url',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'ActivePollsRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ActivePollsRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollsConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollsConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'ActivePollEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ActivePollEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'ActivePollsRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ActivePollsRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'ActivePollsRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "ActivePollsRecord",
+        "fields": [
           {
-            name: 'blockCreated',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockCreated",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'creator',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "creator",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'endDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "endDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'multiHash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "multiHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'pollId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "pollId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'startDate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "startDate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'url',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "url",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVoteEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVoteEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllCurrentVotesRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllCurrentVotesRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVotesArrayConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVotesArrayConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllCurrentVotesArrayEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllCurrentVotesArrayEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllCurrentVotesArrayRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllCurrentVotesArrayRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVotesArrayEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVotesArrayEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllCurrentVotesArrayRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllCurrentVotesArrayRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVotesArrayRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVotesArrayRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'pollId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "pollId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'voter',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "voter",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVotesConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVotesConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllCurrentVoteEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllCurrentVoteEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllCurrentVotesRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllCurrentVotesRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllCurrentVotesRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllCurrentVotesRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'pollId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "pollId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllDelegateEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllDelegateEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllDelegatesRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllDelegatesRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllDelegatesConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllDelegatesConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllDelegateEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllDelegateEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllDelegatesRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllDelegatesRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllDelegatesRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllDelegatesRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'delegate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "delegate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'voteDelegate',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "voteDelegate",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmJoinEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmJoinEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllEsmJoinsRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllEsmJoinsRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmJoinsConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmJoinsConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllEsmJoinEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllEsmJoinEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllEsmJoinsRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllEsmJoinsRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmJoinsRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmJoinsRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'joinAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "joinAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'txFrom',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "txFrom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'txHash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "txHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmV2JoinEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmV2JoinEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllEsmV2JoinsRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllEsmV2JoinsRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmV2JoinsConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmV2JoinsConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllEsmV2JoinEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllEsmV2JoinEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllEsmV2JoinsRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllEsmV2JoinsRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllEsmV2JoinsRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllEsmV2JoinsRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'joinAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "joinAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'txFrom',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "txFrom",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'txHash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "txHash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllLocksSummedConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllLocksSummedConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'AllLocksSummedEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AllLocksSummedEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'AllLocksSummedRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AllLocksSummedRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllLocksSummedEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllLocksSummedEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'AllLocksSummedRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "AllLocksSummedRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'AllLocksSummedRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "AllLocksSummedRecord",
+        "fields": [
           {
-            name: 'blockNumber',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'fromAddress',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'hash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'immediateCaller',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'lockAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'lockTotal',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "lockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteAddressMkrWeightsAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteAddressMkrWeightsAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'BuggyVoteAddressMkrWeightsAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BuggyVoteAddressMkrWeightsAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteAddressMkrWeightsAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteAddressMkrWeightsAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'voter',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "voter",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalanceEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalanceEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'CombinedChiefAndMkrBalancesRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CombinedChiefAndMkrBalancesRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'CombinedChiefAndMkrBalancesAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CombinedChiefAndMkrBalancesAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'mkrAndChiefBalance',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrAndChiefBalance",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'CombinedChiefAndMkrBalanceEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CombinedChiefAndMkrBalanceEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'CombinedChiefAndMkrBalancesRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CombinedChiefAndMkrBalancesRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesCurrentlyConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesCurrentlyConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'CombinedChiefAndMkrBalancesCurrentlyEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CombinedChiefAndMkrBalancesCurrentlyEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesCurrentlyEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesCurrentlyEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'mkrAndChiefBalance',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrAndChiefBalance",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CombinedChiefAndMkrBalancesRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CombinedChiefAndMkrBalancesRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'mkrAndChiefBalance',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrAndChiefBalance",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'CurrentVoteEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CurrentVoteEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'CurrentVoteRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CurrentVoteRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'CurrentVoteRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CurrentVoteRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteRankedChoiceConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteRankedChoiceConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'CurrentVoteRankedChoiceEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CurrentVoteRankedChoiceEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'CurrentVoteRankedChoiceRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CurrentVoteRankedChoiceRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteRankedChoiceEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteRankedChoiceEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'CurrentVoteRankedChoiceRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "CurrentVoteRankedChoiceRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteRankedChoiceRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteRankedChoiceRecord",
+        "fields": [
           {
-            name: 'blockId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'CurrentVoteRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "CurrentVoteRecord",
+        "fields": [
           {
-            name: 'blockId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'HotOrColdWeightAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "HotOrColdWeightAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'HotOrColdWeightAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "HotOrColdWeightAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'HotOrColdWeightAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "HotOrColdWeightAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightAtTimeRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'totalWeight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "totalWeight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'HotOrColdWeightEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "HotOrColdWeightEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'HotOrColdWeightRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "HotOrColdWeightRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightCurrentlyConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightCurrentlyConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'HotOrColdWeightCurrentlyEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "HotOrColdWeightCurrentlyEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'HotOrColdWeightCurrentlyRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "HotOrColdWeightCurrentlyRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightCurrentlyEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightCurrentlyEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'HotOrColdWeightCurrentlyRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "HotOrColdWeightCurrentlyRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightCurrentlyRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightCurrentlyRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'totalWeight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "totalWeight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'HotOrColdWeightRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "HotOrColdWeightRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'HotOrColdWeightRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "HotOrColdWeightRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'totalWeight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "totalWeight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrDelegatedToConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'MkrDelegatedToEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrDelegatedToEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'MkrDelegatedToRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrDelegatedToRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrDelegatedToEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'MkrDelegatedToRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrDelegatedToRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrDelegatedToRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToRecord",
+        "fields": [
           {
-            name: 'blockNumber',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'fromAddress',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'hash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'immediateCaller',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'lockAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Connection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'MkrLockedDelegateArrayEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrDelegatedToV2Edge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'MkrLockedDelegateArrayRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrDelegatedToV2Record",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Edge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'MkrLockedDelegateArrayRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrDelegatedToV2Record",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrDelegatedToV2Record",
+        "fields": [
           {
-            name: 'blockNumber',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'fromAddress',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "delegateContractAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'hash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'immediateCaller',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'lockAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'lockTotal',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayTotalEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayConnection",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'MkrLockedDelegateArrayTotalsRecord',
-              ofType: null
-            },
-            args: []
-          }
-        ],
-        interfaces: []
-      },
-      {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayTotalsConnection',
-        fields: [
-          {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'MkrLockedDelegateArrayTotalEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrLockedDelegateArrayEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'MkrLockedDelegateArrayTotalsRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrLockedDelegateArrayRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateArrayTotalsRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayEdge",
+        "fields": [
           {
-            name: 'blockNumber',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrLockedDelegateArrayRecord",
+              "ofType": null
             },
-            args: []
-          },
-          {
-            name: 'callerLockTotal',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'fromAddress',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'hash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'immediateCaller',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'lockAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'lockTotal',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayRecord",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'MkrLockedDelegateEdge',
-                    ofType: null
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalEdge",
+        "fields": [
+          {
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrLockedDelegateArrayTotalsRecord",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsConnection",
+        "fields": [
+          {
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrLockedDelegateArrayTotalEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'MkrLockedDelegateRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsRecord",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'MkrLockedDelegateRecord',
-              ofType: null
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
+          },
+          {
+            "name": "callerLockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'MkrLockedDelegateRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Connection",
+        "fields": [
           {
-            name: 'blockNumber',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'fromAddress',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'hash',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'immediateCaller',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'lockAmount',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          },
-          {
-            name: 'lockTotal',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
-            },
-            args: []
-          }
-        ],
-        interfaces: []
-      },
-      {
-        kind: 'INTERFACE',
-        name: 'Node',
-        fields: [
-          {
-            name: 'nodeId',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Any'
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrLockedDelegateArrayTotalsV2Edge",
+                    "ofType": null
+                  }
+                }
               }
             },
-            args: []
+            "args": []
+          },
+          {
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrLockedDelegateArrayTotalsV2Record",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
           }
         ],
-        interfaces: [],
-        possibleTypes: [
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Edge",
+        "fields": [
           {
-            kind: 'OBJECT',
-            name: 'Query'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrLockedDelegateArrayTotalsV2Record",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateArrayTotalsV2Record",
+        "fields": [
+          {
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "callerLockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "delegateContractAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateConnection",
+        "fields": [
+          {
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "MkrLockedDelegateEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "MkrLockedDelegateRecord",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateEdge",
+        "fields": [
+          {
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "MkrLockedDelegateRecord",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "MkrLockedDelegateRecord",
+        "fields": [
+          {
+            "name": "blockNumber",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "fromAddress",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hash",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "immediateCaller",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockAmount",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "lockTotal",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "Node",
+        "fields": [
+          {
+            "name": "nodeId",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": [],
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Query"
           }
         ]
       },
       {
-        kind: 'OBJECT',
-        name: 'Query',
-        fields: [
+        "kind": "OBJECT",
+        "name": "Query",
+        "fields": [
           {
-            name: 'activePollById',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'ActivePollByIdConnection',
-                ofType: null
+            "name": "activePollById",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivePollByIdConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'activePollByMultihash',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'ActivePollByMultihashConnection',
-                ofType: null
+            "name": "activePollByMultihash",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivePollByMultihashConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollMultihash',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argPollMultihash",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'activePolls',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'ActivePollsConnection',
-                ofType: null
+            "name": "activePolls",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ActivePollsConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'allCurrentVotes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllCurrentVotesConnection',
-                ofType: null
+            "name": "allCurrentVotes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllCurrentVotesConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'allCurrentVotesArray',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllCurrentVotesArrayConnection',
-                ofType: null
+            "name": "allCurrentVotesArray",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllCurrentVotesArrayConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'LIST',
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "LIST",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Any"
                     }
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'allDelegates',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllDelegatesConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'allEsmJoins',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllEsmJoinsConnection',
-                ofType: null
+            "name": "allDelegates",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllDelegatesConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'allEsmV2Joins',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllEsmV2JoinsConnection',
-                ofType: null
+            "name": "allEsmJoins",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllEsmJoinsConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'allLocksSummed',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'AllLocksSummedConnection',
-                ofType: null
+            "name": "allEsmV2Joins",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllEsmV2JoinsConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'unixtimeEnd',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'unixtimeStart',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'buggyVoteAddressMkrWeightsAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'BuggyVoteAddressMkrWeightsAtTimeConnection',
-                ofType: null
+            "name": "allLocksSummed",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AllLocksSummedConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "unixtimeEnd",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'buggyVoteMkrWeightsAtTimeRankedChoice',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'combinedChiefAndMkrBalances',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'CombinedChiefAndMkrBalancesConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argBlockNumber',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'combinedChiefAndMkrBalancesAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'CombinedChiefAndMkrBalancesAtTimeConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'combinedChiefAndMkrBalancesCurrently',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'CombinedChiefAndMkrBalancesCurrentlyConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'currentVote',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'CurrentVoteConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'currentVoteRankedChoice',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'CurrentVoteRankedChoiceConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'hotOrColdWeight',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'HotOrColdWeightConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argBlockNumber',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'hotOrColdWeightAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'HotOrColdWeightAtTimeConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'hotOrColdWeightCurrently',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'HotOrColdWeightCurrentlyConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'mkrDelegatedTo',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'MkrDelegatedToConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              }
-            ]
-          },
-          {
-            name: 'mkrLockedDelegate',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'MkrLockedDelegateConnection',
-                ofType: null
-              }
-            },
-            args: [
-              {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'unixtimeEnd',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'unixtimeStart',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "unixtimeStart",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               }
             ]
           },
           {
-            name: 'mkrLockedDelegateArray',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'MkrLockedDelegateArrayConnection',
-                ofType: null
+            "name": "buggyVoteAddressMkrWeightsAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuggyVoteAddressMkrWeightsAtTimeConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'LIST',
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "buggyVoteMkrWeightsAtTimeRankedChoice",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "combinedChiefAndMkrBalances",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CombinedChiefAndMkrBalancesConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argBlockNumber",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "combinedChiefAndMkrBalancesAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CombinedChiefAndMkrBalancesAtTimeConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "combinedChiefAndMkrBalancesCurrently",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CombinedChiefAndMkrBalancesCurrentlyConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "currentVote",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CurrentVoteConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "currentVoteRankedChoice",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CurrentVoteRankedChoiceConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hotOrColdWeight",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "HotOrColdWeightConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argBlockNumber",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hotOrColdWeightAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "HotOrColdWeightAtTimeConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hotOrColdWeightCurrently",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "HotOrColdWeightCurrentlyConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "mkrDelegatedTo",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrDelegatedToConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "mkrDelegatedToV2",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrDelegatedToV2Connection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "mkrLockedDelegate",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrLockedDelegateConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "unixtimeEnd",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "unixtimeStart",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "mkrLockedDelegateArray",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrLockedDelegateArrayConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "LIST",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Any"
                     }
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'unixtimeEnd',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "unixtimeEnd",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'unixtimeStart',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "unixtimeStart",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               }
             ]
           },
           {
-            name: 'mkrLockedDelegateArrayTotals',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'MkrLockedDelegateArrayTotalsConnection',
-                ofType: null
+            "name": "mkrLockedDelegateArrayTotals",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrLockedDelegateArrayTotalsConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'LIST',
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "LIST",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Any"
                     }
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'unixtimeEnd',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "unixtimeEnd",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'unixtimeStart',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              }
-            ]
-          },
-          {
-            name: 'node',
-            type: {
-              kind: 'INTERFACE',
-              name: 'Node',
-              ofType: null
-            },
-            args: [
-              {
-                name: 'nodeId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "unixtimeStart",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               }
             ]
           },
           {
-            name: 'nodeId',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'SCALAR',
-                name: 'Any'
+            "name": "mkrLockedDelegateArrayTotalsV2",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "MkrLockedDelegateArrayTotalsV2Connection",
+                "ofType": null
               }
             },
-            args: []
-          },
-          {
-            name: 'query',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'Query',
-                ofType: null
-              }
-            },
-            args: []
-          },
-          {
-            name: 'timeToBlockNumber',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'TimeToBlockNumberConnection',
-                ofType: null
-              }
-            },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "LIST",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Any"
+                    }
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "unixtimeEnd",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "unixtimeStart",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
                 }
               }
             ]
           },
           {
-            name: 'totalMkrWeightProxyAndNoProxyByAddress',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'TotalMkrWeightProxyAndNoProxyByAddressConnection',
-                ofType: null
-              }
+            "name": "node",
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "nodeId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
-                }
-              },
-              {
-                name: 'argBlockNumber',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
-                }
-              },
-              {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
                 }
               }
             ]
           },
           {
-            name: 'totalMkrWeightProxyAndNoProxyByAddressAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection',
-                ofType: null
+            "name": "nodeId",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
               }
             },
-            args: [
+            "args": []
+          },
+          {
+            "name": "query",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Query",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "timeToBlockNumber",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimeToBlockNumberConnection",
+                "ofType": null
+              }
+            },
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'totalMkrWeightProxyAndNoProxyByAddressCurrently',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection',
-                ofType: null
+            "name": "totalMkrWeightProxyAndNoProxyByAddress",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TotalMkrWeightProxyAndNoProxyByAddressConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argAddress',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "argBlockNumber",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'uniqueVoters',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'UniqueVotersConnection',
-                ofType: null
+            "name": "totalMkrWeightProxyAndNoProxyByAddressAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'voteAddressMkrWeightsAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'VoteAddressMkrWeightsAtTimeConnection',
-                ofType: null
+            "name": "totalMkrWeightProxyAndNoProxyByAddressCurrently",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argAddress",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'voteMkrWeightsAtTimeRankedChoice',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'VoteMkrWeightsAtTimeRankedChoiceConnection',
-                ofType: null
+            "name": "uniqueVoters",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueVotersConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
-                  }
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
-                }
-              },
-              {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'voteOptionMkrWeights',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'VoteOptionMkrWeightsConnection',
-                ofType: null
+            "name": "voteAddressMkrWeightsAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteAddressMkrWeightsAtTimeConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argBlockNumber',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'voteOptionMkrWeightsAtTime',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'VoteOptionMkrWeightsAtTimeConnection',
-                ofType: null
+            "name": "voteMkrWeightsAtTimeRankedChoice",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteMkrWeightsAtTimeRankedChoiceConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'argUnix',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           },
           {
-            name: 'voteOptionMkrWeightsCurrently',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'OBJECT',
-                name: 'VoteOptionMkrWeightsCurrentlyConnection',
-                ofType: null
+            "name": "voteOptionMkrWeights",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteOptionMkrWeightsConnection",
+                "ofType": null
               }
             },
-            args: [
+            "args": [
               {
-                name: 'after',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'argPollId',
-                type: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'SCALAR',
-                    name: 'Any'
+                "name": "argBlockNumber",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
                   }
                 }
               },
               {
-                name: 'before',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
                 }
               },
               {
-                name: 'filter',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'first',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'last',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               },
               {
-                name: 'offset',
-                type: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "voteOptionMkrWeightsAtTime",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteOptionMkrWeightsAtTimeConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "argUnix",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "voteOptionMkrWeightsCurrently",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "VoteOptionMkrWeightsCurrentlyConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "argPollId",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "filter",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "offset",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             ]
           }
         ],
-        interfaces: [
+        "interfaces": [
           {
-            kind: 'INTERFACE',
-            name: 'Node'
+            "kind": "INTERFACE",
+            "name": "Node"
           }
         ]
       },
       {
-        kind: 'OBJECT',
-        name: 'TimeToBlockNumberConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TimeToBlockNumberConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'TimeToBlockNumberEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TimeToBlockNumberEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TimeToBlockNumberEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TimeToBlockNumberEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "node",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'weight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "weight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'TotalMkrWeightProxyAndNoProxyByAddressEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TotalMkrWeightProxyAndNoProxyByAddressEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'weight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "weight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
+        "fields": [
           {
-            name: 'address',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "address",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'weight',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "weight",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'UniqueVoterEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "UniqueVoterEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "node",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'UniqueVotersConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "UniqueVotersConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'UniqueVoterEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UniqueVoterEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'SCALAR',
-                  name: 'Any'
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Any"
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteAddressMkrWeightsAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteAddressMkrWeightsAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'VoteAddressMkrWeightsAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VoteAddressMkrWeightsAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'VoteAddressMkrWeightsAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VoteAddressMkrWeightsAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteAddressMkrWeightsAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteAddressMkrWeightsAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'VoteAddressMkrWeightsAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "VoteAddressMkrWeightsAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteAddressMkrWeightsAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteAddressMkrWeightsAtTimeRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'voter',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "voter",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteMkrWeightsAtTimeRankedChoiceConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteMkrWeightsAtTimeRankedChoiceConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'VoteMkrWeightsAtTimeRankedChoiceEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VoteMkrWeightsAtTimeRankedChoiceEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteMkrWeightsAtTimeRankedChoiceEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteMkrWeightsAtTimeRankedChoiceEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionIdRaw',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionIdRaw",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'VoteOptionMkrWeightsRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "VoteOptionMkrWeightsRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsAtTimeConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsAtTimeConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'VoteOptionMkrWeightsAtTimeEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VoteOptionMkrWeightsAtTimeEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'VoteOptionMkrWeightsAtTimeRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VoteOptionMkrWeightsAtTimeRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsAtTimeEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsAtTimeEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'VoteOptionMkrWeightsAtTimeRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "VoteOptionMkrWeightsAtTimeRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsAtTimeRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsAtTimeRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'VoteOptionMkrWeightEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VoteOptionMkrWeightEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'VoteOptionMkrWeightsRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VoteOptionMkrWeightsRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsCurrentlyConnection',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsCurrentlyConnection",
+        "fields": [
           {
-            name: 'edges',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'NON_NULL',
-                  ofType: {
-                    kind: 'OBJECT',
-                    name: 'VoteOptionMkrWeightsCurrentlyEdge',
-                    ofType: null
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "VoteOptionMkrWeightsCurrentlyEdge",
+                    "ofType": null
                   }
                 }
               }
             },
-            args: []
+            "args": []
           },
           {
-            name: 'nodes',
-            type: {
-              kind: 'NON_NULL',
-              ofType: {
-                kind: 'LIST',
-                ofType: {
-                  kind: 'OBJECT',
-                  name: 'VoteOptionMkrWeightsCurrentlyRecord',
-                  ofType: null
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VoteOptionMkrWeightsCurrentlyRecord",
+                  "ofType": null
                 }
               }
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsCurrentlyEdge',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsCurrentlyEdge",
+        "fields": [
           {
-            name: 'cursor',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "cursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'node',
-            type: {
-              kind: 'OBJECT',
-              name: 'VoteOptionMkrWeightsCurrentlyRecord',
-              ofType: null
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "VoteOptionMkrWeightsCurrentlyRecord",
+              "ofType": null
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsCurrentlyRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsCurrentlyRecord",
+        "fields": [
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'OBJECT',
-        name: 'VoteOptionMkrWeightsRecord',
-        fields: [
+        "kind": "OBJECT",
+        "name": "VoteOptionMkrWeightsRecord",
+        "fields": [
           {
-            name: 'blockTimestamp',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "blockTimestamp",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'mkrSupport',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "mkrSupport",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           },
           {
-            name: 'optionId',
-            type: {
-              kind: 'SCALAR',
-              name: 'Any'
+            "name": "optionId",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
             },
-            args: []
+            "args": []
           }
         ],
-        interfaces: []
+        "interfaces": []
       },
       {
-        kind: 'SCALAR',
-        name: 'Any'
+        "kind": "SCALAR",
+        "name": "Any"
       }
     ],
-    directives: []
+    "directives": []
   }
 } as unknown as IntrospectionQuery;

--- a/modules/gql/generated/graphql.tsx
+++ b/modules/gql/generated/graphql.tsx
@@ -1313,7 +1313,6 @@ export type Query = Node & {
   voteOptionMkrWeightsCurrently: VoteOptionMkrWeightsCurrentlyConnection;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollByIdArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1324,7 +1323,6 @@ export type QueryActivePollByIdArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollByMultihashArgs = {
@@ -1337,7 +1335,6 @@ export type QueryActivePollByMultihashArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryActivePollsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1347,7 +1344,6 @@ export type QueryActivePollsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllCurrentVotesArgs = {
@@ -1360,7 +1356,6 @@ export type QueryAllCurrentVotesArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAllCurrentVotesArrayArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1372,7 +1367,6 @@ export type QueryAllCurrentVotesArrayArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAllDelegatesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1382,7 +1376,6 @@ export type QueryAllDelegatesArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllEsmJoinsArgs = {
@@ -1394,7 +1387,6 @@ export type QueryAllEsmJoinsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryAllEsmV2JoinsArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1404,7 +1396,6 @@ export type QueryAllEsmV2JoinsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryAllLocksSummedArgs = {
@@ -1418,7 +1409,6 @@ export type QueryAllLocksSummedArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryBuggyVoteAddressMkrWeightsAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1430,7 +1420,6 @@ export type QueryBuggyVoteAddressMkrWeightsAtTimeArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryBuggyVoteMkrWeightsAtTimeRankedChoiceArgs = {
@@ -1444,7 +1433,6 @@ export type QueryBuggyVoteMkrWeightsAtTimeRankedChoiceArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1455,7 +1443,6 @@ export type QueryCombinedChiefAndMkrBalancesArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesAtTimeArgs = {
@@ -1468,7 +1455,6 @@ export type QueryCombinedChiefAndMkrBalancesAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryCombinedChiefAndMkrBalancesCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1478,7 +1464,6 @@ export type QueryCombinedChiefAndMkrBalancesCurrentlyArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryCurrentVoteArgs = {
@@ -1492,7 +1477,6 @@ export type QueryCurrentVoteArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryCurrentVoteRankedChoiceArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1505,7 +1489,6 @@ export type QueryCurrentVoteRankedChoiceArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1516,7 +1499,6 @@ export type QueryHotOrColdWeightArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightAtTimeArgs = {
@@ -1529,7 +1511,6 @@ export type QueryHotOrColdWeightAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryHotOrColdWeightCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1539,7 +1520,6 @@ export type QueryHotOrColdWeightCurrentlyArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrDelegatedToArgs = {
@@ -1552,7 +1532,6 @@ export type QueryMkrDelegatedToArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrDelegatedToV2Args = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1563,7 +1542,6 @@ export type QueryMkrDelegatedToV2Args = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArgs = {
@@ -1578,7 +1556,6 @@ export type QueryMkrLockedDelegateArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArrayArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1591,7 +1568,6 @@ export type QueryMkrLockedDelegateArrayArgs = {
   unixtimeEnd: Scalars['Int'];
   unixtimeStart: Scalars['Int'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArrayTotalsArgs = {
@@ -1606,7 +1582,6 @@ export type QueryMkrLockedDelegateArrayTotalsArgs = {
   unixtimeStart: Scalars['Int'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryMkrLockedDelegateArrayTotalsV2Args = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1620,12 +1595,10 @@ export type QueryMkrLockedDelegateArrayTotalsV2Args = {
   unixtimeStart: Scalars['Int'];
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryNodeArgs = {
   nodeId: Scalars['ID'];
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryTimeToBlockNumberArgs = {
@@ -1637,7 +1610,6 @@ export type QueryTimeToBlockNumberArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressArgs = {
@@ -1651,7 +1623,6 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1664,7 +1635,6 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryTotalMkrWeightProxyAndNoProxyByAddressCurrentlyArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1676,7 +1646,6 @@ export type QueryTotalMkrWeightProxyAndNoProxyByAddressCurrentlyArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryUniqueVotersArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1686,7 +1655,6 @@ export type QueryUniqueVotersArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteAddressMkrWeightsAtTimeArgs = {
@@ -1700,7 +1668,6 @@ export type QueryVoteAddressMkrWeightsAtTimeArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteMkrWeightsAtTimeRankedChoiceArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1712,7 +1679,6 @@ export type QueryVoteMkrWeightsAtTimeRankedChoiceArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsArgs = {
@@ -1726,7 +1692,6 @@ export type QueryVoteOptionMkrWeightsArgs = {
   offset?: InputMaybe<Scalars['Int']>;
 };
 
-
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsAtTimeArgs = {
   after?: InputMaybe<Scalars['Cursor']>;
@@ -1738,7 +1703,6 @@ export type QueryVoteOptionMkrWeightsAtTimeArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
 };
-
 
 /** The root query type which gives access points into the data universe. */
 export type QueryVoteOptionMkrWeightsCurrentlyArgs = {
@@ -2172,6038 +2136,6038 @@ export type VoteOptionMkrWeightsRecordFilter = {
 
 import { IntrospectionQuery } from 'graphql';
 export default {
-  "__schema": {
-    "queryType": {
-      "name": "Query"
+  __schema: {
+    queryType: {
+      name: 'Query'
     },
-    "mutationType": null,
-    "subscriptionType": null,
-    "types": [
+    mutationType: null,
+    subscriptionType: null,
+    types: [
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByIdConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByIdConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ActivePollByIdEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'ActivePollByIdEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ActivePollByIdRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'ActivePollByIdRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByIdEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByIdEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "ActivePollByIdRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'ActivePollByIdRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByIdRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByIdRecord',
+        fields: [
           {
-            "name": "blockCreated",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockCreated',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "creator",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'creator',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "endDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'endDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "multiHash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'multiHash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "pollId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'pollId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "startDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'startDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "url",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'url',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByMultihashConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByMultihashConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ActivePollByMultihashEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'ActivePollByMultihashEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ActivePollByMultihashRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'ActivePollByMultihashRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByMultihashEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByMultihashEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "ActivePollByMultihashRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'ActivePollByMultihashRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollByMultihashRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollByMultihashRecord',
+        fields: [
           {
-            "name": "blockCreated",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockCreated',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "creator",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'creator',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "endDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'endDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "multiHash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'multiHash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "pollId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'pollId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "startDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'startDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "url",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'url',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "ActivePollsRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'ActivePollsRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollsConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollsConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ActivePollEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'ActivePollEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ActivePollsRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'ActivePollsRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "ActivePollsRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'ActivePollsRecord',
+        fields: [
           {
-            "name": "blockCreated",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockCreated',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "creator",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'creator',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "endDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'endDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "multiHash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'multiHash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "pollId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'pollId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "startDate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'startDate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "url",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'url',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVoteEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVoteEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllCurrentVotesRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllCurrentVotesRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVotesArrayConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVotesArrayConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllCurrentVotesArrayEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllCurrentVotesArrayEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllCurrentVotesArrayRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllCurrentVotesArrayRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVotesArrayEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVotesArrayEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllCurrentVotesArrayRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllCurrentVotesArrayRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVotesArrayRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVotesArrayRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "pollId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'pollId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "voter",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'voter',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVotesConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVotesConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllCurrentVoteEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllCurrentVoteEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllCurrentVotesRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllCurrentVotesRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllCurrentVotesRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllCurrentVotesRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "pollId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'pollId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllDelegateEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllDelegateEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllDelegatesRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllDelegatesRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllDelegatesConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllDelegatesConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllDelegateEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllDelegateEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllDelegatesRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllDelegatesRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllDelegatesRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllDelegatesRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "delegate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'delegate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "voteDelegate",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'voteDelegate',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmJoinEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmJoinEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllEsmJoinsRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllEsmJoinsRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmJoinsConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmJoinsConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllEsmJoinEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllEsmJoinEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllEsmJoinsRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllEsmJoinsRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmJoinsRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmJoinsRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "joinAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'joinAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "txFrom",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'txFrom',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "txHash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'txHash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmV2JoinEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmV2JoinEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllEsmV2JoinsRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllEsmV2JoinsRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmV2JoinsConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmV2JoinsConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllEsmV2JoinEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllEsmV2JoinEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllEsmV2JoinsRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllEsmV2JoinsRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllEsmV2JoinsRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllEsmV2JoinsRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "joinAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'joinAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "txFrom",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'txFrom',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "txHash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'txHash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllLocksSummedConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllLocksSummedConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AllLocksSummedEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'AllLocksSummedEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AllLocksSummedRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'AllLocksSummedRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllLocksSummedEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllLocksSummedEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "AllLocksSummedRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'AllLocksSummedRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "AllLocksSummedRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'AllLocksSummedRecord',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteAddressMkrWeightsAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteAddressMkrWeightsAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "BuggyVoteAddressMkrWeightsAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'BuggyVoteAddressMkrWeightsAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteAddressMkrWeightsAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteAddressMkrWeightsAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteAddressMkrWeightsAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteAddressMkrWeightsAtTimeRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "voter",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'voter',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalanceEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalanceEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CombinedChiefAndMkrBalancesRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'CombinedChiefAndMkrBalancesRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CombinedChiefAndMkrBalancesAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'CombinedChiefAndMkrBalancesAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesAtTimeRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "mkrAndChiefBalance",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrAndChiefBalance',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CombinedChiefAndMkrBalanceEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'CombinedChiefAndMkrBalanceEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CombinedChiefAndMkrBalancesRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'CombinedChiefAndMkrBalancesRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesCurrentlyConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesCurrentlyConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CombinedChiefAndMkrBalancesCurrentlyEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'CombinedChiefAndMkrBalancesCurrentlyEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesCurrentlyEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesCurrentlyEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesCurrentlyRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesCurrentlyRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "mkrAndChiefBalance",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrAndChiefBalance',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CombinedChiefAndMkrBalancesRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CombinedChiefAndMkrBalancesRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "mkrAndChiefBalance",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrAndChiefBalance',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CurrentVoteEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'CurrentVoteEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CurrentVoteRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'CurrentVoteRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CurrentVoteRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'CurrentVoteRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteRankedChoiceConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteRankedChoiceConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "CurrentVoteRankedChoiceEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'CurrentVoteRankedChoiceEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CurrentVoteRankedChoiceRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'CurrentVoteRankedChoiceRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteRankedChoiceEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteRankedChoiceEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "CurrentVoteRankedChoiceRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'CurrentVoteRankedChoiceRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteRankedChoiceRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteRankedChoiceRecord',
+        fields: [
           {
-            "name": "blockId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "CurrentVoteRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'CurrentVoteRecord',
+        fields: [
           {
-            "name": "blockId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "HotOrColdWeightAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'HotOrColdWeightAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "HotOrColdWeightAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'HotOrColdWeightAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "HotOrColdWeightAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'HotOrColdWeightAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightAtTimeRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "totalWeight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'totalWeight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "HotOrColdWeightEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'HotOrColdWeightEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "HotOrColdWeightRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'HotOrColdWeightRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightCurrentlyConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightCurrentlyConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "HotOrColdWeightCurrentlyEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'HotOrColdWeightCurrentlyEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "HotOrColdWeightCurrentlyRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'HotOrColdWeightCurrentlyRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightCurrentlyEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightCurrentlyEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "HotOrColdWeightCurrentlyRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'HotOrColdWeightCurrentlyRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightCurrentlyRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightCurrentlyRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "totalWeight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'totalWeight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "HotOrColdWeightRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'HotOrColdWeightRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "HotOrColdWeightRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'HotOrColdWeightRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "totalWeight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'totalWeight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrDelegatedToEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrDelegatedToEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrDelegatedToRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrDelegatedToRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrDelegatedToRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrDelegatedToRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToRecord',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToV2Connection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToV2Connection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrDelegatedToV2Edge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrDelegatedToV2Edge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrDelegatedToV2Record",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrDelegatedToV2Record',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToV2Edge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToV2Edge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrDelegatedToV2Record",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrDelegatedToV2Record',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrDelegatedToV2Record",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrDelegatedToV2Record',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "delegateContractAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'delegateContractAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrLockedDelegateArrayEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrLockedDelegateArrayEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrLockedDelegateArrayRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrLockedDelegateArrayRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrLockedDelegateArrayRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrLockedDelegateArrayRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayRecord',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrLockedDelegateArrayTotalsRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrLockedDelegateArrayTotalsRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalsConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalsConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrLockedDelegateArrayTotalEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrLockedDelegateArrayTotalEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrLockedDelegateArrayTotalsRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrLockedDelegateArrayTotalsRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalsRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalsRecord',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "callerLockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'callerLockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalsV2Connection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalsV2Connection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrLockedDelegateArrayTotalsV2Edge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrLockedDelegateArrayTotalsV2Edge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrLockedDelegateArrayTotalsV2Record",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrLockedDelegateArrayTotalsV2Record',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalsV2Edge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalsV2Edge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrLockedDelegateArrayTotalsV2Record",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrLockedDelegateArrayTotalsV2Record',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateArrayTotalsV2Record",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateArrayTotalsV2Record',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "callerLockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'callerLockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "delegateContractAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'delegateContractAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "MkrLockedDelegateEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'MkrLockedDelegateEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "MkrLockedDelegateRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'MkrLockedDelegateRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "MkrLockedDelegateRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'MkrLockedDelegateRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "MkrLockedDelegateRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'MkrLockedDelegateRecord',
+        fields: [
           {
-            "name": "blockNumber",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockNumber',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "fromAddress",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'fromAddress',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "hash",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'hash',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "immediateCaller",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'immediateCaller',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockAmount",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockAmount',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "lockTotal",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'lockTotal',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "INTERFACE",
-        "name": "Node",
-        "fields": [
+        kind: 'INTERFACE',
+        name: 'Node',
+        fields: [
           {
-            "name": "nodeId",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
+            name: 'nodeId',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Any'
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": [],
-        "possibleTypes": [
+        interfaces: [],
+        possibleTypes: [
           {
-            "kind": "OBJECT",
-            "name": "Query"
+            kind: 'OBJECT',
+            name: 'Query'
           }
         ]
       },
       {
-        "kind": "OBJECT",
-        "name": "Query",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'Query',
+        fields: [
           {
-            "name": "activePollById",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ActivePollByIdConnection",
-                "ofType": null
+            name: 'activePollById',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'ActivePollByIdConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "activePollByMultihash",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ActivePollByMultihashConnection",
-                "ofType": null
+            name: 'activePollByMultihash',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'ActivePollByMultihashConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollMultihash",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollMultihash',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "activePolls",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ActivePollsConnection",
-                "ofType": null
+            name: 'activePolls',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'ActivePollsConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "allCurrentVotes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllCurrentVotesConnection",
-                "ofType": null
+            name: 'allCurrentVotes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllCurrentVotesConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "allCurrentVotesArray",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllCurrentVotesArrayConnection",
-                "ofType": null
+            name: 'allCurrentVotesArray',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllCurrentVotesArrayConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "LIST",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'LIST',
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Any'
                     }
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "allDelegates",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllDelegatesConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "allEsmJoins",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllEsmJoinsConnection",
-                "ofType": null
+            name: 'allDelegates',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllDelegatesConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "allEsmV2Joins",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllEsmV2JoinsConnection",
-                "ofType": null
+            name: 'allEsmJoins',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllEsmJoinsConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "allLocksSummed",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AllLocksSummedConnection",
-                "ofType": null
+            name: 'allEsmV2Joins',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllEsmV2JoinsConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "unixtimeEnd",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "unixtimeStart",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "buggyVoteAddressMkrWeightsAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "BuggyVoteAddressMkrWeightsAtTimeConnection",
-                "ofType": null
+            name: 'allLocksSummed',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'AllLocksSummedConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'unixtimeEnd',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "buggyVoteMkrWeightsAtTimeRankedChoice",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "BuggyVoteMkrWeightsAtTimeRankedChoiceConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "combinedChiefAndMkrBalances",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CombinedChiefAndMkrBalancesConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argBlockNumber",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "combinedChiefAndMkrBalancesAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CombinedChiefAndMkrBalancesAtTimeConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "combinedChiefAndMkrBalancesCurrently",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CombinedChiefAndMkrBalancesCurrentlyConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "currentVote",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CurrentVoteConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "currentVoteRankedChoice",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CurrentVoteRankedChoiceConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hotOrColdWeight",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "HotOrColdWeightConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argBlockNumber",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hotOrColdWeightAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "HotOrColdWeightAtTimeConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hotOrColdWeightCurrently",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "HotOrColdWeightCurrentlyConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "mkrDelegatedTo",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrDelegatedToConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "mkrDelegatedToV2",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrDelegatedToV2Connection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
-          {
-            "name": "mkrLockedDelegate",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrLockedDelegateConnection",
-                "ofType": null
-              }
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "unixtimeEnd",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              },
-              {
-                "name": "unixtimeStart",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeStart',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               }
             ]
           },
           {
-            "name": "mkrLockedDelegateArray",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrLockedDelegateArrayConnection",
-                "ofType": null
+            name: 'buggyVoteAddressMkrWeightsAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'BuggyVoteAddressMkrWeightsAtTimeConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "LIST",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'buggyVoteMkrWeightsAtTimeRankedChoice',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'BuggyVoteMkrWeightsAtTimeRankedChoiceConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'combinedChiefAndMkrBalances',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'CombinedChiefAndMkrBalancesConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argBlockNumber',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'combinedChiefAndMkrBalancesAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'CombinedChiefAndMkrBalancesAtTimeConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'combinedChiefAndMkrBalancesCurrently',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'CombinedChiefAndMkrBalancesCurrentlyConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'currentVote',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'CurrentVoteConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'currentVoteRankedChoice',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'CurrentVoteRankedChoiceConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'hotOrColdWeight',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'HotOrColdWeightConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argBlockNumber',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'hotOrColdWeightAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'HotOrColdWeightAtTimeConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'hotOrColdWeightCurrently',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'HotOrColdWeightCurrentlyConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'mkrDelegatedTo',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrDelegatedToConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'mkrDelegatedToV2',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrDelegatedToV2Connection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'mkrLockedDelegate',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrLockedDelegateConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'unixtimeEnd',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'unixtimeStart',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              }
+            ]
+          },
+          {
+            name: 'mkrLockedDelegateArray',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrLockedDelegateArrayConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'LIST',
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Any'
                     }
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "unixtimeEnd",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeEnd',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "unixtimeStart",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeStart',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               }
             ]
           },
           {
-            "name": "mkrLockedDelegateArrayTotals",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrLockedDelegateArrayTotalsConnection",
-                "ofType": null
+            name: 'mkrLockedDelegateArrayTotals',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrLockedDelegateArrayTotalsConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "LIST",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'LIST',
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Any'
                     }
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "unixtimeEnd",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeEnd',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "unixtimeStart",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeStart',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               }
             ]
           },
           {
-            "name": "mkrLockedDelegateArrayTotalsV2",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "MkrLockedDelegateArrayTotalsV2Connection",
-                "ofType": null
+            name: 'mkrLockedDelegateArrayTotalsV2',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'MkrLockedDelegateArrayTotalsV2Connection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "LIST",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'LIST',
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Any'
                     }
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "unixtimeEnd",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeEnd',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "unixtimeStart",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
-                }
-              }
-            ]
-          },
-          {
-            "name": "node",
-            "type": {
-              "kind": "INTERFACE",
-              "name": "Node",
-              "ofType": null
-            },
-            "args": [
-              {
-                "name": "nodeId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'unixtimeStart',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               }
             ]
           },
           {
-            "name": "nodeId",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
+            name: 'node',
+            type: {
+              kind: 'INTERFACE',
+              name: 'Node',
+              ofType: null
             },
-            "args": []
-          },
-          {
-            "name": "query",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Query",
-                "ofType": null
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "timeToBlockNumber",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "TimeToBlockNumberConnection",
-                "ofType": null
-              }
-            },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'nodeId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
                 }
               }
             ]
           },
           {
-            "name": "totalMkrWeightProxyAndNoProxyByAddress",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "TotalMkrWeightProxyAndNoProxyByAddressConnection",
-                "ofType": null
+            name: 'nodeId',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'SCALAR',
+                name: 'Any'
               }
             },
-            "args": [
+            args: []
+          },
+          {
+            name: 'query',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'Query',
+                ofType: null
+              }
+            },
+            args: []
+          },
+          {
+            name: 'timeToBlockNumber',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'TimeToBlockNumberConnection',
+                ofType: null
+              }
+            },
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argBlockNumber",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "totalMkrWeightProxyAndNoProxyByAddressAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection",
-                "ofType": null
+            name: 'totalMkrWeightProxyAndNoProxyByAddress',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'TotalMkrWeightProxyAndNoProxyByAddressConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argBlockNumber',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "totalMkrWeightProxyAndNoProxyByAddressCurrently",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection",
-                "ofType": null
+            name: 'totalMkrWeightProxyAndNoProxyByAddressAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argAddress",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "uniqueVoters",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UniqueVotersConnection",
-                "ofType": null
+            name: 'totalMkrWeightProxyAndNoProxyByAddressCurrently',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argAddress',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "voteAddressMkrWeightsAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "VoteAddressMkrWeightsAtTimeConnection",
-                "ofType": null
+            name: 'uniqueVoters',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'UniqueVotersConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
-                  }
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "voteMkrWeightsAtTimeRankedChoice",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "VoteMkrWeightsAtTimeRankedChoiceConnection",
-                "ofType": null
+            name: 'voteAddressMkrWeightsAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'VoteAddressMkrWeightsAtTimeConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "voteOptionMkrWeights",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "VoteOptionMkrWeightsConnection",
-                "ofType": null
+            name: 'voteMkrWeightsAtTimeRankedChoice',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'VoteMkrWeightsAtTimeRankedChoiceConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argBlockNumber",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "voteOptionMkrWeightsAtTime",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "VoteOptionMkrWeightsAtTimeConnection",
-                "ofType": null
+            name: 'voteOptionMkrWeights',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'VoteOptionMkrWeightsConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argBlockNumber',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "argUnix",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           },
           {
-            "name": "voteOptionMkrWeightsCurrently",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "VoteOptionMkrWeightsCurrentlyConnection",
-                "ofType": null
+            name: 'voteOptionMkrWeightsAtTime',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'VoteOptionMkrWeightsAtTimeConnection',
+                ofType: null
               }
             },
-            "args": [
+            args: [
               {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "argPollId",
-                "type": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Any"
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
                   }
                 }
               },
               {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'argUnix',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
                 }
               },
               {
-                "name": "filter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               },
               {
-                "name": "offset",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              }
+            ]
+          },
+          {
+            name: 'voteOptionMkrWeightsCurrently',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'OBJECT',
+                name: 'VoteOptionMkrWeightsCurrentlyConnection',
+                ofType: null
+              }
+            },
+            args: [
+              {
+                name: 'after',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'argPollId',
+                type: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'SCALAR',
+                    name: 'Any'
+                  }
+                }
+              },
+              {
+                name: 'before',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'filter',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'first',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'last',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
+                }
+              },
+              {
+                name: 'offset',
+                type: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             ]
           }
         ],
-        "interfaces": [
+        interfaces: [
           {
-            "kind": "INTERFACE",
-            "name": "Node"
+            kind: 'INTERFACE',
+            name: 'Node'
           }
         ]
       },
       {
-        "kind": "OBJECT",
-        "name": "TimeToBlockNumberConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TimeToBlockNumberConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "TimeToBlockNumberEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'TimeToBlockNumberEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TimeToBlockNumberEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TimeToBlockNumberEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'node',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressAtTimeRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "weight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'weight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "TotalMkrWeightProxyAndNoProxyByAddressEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'TotalMkrWeightProxyAndNoProxyByAddressEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressCurrentlyRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "weight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'weight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "TotalMkrWeightProxyAndNoProxyByAddressRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'TotalMkrWeightProxyAndNoProxyByAddressRecord',
+        fields: [
           {
-            "name": "address",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'address',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "weight",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'weight',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "UniqueVoterEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'UniqueVoterEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'node',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "UniqueVotersConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'UniqueVotersConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "UniqueVoterEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'UniqueVoterEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Any"
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'SCALAR',
+                  name: 'Any'
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteAddressMkrWeightsAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteAddressMkrWeightsAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "VoteAddressMkrWeightsAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'VoteAddressMkrWeightsAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VoteAddressMkrWeightsAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'VoteAddressMkrWeightsAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteAddressMkrWeightsAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteAddressMkrWeightsAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "VoteAddressMkrWeightsAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'VoteAddressMkrWeightsAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteAddressMkrWeightsAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteAddressMkrWeightsAtTimeRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "voter",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'voter',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteMkrWeightsAtTimeRankedChoiceConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteMkrWeightsAtTimeRankedChoiceConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "VoteMkrWeightsAtTimeRankedChoiceEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'VoteMkrWeightsAtTimeRankedChoiceEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteMkrWeightsAtTimeRankedChoiceEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteMkrWeightsAtTimeRankedChoiceEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteMkrWeightsAtTimeRankedChoiceRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteMkrWeightsAtTimeRankedChoiceRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionIdRaw",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionIdRaw',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "VoteOptionMkrWeightsRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'VoteOptionMkrWeightsRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsAtTimeConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsAtTimeConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "VoteOptionMkrWeightsAtTimeEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'VoteOptionMkrWeightsAtTimeEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VoteOptionMkrWeightsAtTimeRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'VoteOptionMkrWeightsAtTimeRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsAtTimeEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsAtTimeEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "VoteOptionMkrWeightsAtTimeRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'VoteOptionMkrWeightsAtTimeRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsAtTimeRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsAtTimeRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "VoteOptionMkrWeightEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'VoteOptionMkrWeightEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VoteOptionMkrWeightsRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'VoteOptionMkrWeightsRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsCurrentlyConnection",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsCurrentlyConnection',
+        fields: [
           {
-            "name": "edges",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "VoteOptionMkrWeightsCurrentlyEdge",
-                    "ofType": null
+            name: 'edges',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'NON_NULL',
+                  ofType: {
+                    kind: 'OBJECT',
+                    name: 'VoteOptionMkrWeightsCurrentlyEdge',
+                    ofType: null
                   }
                 }
               }
             },
-            "args": []
+            args: []
           },
           {
-            "name": "nodes",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "LIST",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VoteOptionMkrWeightsCurrentlyRecord",
-                  "ofType": null
+            name: 'nodes',
+            type: {
+              kind: 'NON_NULL',
+              ofType: {
+                kind: 'LIST',
+                ofType: {
+                  kind: 'OBJECT',
+                  name: 'VoteOptionMkrWeightsCurrentlyRecord',
+                  ofType: null
                 }
               }
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsCurrentlyEdge",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsCurrentlyEdge',
+        fields: [
           {
-            "name": "cursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'cursor',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "VoteOptionMkrWeightsCurrentlyRecord",
-              "ofType": null
+            name: 'node',
+            type: {
+              kind: 'OBJECT',
+              name: 'VoteOptionMkrWeightsCurrentlyRecord',
+              ofType: null
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsCurrentlyRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsCurrentlyRecord',
+        fields: [
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "OBJECT",
-        "name": "VoteOptionMkrWeightsRecord",
-        "fields": [
+        kind: 'OBJECT',
+        name: 'VoteOptionMkrWeightsRecord',
+        fields: [
           {
-            "name": "blockTimestamp",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'blockTimestamp',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "mkrSupport",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'mkrSupport',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           },
           {
-            "name": "optionId",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
+            name: 'optionId',
+            type: {
+              kind: 'SCALAR',
+              name: 'Any'
             },
-            "args": []
+            args: []
           }
         ],
-        "interfaces": []
+        interfaces: []
       },
       {
-        "kind": "SCALAR",
-        "name": "Any"
+        kind: 'SCALAR',
+        name: 'Any'
       }
     ],
-    "directives": []
+    directives: []
   }
 } as unknown as IntrospectionQuery;

--- a/modules/gql/queries/mkrDelegatedTo.ts
+++ b/modules/gql/queries/mkrDelegatedTo.ts
@@ -1,11 +1,12 @@
 import { gql } from 'graphql-request';
 
 export const mkrDelegatedTo = gql`
-  query mkrDelegatedTo($argAddress: String!) {
+  query mkrDelegatedToV2($argAddress: String!) {
     mkrDelegatedTo(argAddress: $argAddress) {
       nodes {
         fromAddress
         immediateCaller
+        delegateContractAddress
         lockAmount
         blockNumber
         blockTimestamp

--- a/modules/gql/queries/mkrDelegatedTo.ts
+++ b/modules/gql/queries/mkrDelegatedTo.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
-export const mkrDelegatedTo = gql`
+export const mkrDelegatedToV2 = gql`
   query mkrDelegatedToV2($argAddress: String!) {
-    mkrDelegatedTo(argAddress: $argAddress) {
+    mkrDelegatedToV2(argAddress: $argAddress) {
       nodes {
         fromAddress
         immediateCaller

--- a/modules/gql/queries/mkrLockedDelegateArray.ts
+++ b/modules/gql/queries/mkrLockedDelegateArray.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-request';
 
 export const mkrLockedDelegateArrayTotals = gql`
-  query mkrLockedDelegateArrayTotals($argAddress: [String]!, $argUnixTimeStart: Int!, $argUnixTimeEnd: Int!) {
+  query mkrLockedDelegateArrayTotalsV2($argAddress: [String]!, $argUnixTimeStart: Int!, $argUnixTimeEnd: Int!) {
     mkrLockedDelegateArrayTotals(
       argAddress: $argAddress
       unixtimeStart: $argUnixTimeStart
@@ -10,6 +10,7 @@ export const mkrLockedDelegateArrayTotals = gql`
       nodes {
         fromAddress
         immediateCaller
+        delegateContractAddress
         lockAmount
         blockNumber
         blockTimestamp

--- a/modules/gql/queries/mkrLockedDelegateArray.ts
+++ b/modules/gql/queries/mkrLockedDelegateArray.ts
@@ -1,8 +1,12 @@
 import { gql } from 'graphql-request';
 
-export const mkrLockedDelegateArrayTotals = gql`
-  query mkrLockedDelegateArrayTotalsV2($argAddress: [String]!, $argUnixTimeStart: Int!, $argUnixTimeEnd: Int!) {
-    mkrLockedDelegateArrayTotals(
+export const mkrLockedDelegateArrayTotalsV2 = gql`
+  query mkrLockedDelegateArrayTotalsV2(
+    $argAddress: [String]!
+    $argUnixTimeStart: Int!
+    $argUnixTimeEnd: Int!
+  ) {
+    mkrLockedDelegateArrayTotalsV2(
       argAddress: $argAddress
       unixtimeStart: $argUnixTimeStart
       unixtimeEnd: $argUnixTimeEnd


### PR DESCRIPTION

Updates delegate events, to use the msg.sender as the delegator address, instead of the tx.origin

To test, compare delegation events on production to the deployment here: https://governance-portal-v2-git-updateddelegatequeries-dux-core-unit.vercel.app/

Also look at Rune’s Gnosis safe delegation history:
 https://governance-portal-v2-git-updateddelegatequeries-dux-core-unit.vercel.app/address/0xf65475e74c1ed6d004d5240b06e3088724dfda5d#account-details compared to production: https://vote.makerdao.com/address/0xc0583df0d10c2e87ae1873b728a0bda04d8b660c#account-details

And as we can see here^, we’re currently missing Rune’s 5000 un-delegation event from Hasu.  That’s why production shows that someone delegated -5000 MKR to Hasu: https://vote.makerdao.com/address/0xafaff1a605c373b43727136c995d21a7fcd08989#metrics
Whereas this deployment doesn’t have that bug on Hasu’s page: https://governance-portal-v2-git-updateddelegatequeries-dux-core-unit.vercel.app/address/0xafaff1a605c373b43727136c995d21a7fcd08989#metrics


Another example of the history being tied to msg.sender instead of the tx.origin:
https://governance-portal-v2-git-updateddelegatequeries-dux-core-unit.vercel.app/address/0x00e286b5256aa6cf252d5a8a5a7b8c20ec3bc4d5#account-details compared to: https://vote.makerdao.com/address/0x87e6888935180a9b27a9b48b75c9b779bfec1f76#account-details