### PR TITLE
Reuse voting account trhough app and fix precheck gasless

### DIFF
--- a/modules/app/context/AccountContext.tsx
+++ b/modules/app/context/AccountContext.tsx
@@ -25,6 +25,9 @@ interface AccountContextProps {
   voteProxyOldHotAddress?: string;
   voteProxyOldColdAddress?: string;
 
+  // Voting account is either the normal wallet address, the delegateContract address or the vote proxy address
+  votingAccount?: string;
+
   mutate?: () => void;
 }
 
@@ -49,6 +52,13 @@ export const AccountProvider = ({ children }: PropTypes): React.ReactElement => 
   // Use for tesing purposes, allow to log-in an account on the localhost network with a fork of goerli
   useGoerliForkWindowBindings();
 
+  // In order of priority for voting: 1) Delegate contract, 2) Proxy 3) Wallet account
+  const votingAccount = voteDelegateContractAddress
+    ? voteDelegateContractAddress
+    : voteProxyResponse?.voteProxyAddress
+    ? voteProxyResponse?.voteProxyAddress
+    : account;
+
   return (
     <AccountContext.Provider
       value={{
@@ -66,6 +76,8 @@ export const AccountProvider = ({ children }: PropTypes): React.ReactElement => 
         voteProxyOldContractAddress: voteProxyOldResponse?.voteProxyAddress,
         voteProxyOldHotAddress: voteProxyOldResponse?.hotAddress,
         voteProxyOldColdAddress: voteProxyOldResponse?.coldAddress,
+
+        votingAccount,
 
         mutate: () => {
           mutateVoteDelegate();

--- a/modules/delegates/components/modals/InputDelegateMkr.tsx
+++ b/modules/delegates/components/modals/InputDelegateMkr.tsx
@@ -30,7 +30,7 @@ export function InputDelegateMkr({
 }: Props): React.ReactElement {
   const [value, setValue] = useState(BigNumber.from(0));
   const { account, voteProxyContractAddress } = useAccount();
-  const { data: lockedMkr } = useLockedMkr(account, voteProxyContractAddress);
+  const { data: lockedMkr } = useLockedMkr(voteProxyContractAddress || account);
   function handleChange(val: BigNumber): void {
     setValue(val);
     onChange(val);

--- a/modules/executive/components/VoteModal/DefaultView.tsx
+++ b/modules/executive/components/VoteModal/DefaultView.tsx
@@ -48,14 +48,9 @@ export default function DefaultVoteModalView({
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.EXECUTIVE);
   const bpi = useBreakpointIndex();
 
-  const { account, voteProxyContractAddress, voteDelegateContractAddress } = useAccount();
+  const { account, voteProxyContractAddress, voteDelegateContractAddress, votingAccount } = useAccount();
   const { network, provider } = useWeb3();
-  const addressLockedMKR = voteDelegateContractAddress || voteProxyContractAddress || account;
-  const { data: lockedMkr, mutate: mutateLockedMkr } = useLockedMkr(
-    addressLockedMKR,
-    voteProxyContractAddress,
-    voteDelegateContractAddress
-  );
+  const { data: lockedMkr, mutate: mutateLockedMkr } = useLockedMkr(votingAccount);
 
   const spellAddress = proposal ? proposal.address : address ? address : '';
 
@@ -133,12 +128,12 @@ export default function DefaultVoteModalView({
         // if comment included, add to comments db
         if (comment.length > 0) {
           const requestBody: ExecutiveCommentsRequestBody = {
-            voterAddress: addressLockedMKR || '',
+            voterAddress: votingAccount || '',
             hotAddress: account || '',
             comment: comment,
             signedMessage: signedMessage,
             txHash,
-            addressLockedMKR: addressLockedMKR || ''
+            addressLockedMKR: votingAccount || ''
           };
           fetchJson(`/api/comments/executive/add/${spellAddress}?network=${network}`, {
             method: 'POST',

--- a/modules/executive/hooks/useVotedProposals.ts
+++ b/modules/executive/hooks/useVotedProposals.ts
@@ -12,27 +12,14 @@ type VotedProposalsResponse = {
 };
 
 export const useVotedProposals = (passedAddress?: string): VotedProposalsResponse => {
-  let addressToUse;
   const { chief } = useContracts();
-
-  // if address is passed, fetch for that
-  if (passedAddress) {
-    addressToUse = passedAddress;
-  } else {
-    // if no address, fetch for connected account
-    const { account, voteDelegateContractAddress, voteProxyContractAddress } = useAccount();
-
-    addressToUse = voteDelegateContractAddress
-      ? voteDelegateContractAddress
-      : voteProxyContractAddress
-      ? voteProxyContractAddress
-      : account;
-  }
+  const { votingAccount } = useAccount();
+  const addressToUse = passedAddress ? passedAddress : votingAccount;
 
   const { data, error, mutate } = useSWR<string[]>(
     addressToUse ? `${addressToUse}/executive/voted-proposals` : null,
     async () => {
-      const votedSlate = await chief.votes(addressToUse);
+      const votedSlate = await chief.votes(addressToUse as string);
       return votedSlate !== ZERO_SLATE_HASH ? await getSlateAddresses(chief, votedSlate) : [];
     },
     { revalidateOnMount: true, refreshInterval: 60000, revalidateOnFocus: false }

--- a/modules/mkr/components/Deposit.tsx
+++ b/modules/mkr/components/Deposit.tsx
@@ -35,7 +35,7 @@ const ModalContent = ({
   const { account, voteProxyContractAddress, voteProxyColdAddress } = useAccount();
   const { data: mkrBalance } = useMkrBalance(account);
 
-  const { mutate: mutateLocked } = useLockedMkr(account, voteProxyContractAddress);
+  const { mutate: mutateLocked } = useLockedMkr(voteProxyContractAddress || account);
   const { chief } = useContracts();
 
   const { data: chiefAllowance, mutate: mutateTokenAllowance } = useTokenAllowance(

--- a/modules/mkr/components/Withdraw.tsx
+++ b/modules/mkr/components/Withdraw.tsx
@@ -38,7 +38,7 @@ const ModalContent = ({ close, ...props }) => {
 
   const allowanceOk = voteProxyContract ? true : allowance; // no need for IOU approval when using vote proxy
 
-  const { data: lockedMkr, mutate: mutateLocked } = useLockedMkr(account, voteProxyContractAddress);
+  const { data: lockedMkr, mutate: mutateLocked } = useLockedMkr(voteProxyContractAddress || account);
 
   const { free, tx: freeTx, setTxId: resetFree } = useFree();
 

--- a/modules/mkr/hooks/useLockedMkr.ts
+++ b/modules/mkr/hooks/useLockedMkr.ts
@@ -10,19 +10,13 @@ type LockedMkrData = {
   mutate: () => void;
 };
 
-export const useLockedMkr = (
-  address?: string,
-  voteProxyAddress?: string | null,
-  voteDelegateAddress?: string | null
-): LockedMkrData => {
+export const useLockedMkr = (address?: string): LockedMkrData => {
   const { chief } = useContracts();
 
-  const addressToCache = voteProxyAddress && !voteDelegateAddress ? voteProxyAddress : address;
-
   const { data, error, mutate } = useSWR(
-    addressToCache ? `${chief.address}/user/mkr-locked${addressToCache}` : null,
+    address ? `${chief.address}/user/mkr-locked${address}` : null,
     async () => {
-      return addressToCache ? await getChiefDeposits(addressToCache, chief) : undefined;
+      return address ? await getChiefDeposits(address, chief) : undefined;
     },
     {
       revalidateOnFocus: false,

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -103,19 +103,12 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
   const [previousBallot, setPreviousBallot] = useState<Ballot>({});
 
   // Determines which address will be use to save the comments
-  const { account, voteDelegateContract, voteDelegateContractAddress, voteProxyContractAddress } =
-    useAccount();
+  const { account, voteDelegateContract, votingAccount } = useAccount();
 
   const { network, provider } = useWeb3();
 
-  const accountToUse = voteDelegateContractAddress
-    ? voteDelegateContractAddress
-    : voteProxyContractAddress
-    ? voteProxyContractAddress
-    : account;
-
   // Import the hook with the current user votes to mutate after voting.
-  const { mutate: mutatePreviousVotes } = useAllUserVotes(accountToUse);
+  const { mutate: mutatePreviousVotes } = useAllUserVotes(votingAccount);
 
   const clearBallot = () => {
     setCommentSignature('');
@@ -279,7 +272,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
           // if comment included, add to comments db
           if (comments.length > 0) {
             const commentsRequest: PollsCommentsRequestBody = {
-              voterAddress: accountToUse || '',
+              voterAddress: votingAccount || '',
               hotAddress: account || '',
               comments: comments,
               signedMessage: commentsSignature,

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -38,18 +38,14 @@ const AccountPage = (): React.ReactElement => {
     account,
     mutate: mutateAccount,
     voteDelegateContractAddress,
-    voteProxyContractAddress
+    voteProxyContractAddress,
+    votingAccount
   } = useAccount();
-  const addressToCheck = voteDelegateContractAddress
-    ? voteDelegateContractAddress
-    : voteProxyContractAddress
-    ? voteProxyContractAddress
-    : account;
 
   const { newOwnerConnected, newOwnerHasDelegateContract, previousOwnerAddress } = useLinkedDelegateInfo();
-  const { data: addressInfo, error: errorLoadingAddressInfo } = useAddressInfo(addressToCheck, network);
+  const { data: addressInfo, error: errorLoadingAddressInfo } = useAddressInfo(votingAccount, network);
   const { data: previousOwnerContractAddress } = useVoteDelegateAddress(previousOwnerAddress);
-  const { data: chiefBalance } = useLockedMkr(account, voteProxyContractAddress);
+  const { data: chiefBalance } = useLockedMkr(voteProxyContractAddress || account);
 
   const [modalOpen, setModalOpen] = useState(false);
   const [warningRead, setWarningRead] = useState(false);

--- a/pages/api/polling/precheck.ts
+++ b/pages/api/polling/precheck.ts
@@ -20,7 +20,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
     });
   }
 
-  if (!pollIds || pollIdsArray.length < 1) {
+  if (!pollIds || pollIdsArray.length === 0) {
     return res.status(400).json({
       error: 'no poll ids provided'
     });

--- a/pages/custom-spell/[address].tsx
+++ b/pages/custom-spell/[address].tsx
@@ -21,15 +21,14 @@ type Props = {
 export default function CustomSpellAddress({ spellAddress, spellDetails }: Props): JSX.Element {
   const [voting, setVoting] = useState(false);
   const { network } = useWeb3();
-  const { account, voteDelegateContractAddress, voteProxyContractAddress } = useAccount();
-  const address = voteDelegateContractAddress || voteProxyContractAddress || account;
+  const { account, votingAccount } = useAccount();
 
   const { data: votedProposals, mutate: mutateVotedProposals } = useVotedProposals();
 
   // revalidate votedProposals if connected address changes
   useEffect(() => {
     mutateVotedProposals();
-  }, [address]);
+  }, [votingAccount]);
 
   const hasVotedFor =
     votedProposals &&

--- a/pages/custom-spell/index.tsx
+++ b/pages/custom-spell/index.tsx
@@ -18,15 +18,14 @@ export default function CustomSpell(): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [voting, setVoting] = useState(false);
   const { network } = useWeb3();
-  const { account, voteDelegateContractAddress, voteProxyContractAddress } = useAccount();
-  const address = voteDelegateContractAddress || voteProxyContractAddress || account;
+  const { account, votingAccount } = useAccount();
 
   const { data: votedProposals, mutate: mutateVotedProposals } = useVotedProposals();
 
   // revalidate votedProposals if connected address changes
   useEffect(() => {
     mutateVotedProposals();
-  }, [address]);
+  }, [votingAccount]);
 
   const hasVotedFor =
     votedProposals &&

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -65,15 +65,19 @@ const MigrationBadge = ({ children, py = [2, 3] }) => (
 );
 
 export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JSX.Element => {
-  const { account, voteDelegateContractAddress, voteProxyContractAddress, voteProxyOldContractAddress } =
-    useAccount();
+  const {
+    account,
+    voteDelegateContractAddress,
+    voteProxyContractAddress,
+    voteProxyOldContractAddress,
+    votingAccount
+  } = useAccount();
   const { network } = useWeb3();
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.EXECUTIVE);
 
   const [showHistorical, setShowHistorical] = React.useState(false);
 
-  const address = voteDelegateContractAddress || voteProxyContractAddress || account;
-  const { data: lockedMkr } = useLockedMkr(address, voteProxyContractAddress, voteDelegateContractAddress);
+  const { data: lockedMkr } = useLockedMkr(votingAccount);
 
   const { data: votedProposals, mutate: mutateVotedProposals } = useVotedProposals();
   const { chiefOld } = useContracts() as MainnetSdk;
@@ -135,7 +139,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
   // revalidate votedProposals if connected address changes
   useEffect(() => {
     mutateVotedProposals();
-  }, [address]);
+  }, [votingAccount]);
 
   useEffect(() => {
     setSize(1);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -61,8 +61,7 @@ const LandingPage = ({ proposals, polls, delegates, stats, mkrOnHat, hat, mkrInC
   }, [mode]);
 
   // account
-  const { account, voteDelegateContractAddress, voteProxyContractAddress } = useAccount();
-  const address = voteDelegateContractAddress || voteProxyContractAddress || account;
+  const { account, votingAccount } = useAccount();
 
   // polls
   const activePolls = useMemo(() => polls.filter(poll => isActivePoll(poll)).slice(0, 4), [polls]);
@@ -87,7 +86,7 @@ const LandingPage = ({ proposals, polls, delegates, stats, mkrOnHat, hat, mkrInC
   // revalidate votedProposals if connected address changes
   useEffect(() => {
     mutateVotedProposals();
-  }, [address]);
+  }, [votingAccount]);
 
   // Use intersection observers to change the hash on scroll
   const [activeTab, setActiveTab] = useState('#vote');

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -155,14 +155,13 @@ const PollingOverview = ({ polls, tags }: PollingPageData) => {
     setNumHistoricalGroupingsLoaded(3); // reset inifite scroll if a new filter is applied
   }, [filteredPolls]);
 
-  const { account, voteDelegateContractAddress } = useAccount();
-  const addressToCheck = voteDelegateContractAddress ? voteDelegateContractAddress : account;
-  const { mutate: mutateAllUserVotes } = useAllUserVotes(addressToCheck);
+  const { account, votingAccount } = useAccount();
+  const { mutate: mutateAllUserVotes } = useAllUserVotes(votingAccount);
 
   // revalidate user votes if connected address changes
   useEffect(() => {
     mutateAllUserVotes();
-  }, [addressToCheck]);
+  }, [votingAccount]);
 
   return (
     <PrimaryLayout sx={{ maxWidth: [null, null, null, 'page', 'dashboard'] }}>

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -52,7 +52,7 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
     setTransactionStatus(transaction?.status || 'default');
   }, [transaction]);
 
-  const { account } = useAccount();
+  const { account, votingAccount } = useAccount();
 
   const activePolls = polls.filter(poll => isActivePoll(poll));
 
@@ -189,11 +189,11 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
                   </Text>
                 )}
 
-                {bpi <= 2 && !!account && (
+                {bpi <= 2 && !!votingAccount && (
                   <Box>
                     {!hasVoted && (
                       <ReviewBox
-                        account={account}
+                        account={votingAccount}
                         polls={polls}
                         activePolls={activePolls}
                         ballotPollIds={ballotPollIds}
@@ -293,7 +293,7 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
             </Stack>
           </Box>
 
-          {bpi >= 3 && !!account && (
+          {bpi >= 3 && !!votingAccount && (
             <Box sx={{ pt: 3 }}>
               {!hasVoted && (
                 <Box>
@@ -301,7 +301,7 @@ const PollingReview = ({ polls }: PollingReviewPageData) => {
                     Submit Ballot
                   </Heading>
                   <ReviewBox
-                    account={account}
+                    account={votingAccount}
                     polls={polls}
                     activePolls={activePolls}
                     ballotPollIds={ballotPollIds}


### PR DESCRIPTION
We had duplicated code that checked which was the right account to use for voting, i removed it and added to the "useACcount" hook, so we can just access the right voting account.

The "precheck" for gasless was using the wrong address, and failed if you used a delegate contract. Fixed now.

Simplified the "useLockedMKR" hook to only have 1 parameter