### PR TITLE
Refactoring api for comments on gasless

### DIFF
--- a/modules/comments/types/comments.ts
+++ b/modules/comments/types/comments.ts
@@ -77,6 +77,7 @@ export type PollComment = {
   commentType: 'poll';
   pollId: number;
   network: SupportedNetworks;
+  gaslessNetwork?: SupportedNetworks;
   txHash?: string;
 };
 

--- a/pages/api/comments/polling/add.ts
+++ b/pages/api/comments/polling/add.ts
@@ -1,10 +1,12 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { SupportedNetworks } from 'modules/web3/constants/networks';
+import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import { PollComment, PollsCommentsRequestBody } from 'modules/comments/types/comments';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { verifyCommentParameters } from 'modules/comments/api/verifyCommentParameters';
 import { insertPollComments } from 'modules/comments/api/insertPollingComments';
 import logger from 'lib/logger';
+import validateQueryParam from 'modules/app/api/validateQueryParam';
+import { getGaslessNetwork } from 'modules/web3/helpers/chain';
 
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
@@ -15,10 +17,24 @@ export default withApiHandler(
         throw new Error('Unsupported parameters');
       }
 
-      // TODO: Read gasless network parameter and insert that in the comment correctly / matching the right network
-      // TODO: Validate network and gasless network parameters using new validation method
-      const gaslessNetwork = req.query.gasless ? (req.query.gasless as SupportedNetworks) : null;
-      const network = req.query.network as SupportedNetworks;
+      const network = validateQueryParam(req.query.network, 'string', {
+        defaultValue: DEFAULT_NETWORK.network,
+        validValues: [SupportedNetworks.GOERLI, SupportedNetworks.GOERLIFORK, SupportedNetworks.MAINNET]
+      }) as SupportedNetworks;
+
+      const gaslessNetwork = validateQueryParam(req.query.gasless, 'string', {
+        defaultValue: '',
+        validValues: [SupportedNetworks.ARBITRUM, SupportedNetworks.ARBITRUMTESTNET]
+      }) as SupportedNetworks;
+
+      // Verify that gaslesNetwork and network match
+      const gaslessNetworkMatches = gaslessNetwork && getGaslessNetwork(network) === gaslessNetwork;
+
+      if (gaslessNetwork && !gaslessNetworkMatches) {
+        return res.status(400).json({
+          error: 'Invalid Gasless Network'
+        });
+      }
 
       // Verifies the data
       const resultVerify = await verifyCommentParameters(
@@ -32,20 +48,20 @@ export default withApiHandler(
       // TODO: check that the transaction is from a real polling contract
       // console.log(transaction);
 
-      //if L2 vote, store the L2 network as the network
-      const txNetwork = gaslessNetwork ?? network;
-
-      const commentsToInsert: PollComment[] = body.comments.map(comment => ({
-        pollId: comment.pollId as number,
-        comment: comment.comment as string,
-        hotAddress: body.hotAddress?.toLowerCase() || '',
-        accountType: resultVerify,
-        commentType: 'poll',
-        network: txNetwork,
-        date: new Date(),
-        voterAddress: body.voterAddress.toLowerCase(),
-        txHash: body.txHash
-      }));
+      const commentsToInsert: PollComment[] = body.comments.map(
+        (comment): PollComment => ({
+          pollId: comment.pollId as number,
+          comment: comment.comment as string,
+          hotAddress: body.hotAddress?.toLowerCase() || '',
+          accountType: resultVerify,
+          commentType: 'poll',
+          network,
+          gaslessNetwork,
+          date: new Date(),
+          voterAddress: body.voterAddress.toLowerCase(),
+          txHash: body.txHash
+        })
+      );
 
       await insertPollComments(commentsToInsert);
 


### PR DESCRIPTION
Changes to get and add comments in gasless , it puts a property on the comment object indicating that is gasless, but it mantains the origin network.