### PR TITLE
use .toFixed instead of .toNumber to avoid exponential notation

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -236,3 +236,7 @@ export function openWindowWithUrl(url: string): void {
 
   windowOpen(url, windowConfig);
 }
+
+export function isExponential(numberToCheck: number): boolean {
+  return numberToCheck.toString().includes('e');
+}

--- a/modules/polling/api/fetchPollTally.ts
+++ b/modules/polling/api/fetchPollTally.ts
@@ -224,11 +224,11 @@ export async function fetchPollTally(poll: Poll, network: SupportedNetworks): Pr
         eliminated: instantRunoffOption?.eliminated,
         transfer: instantRunoffOption?.transfer?.toString(),
         firstPct: totalMkrParticipation.gt(0)
-          ? new BigNumber(mkrSupport).div(totalMkrParticipation).times(100).toNumber()
+          ? new BigNumber(mkrSupport).div(totalMkrParticipation).times(100).toFixed()
           : 0,
         transferPct:
           totalMkrParticipation.gt(0) && instantRunoffOption?.transfer
-            ? new BigNumber(instantRunoffOption?.transfer).div(totalMkrParticipation).times(100).toNumber()
+            ? new BigNumber(instantRunoffOption?.transfer).div(totalMkrParticipation).times(100).toFixed()
             : 0
       };
     })

--- a/modules/polling/api/fetchPollTally.ts
+++ b/modules/polling/api/fetchPollTally.ts
@@ -15,6 +15,7 @@ import { InstantRunoffResults } from '../types/instantRunoff';
 import { parseRawOptionId } from '../helpers/parseRawOptionId';
 import { extractSatisfiesComparison } from './victory_conditions/comparison';
 import { hasVictoryConditionInstantRunOff } from '../helpers/utils';
+import { isExponential } from 'lib/utils';
 
 type WinnerOption = { winner: number | null; results: InstantRunoffResults | null };
 
@@ -216,6 +217,27 @@ export async function fetchPollTally(poll: Poll, network: SupportedNetworks): Pr
           ? instantRunoffOption?.mkrSupport || new BigNumber(0)
           : votesInfo[optionId] || new BigNumber(0);
 
+      let firstPct: string | number = 0;
+      let transferPct: string | number = 0;
+
+      if (totalMkrParticipation.gt(0)) {
+        const firstPctBn = new BigNumber(mkrSupport).div(totalMkrParticipation).times(100);
+
+        // If firstPct has too many decimal places it will be cast as an exponential number, in which case we instead cast as a string
+        firstPct = isExponential(firstPctBn.toNumber()) ? firstPctBn.toFixed(18) : firstPctBn.toNumber();
+
+        if (instantRunoffOption?.transfer) {
+          const transferPctBn = new BigNumber(instantRunoffOption?.transfer)
+            .div(totalMkrParticipation)
+            .times(100);
+
+          // Same situation for transferPct, cast as a string with regular notation if necessary
+          transferPct = isExponential(transferPctBn.toNumber())
+            ? transferPctBn.toFixed(18)
+            : transferPctBn.toNumber();
+        }
+      }
+
       return {
         optionId,
         winner: winnerOption.winner === optionId,
@@ -223,13 +245,8 @@ export async function fetchPollTally(poll: Poll, network: SupportedNetworks): Pr
         optionName: poll.options[optionId],
         eliminated: instantRunoffOption?.eliminated,
         transfer: instantRunoffOption?.transfer?.toString(),
-        firstPct: totalMkrParticipation.gt(0)
-          ? new BigNumber(mkrSupport).div(totalMkrParticipation).times(100).toFixed()
-          : 0,
-        transferPct:
-          totalMkrParticipation.gt(0) && instantRunoffOption?.transfer
-            ? new BigNumber(instantRunoffOption?.transfer).div(totalMkrParticipation).times(100).toFixed()
-            : 0
+        firstPct,
+        transferPct
       };
     })
     .sort((a, b) => {

--- a/modules/polling/types/pollTally.d.ts
+++ b/modules/polling/types/pollTally.d.ts
@@ -11,9 +11,9 @@ export type PollTallyOption = {
   optionId: number;
   optionName: string;
   winner: boolean;
-  firstPct: number;
+  firstPct: number | string;
   eliminated?: boolean;
-  transferPct?: number;
+  transferPct?: number | string;
   transfer?: number | string;
 };
 

--- a/modules/tags/constants/poll-tags-mapping.json
+++ b/modules/tags/constants/poll-tags-mapping.json
@@ -840,5 +840,6 @@
   "867": ["high-impact", "ratification", "mips", "budget"],
   "868": ["high-impact", "misc-funding", "ratification", "mips"],
   "869": ["high-impact", "ratification", "mips", "budget"],
-  "870": ["high-impact", "ratification", "mips", "core-unit-offboard"]
+  "870": ["high-impact", "ratification", "mips", "core-unit-offboard"],
+  "871": ["medium-impact", "greenlight"]
 }


### PR DESCRIPTION
In tally calculation converting a BigNumber with `.toNumber()` had a result that was cast using exponential notation `9.59688000646e-7`. Using `.toFixed()` will always return a value in normal notation. Now that result is a string, so I had to change the type as well.