### PR TITLE
add tooltip explaining difference between v1 and v2 polling contracts…

### DIFF
--- a/modules/app/components/SystemStatsSidebar.tsx
+++ b/modules/app/components/SystemStatsSidebar.tsx
@@ -24,7 +24,6 @@ type StatField =
   | 'polling contract v2'
   | 'arbitrum polling contract'
   | 'mkr in chief'
-  | 'polling contract'
   | 'mkr needed to pass'
   | 'savings rate'
   | 'total dai'

--- a/modules/app/components/SystemStatsSidebar.tsx
+++ b/modules/app/components/SystemStatsSidebar.tsx
@@ -16,9 +16,12 @@ import { useWeb3 } from 'modules/web3/hooks/useWeb3';
 import { Tokens } from 'modules/web3/constants/tokens';
 import { ArbitrumPollingAddressMap } from 'modules/web3/constants/addresses';
 import { SupportedNetworks } from 'modules/web3/constants/networks';
+import TooltipComponent from './Tooltip';
 
 type StatField =
   | 'chief contract'
+  | 'polling contract v1'
+  | 'polling contract v2'
   | 'arbitrum polling contract'
   | 'mkr in chief'
   | 'polling contract'
@@ -78,12 +81,26 @@ export default function SystemStatsSidebar({
       );
     },
 
-    'polling contract': key => {
+    'polling contract v2': key => {
       const pollingAddress = useContractAddress('polling');
 
       return (
         <Flex key={key} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
-          <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Polling Contract</Text>
+          <Flex sx={{ alignItems: 'center' }}>
+            <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Polling Contract v2</Text>
+            <TooltipComponent
+              label={
+                <Text sx={{ whiteSpace: 'normal' }}>
+                  The latest version of the polling contract was deployed to enable batch voting, so users can
+                  vote on multiple polls in one transaction.
+                </Text>
+              }
+            >
+              <Flex>
+                <Icon name="question" ml={2} color={'textSecondary'} />
+              </Flex>
+            </TooltipComponent>
+          </Flex>
           <Text variant="h2" sx={{ fontSize: 3 }}>
             {pollingAddress ? (
               <ExternalLink href={getEtherscanLink(network, pollingAddress, 'address')} target="_blank">
@@ -97,6 +114,35 @@ export default function SystemStatsSidebar({
           </Text>
         </Flex>
       );
+    },
+
+    'polling contract v1': key => {
+      const pollingAddress = useContractAddress('pollingOld');
+
+      return pollingAddress ? (
+        <Flex key={key} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+          <Flex sx={{ alignItems: 'center' }}>
+            <Text sx={{ fontSize: 3, color: 'textSecondary' }}>Polling Contract v1</Text>
+            <TooltipComponent
+              label={
+                <Text>
+                  The first version of the polling contract is still used for creating polls on-chain, but it
+                  only allows for voting on a single poll per transaction, so an upgrade was deployed.
+                </Text>
+              }
+            >
+              <Flex>
+                <Icon name="question" ml={2} color={'textSecondary'} />
+              </Flex>
+            </TooltipComponent>
+          </Flex>
+          <Text variant="h2" sx={{ fontSize: 3 }}>
+            <ExternalLink href={getEtherscanLink(network, pollingAddress, 'address')} target="_blank">
+              <Text>{formatAddress(pollingAddress)}</Text>
+            </ExternalLink>
+          </Text>
+        </Flex>
+      ) : null;
     },
 
     'arbitrum polling contract': key => {

--- a/modules/web3/hooks/useContractAddress.ts
+++ b/modules/web3/hooks/useContractAddress.ts
@@ -4,5 +4,5 @@ import { ContractName } from 'modules/web3/types/contracts';
 export const useContractAddress = (contractName: ContractName): string => {
   const contracts = useContracts();
 
-  return contracts[contractName].address;
+  return contracts[contractName]?.address;
 };

--- a/modules/web3/types/contracts.d.ts
+++ b/modules/web3/types/contracts.d.ts
@@ -13,6 +13,7 @@ export type ContractName =
   | 'pause'
   | 'pauseProxy'
   | 'polling'
+  | 'pollingOld'
   | 'pot'
   | 'vat'
   | 'voteDelegateFactory'

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -248,7 +248,14 @@ const AccountPage = (): React.ReactElement => {
           )}
           <ErrorBoundary componentName="System Info">
             <SystemStatsSidebar
-              fields={['polling contract', 'savings rate', 'total dai', 'debt ceiling', 'system surplus']}
+              fields={[
+                'polling contract v2',
+                'polling contract v1',
+                'savings rate',
+                'total dai',
+                'debt ceiling',
+                'system surplus'
+              ]}
             />
           </ErrorBoundary>
           <ResourceBox type={'delegates'} />

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -78,7 +78,14 @@ const AddressView = ({ addressInfo }: { addressInfo: AddressApiResponse }) => {
           )}
           <ErrorBoundary componentName="System Info">
             <SystemStatsSidebar
-              fields={['polling contract', 'savings rate', 'total dai', 'debt ceiling', 'system surplus']}
+              fields={[
+                'polling contract v2',
+                'polling contract v1',
+                'savings rate',
+                'total dai',
+                'debt ceiling',
+                'system surplus'
+              ]}
             />
           </ErrorBoundary>
           {addressInfo.isDelegate && <ResourceBox type={'delegates'} />}

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -333,7 +333,8 @@ const PollingOverview = ({ polls, tags }: PollingPageData) => {
             <ErrorBoundary componentName="System Info">
               <SystemStatsSidebar
                 fields={[
-                  'polling contract',
+                  'polling contract v2',
+                  'polling contract v1',
                   'arbitrum polling contract',
                   'savings rate',
                   'total dai',

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -327,7 +327,14 @@ const PollView = ({ poll }: { poll: Poll }) => {
           )}
           <ErrorBoundary componentName="System Info">
             <SystemStatsSidebar
-              fields={['polling contract', 'savings rate', 'total dai', 'debt ceiling', 'system surplus']}
+              fields={[
+                'polling contract v2',
+                'polling contract v1',
+                'savings rate',
+                'total dai',
+                'debt ceiling',
+                'system surplus'
+              ]}
             />
           </ErrorBoundary>
           <ResourceBox type={'polling'} />


### PR DESCRIPTION
… to sidebar

### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/1552/fe-add-arbitrum-contract-addresses-to-system-info-sidebar

### What does this PR do?
Clarifies difference between v1 and v2 polling contracts with tooltip.


### Screenshots (if relevant):
![Screen Shot 2022-09-20 at 4 40 25 PM](https://user-images.githubusercontent.com/13105602/191377520-424e3c28-1c5c-4e1e-9d11-4f5a61b9394d.jpg)
