### PR TITLE
backoffRetry when fetching gasless transaction in case it hasn't been…

### DIFF
--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -21,6 +21,7 @@ import { ethers } from 'ethers';
 import PollingContractAbi from 'modules/contracts/abis/arbitrumTestnet/polling.json';
 import { ContractTransaction } from 'ethers';
 import { getGaslessNetwork, getGaslessProvider } from 'modules/web3/helpers/chain';
+import { getGaslessTransaction } from 'modules/web3/helpers/getGaslessTransaction';
 
 type BallotSteps =
   | 'initial'
@@ -401,7 +402,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
       body: JSON.stringify({ ...signatureValues, signature, network })
     })
       .then(res => {
-        const voteTxCreator = () => gaslessProvider.getTransaction(res.hash);
+        const voteTxCreator = () => getGaslessTransaction(gaslessProvider, res.hash);
         trackPollVote(voteTxCreator, getGaslessNetwork(network));
       })
       .catch(error => {

--- a/modules/web3/helpers/getGaslessTransaction.ts
+++ b/modules/web3/helpers/getGaslessTransaction.ts
@@ -1,0 +1,13 @@
+import { ContractTransaction, providers } from 'ethers';
+import { backoffRetry } from 'lib/utils';
+
+export const getGaslessTransaction = async (
+  gaslessProvider: providers.JsonRpcProvider,
+  hash: string
+): Promise<ContractTransaction> =>
+  backoffRetry(3, () =>
+    gaslessProvider.getTransaction(hash).then(tx => {
+      if (tx === null) throw new Error(`Transaction ${hash} not found on gasless network`);
+      return tx;
+    })
+  );


### PR DESCRIPTION
… picked up by network yet

### Link to Shortcut ticket:

### What does this PR do?
Due to a possible delay with the relayer, sometimes the tx doesn't appear on the network before we try to get it with the provider. This results in the tx object being null & an error. This PR uses backoffRetry to attempt to fetch the tx again if it is not found at first.
