### PR TITLE
Add new class API error and change API to return the same error struc…

### DIFF
--- a/lib/fetchJson.ts
+++ b/lib/fetchJson.ts
@@ -7,7 +7,7 @@ export async function fetchJson(url: RequestInfo, init?: RequestInit): Promise<a
       status: response.status,
       statusText: response.statusText,
       json,
-      message: json?.error ? json.error : 'Request failed'
+      message: json?.error && json.error.message ? json.error.message : 'Request failed'
     });
   }
   return json;

--- a/modules/app/api/ApiError.ts
+++ b/modules/app/api/ApiError.ts
@@ -1,0 +1,27 @@
+import { API_ERROR_CODES } from '../constants/apiErrors';
+
+export class ApiError extends Error {
+  code: string;
+  status: number;
+  clientMessage: string;
+
+  constructor(m: string, status = 500, clientMessage = 'Unexpected Error') {
+    super(m);
+    this.status = status;
+    this.code =
+      status === 400
+        ? API_ERROR_CODES.INVALID_REQUEST
+        : status === 404
+        ? API_ERROR_CODES.NOT_FOUND
+        : status === 401
+        ? API_ERROR_CODES.UNAUTHORIZED
+        : API_ERROR_CODES.UNEXPECTED_ERROR;
+    this.clientMessage = clientMessage;
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, ApiError.prototype);
+  }
+
+  isApiError() {
+    return true;
+  }
+}

--- a/modules/app/components/ErrorPage.tsx
+++ b/modules/app/components/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import { Box, Text } from 'theme-ui';
+
+export default function ErrorPage({
+  statusCode,
+  title = 'An unexpected error has ocurred',
+  children
+}: {
+  statusCode: number;
+  title?: string;
+  children?: React.ReactElement;
+}): React.ReactElement {
+  return (
+    <Box>
+      <Text>{statusCode} </Text> | {title}
+      <Box>{children}</Box>
+      <Box>
+        <Text>For more information or help contact the Development and UX core unit at : Discord</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/modules/app/components/ErrorPage.tsx
+++ b/modules/app/components/ErrorPage.tsx
@@ -1,4 +1,6 @@
-import { Box, Text } from 'theme-ui';
+import Head from 'next/head';
+import { Box, Flex, Text } from 'theme-ui';
+import { ExternalLink } from './ExternalLink';
 
 export default function ErrorPage({
   statusCode,
@@ -11,10 +13,25 @@ export default function ErrorPage({
 }): React.ReactElement {
   return (
     <Box>
-      <Text>{statusCode} </Text> | {title}
-      <Box>{children}</Box>
-      <Box>
-        <Text>For more information or help contact the Development and UX core unit at : Discord</Text>
+      <Head>
+        <title>
+          {statusCode}: {title}
+        </title>
+      </Head>
+      <Box sx={{ maxWidth: '500px', margin: '0 auto', pt: '200px', paddingBottom: '200px' }}>
+        <Flex sx={{ justifyContent: 'center', alignItems: 'center' }}>
+          <Text sx={{ fontSize: 5, fontWeight: 'bold', mr: 2 }}>{statusCode}</Text> |{' '}
+          <Text sx={{ ml: 2 }}>{title}</Text>
+        </Flex>
+        <Box pt={3}>{children}</Box>
+        <Box pt={3}>
+          <Text sx={{ textAlign: 'center' }}>
+            For more information or help contact the Development and UX core unit at{' '}
+            <ExternalLink href="https://discord.gg/GHcFMdKden" title="Discord">
+              <Text>Discord</Text>
+            </ExternalLink>
+          </Text>
+        </Box>
       </Box>
     </Box>
   );

--- a/modules/app/components/ErrorPage.tsx
+++ b/modules/app/components/ErrorPage.tsx
@@ -26,7 +26,7 @@ export default function ErrorPage({
         <Box pt={3}>{children}</Box>
         <Box pt={3}>
           <Text sx={{ textAlign: 'center' }}>
-            For more information or help contact the Development and UX core unit at{' '}
+            For more information or help, please contact the Development &amp; UX core unit on{' '}
             <ExternalLink href="https://discord.gg/GHcFMdKden" title="Discord">
               <Text>Discord</Text>
             </ExternalLink>

--- a/modules/app/constants/apiErrors.ts
+++ b/modules/app/constants/apiErrors.ts
@@ -1,0 +1,7 @@
+export const API_ERROR_CODES = {
+  UNEXPECTED_ERROR: 'unexpected_error',
+  UNAUTHORIZED: 'unauthorized',
+  INVALID_REQUEST: 'invalid_request',
+  NOT_FOUND: 'not_found',
+  METHOD_NOT_ALLOWED: 'method_not_allowed'
+};

--- a/modules/delegates/components/modals/Confirm.tsx
+++ b/modules/delegates/components/modals/Confirm.tsx
@@ -25,11 +25,23 @@ export const ConfirmContent = ({ mkrToDeposit, delegate, onClick, onBack }: Prop
         You are delegating{' '}
         <Text sx={{ fontWeight: 'bold', display: 'inline' }}>{formatValue(mkrToDeposit, 'wad', 6)} MKR</Text>{' '}
         to delegate contract{' '}
-        <EtherscanLink type="address" showAddress hash={voteDelegateAddress} network={network} />
+        <EtherscanLink
+          type="address"
+          showAddress
+          hash={voteDelegateAddress}
+          network={network}
+          styles={{ justifyContent: 'center' }}
+        />
       </Text>
       <Text sx={{ color: 'secondaryEmphasis', mt: 4 }}>
         This delegate contract was created by{' '}
-        <EtherscanLink type="address" showAddress hash={address} network={network} />
+        <EtherscanLink
+          type="address"
+          showAddress
+          hash={address}
+          network={network}
+          styles={{ justifyContent: 'center' }}
+        />
       </Text>
       <Button onClick={onClick} sx={{ mt: 4 }}>
         Confirm Transaction

--- a/modules/gql/gql.constants.ts
+++ b/modules/gql/gql.constants.ts
@@ -5,7 +5,7 @@ export const GOERLI_SPOCK_URL = 'https://pollingdb2-goerli-staging.makerdux.com/
 
 //TODO: switch both back to actual deployment
 // export const STAGING_MAINNET_SPOCK_URL = 'https://polling-db-staging.makerdux.com/api/v1';
-export const STAGING_MAINNET_SPOCK_URL = 'https://pollingdb2-mainnet-staging.makerdux.com/';
+export const STAGING_MAINNET_SPOCK_URL = 'https://pollingdb2-mainnet-staging.makerdux.com/api/v1';
 // export const MAINNET_SPOCK_URL = 'https://polling-db-prod.makerdux.com/api/v1';
 export const MAINNET_SPOCK_URL = 'https://b0f9-3-69-177-22.eu.ngrok.io/v1';
 

--- a/modules/gql/gqlRequest.ts
+++ b/modules/gql/gqlRequest.ts
@@ -23,8 +23,6 @@ export const gqlRequest = async <TQuery = any>({
       return Promise.reject(new ApiError(`Missing spock url in configuration for chainId: ${id}`));
     }
 
-    throw { message: 'ee' };
-
     const resp = await request(url, query, variables);
     return resp;
   } catch (e) {

--- a/modules/gql/gqlRequest.ts
+++ b/modules/gql/gqlRequest.ts
@@ -1,4 +1,6 @@
 import { request, Variables, RequestDocument } from 'graphql-request';
+import logger from 'lib/logger';
+import { ApiError } from 'modules/app/api/ApiError';
 import { SupportedChainId } from 'modules/web3/constants/chainID';
 import { CHAIN_INFO } from 'modules/web3/constants/networks';
 
@@ -14,11 +16,20 @@ export const gqlRequest = async <TQuery = any>({
   query,
   variables
 }: GqlRequestProps): Promise<TQuery> => {
-  const id = chainId ?? SupportedChainId.MAINNET;
-  const url = CHAIN_INFO[id].spockUrl;
-  if (!url) {
-    return Promise.reject('missing spock url');
-  }
+  try {
+    const id = chainId ?? SupportedChainId.MAINNET;
+    const url = CHAIN_INFO[id].spockUrl;
+    if (!url) {
+      return Promise.reject(new ApiError(`Missing spock url in configuration for chainId: ${id}`));
+    }
 
-  return await request(url, query, variables);
+    throw { message: 'ee' };
+
+    const resp = await request(url, query, variables);
+    return resp;
+  } catch (e) {
+    const message = `Error on GraphQL query, Chain ID: ${chainId}, query: ${query}, message: ${e.message}`;
+    logger.error(message);
+    throw new ApiError(message);
+  }
 };

--- a/modules/mkr/helpers/getMKRVotingWeight.ts
+++ b/modules/mkr/helpers/getMKRVotingWeight.ts
@@ -70,7 +70,6 @@ export async function getMKRVotingWeight(
   // otherwise, not proxy or delegate, get connected wallet balances
   const walletBalanceHot = await contracts.mkr.balanceOf(address);
   const chiefBalanceHot = await contracts.chief.deposits(address);
-  console.log('eeeeee', chiefBalanceHot.toNumber());
   return {
     walletBalanceHot,
     chiefBalanceHot,

--- a/modules/mkr/helpers/getMKRVotingWeight.ts
+++ b/modules/mkr/helpers/getMKRVotingWeight.ts
@@ -70,7 +70,7 @@ export async function getMKRVotingWeight(
   // otherwise, not proxy or delegate, get connected wallet balances
   const walletBalanceHot = await contracts.mkr.balanceOf(address);
   const chiefBalanceHot = await contracts.chief.deposits(address);
-
+  console.log('eeeeee', chiefBalanceHot.toNumber());
   return {
     walletBalanceHot,
     chiefBalanceHot,

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,0 +1,14 @@
+import ErrorPage from 'modules/app/components/ErrorPage';
+
+function Error({ statusCode }): React.ReactElement {
+  return (
+    <ErrorPage statusCode={statusCode} title={statusCode === 404 ? 'Page not found' : 'Unexpected error'} />
+  );
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,8 +1,11 @@
 import ErrorPage from 'modules/app/components/ErrorPage';
+import PrimaryLayout from 'modules/app/components/layout/layouts/Primary';
 
 function Error({ statusCode }): React.ReactElement {
   return (
-    <ErrorPage statusCode={statusCode} title={statusCode === 404 ? 'Page not found' : 'Unexpected error'} />
+    <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+      <ErrorPage statusCode={statusCode} title={statusCode === 404 ? 'Page not found' : 'Unexpected error'} />
+    </PrimaryLayout>
   );
 }
 

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -119,7 +119,7 @@ export default function AddressPage(): JSX.Element {
   } else if (error) {
     return (
       <PrimaryLayout>
-        <ErrorPage statusCode={500} title="Error fetching address information" />
+        <ErrorPage statusCode={error.status} title="Error fetching address information" />
       </PrimaryLayout>
     );
   }

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -112,9 +112,17 @@ export default function AddressPage(): JSX.Element {
   console.log('SSR', error);
 
   if (error && error.status === 404) {
-    return <ErrorPage statusCode={404} title="This address does not exist" />;
+    return (
+      <PrimaryLayout>
+        <ErrorPage statusCode={404} title="This address does not exist" />
+      </PrimaryLayout>
+    );
   } else if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching address information" />;
+    return (
+      <PrimaryLayout>
+        <ErrorPage statusCode={500} title="Error fetching address information" />
+      </PrimaryLayout>
+    );
   }
 
   if (!data) {

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -109,7 +109,6 @@ export default function AddressPage(): JSX.Element {
     revalidateOnMount: !cache.get(dataKeyAccount),
     revalidateOnReconnect: false
   });
-  console.log('SSR', error);
 
   if (error && error.status === 404) {
     return (

--- a/pages/address/[address]/index.tsx
+++ b/pages/address/[address]/index.tsx
@@ -1,6 +1,6 @@
 import { Heading, Box, Flex, Button } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { fetchJson } from 'lib/fetchJson';
 import { useAnalytics } from 'modules/app/client/analytics/useAnalytics';
@@ -109,9 +109,12 @@ export default function AddressPage(): JSX.Element {
     revalidateOnMount: !cache.get(dataKeyAccount),
     revalidateOnReconnect: false
   });
+  console.log('SSR', error);
 
-  if (error) {
-    return <ErrorPage statusCode={404} title="Error fetching address information" />;
+  if (error && error.status === 404) {
+    return <ErrorPage statusCode={404} title="This address does not exist" />;
+  } else if (error) {
+    return <ErrorPage statusCode={500} title="Error fetching address information" />;
   }
 
   if (!data) {

--- a/pages/api/address/stats.ts
+++ b/pages/api/address/stats.ts
@@ -85,7 +85,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
       : (req.query.address as string[]);
 
   if (!req.query.address) {
-    throw new ApiError('Address stats, missing address', 401, 'Missing address');
+    throw new ApiError('Address stats, missing address', 400, 'Missing address');
   }
 
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);

--- a/pages/api/address/stats.ts
+++ b/pages/api/address/stats.ts
@@ -9,6 +9,7 @@ import { resolveENS } from 'modules/web3/helpers/ens';
 import { getAddressStatsCacheKey } from 'modules/cache/constants/cache-keys';
 import { cacheGet, cacheSet } from 'modules/cache/cache';
 import { TEN_MINUTES_IN_MS } from 'modules/app/constants/time';
+import { ApiError } from 'modules/app/api/ApiError';
 
 /**
  * @swagger
@@ -84,9 +85,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
       : (req.query.address as string[]);
 
   if (!req.query.address) {
-    return res.status(400).json({
-      error: 'Missing address'
-    });
+    throw new ApiError('Address stats, missing address', 401, 'Missing address');
   }
 
   invariant(isSupportedNetwork(network), `unsupported network ${network}`);

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import withApiHandler from 'modules/app/api/withApiHandler';
-import logger from 'lib/logger';
 import { config } from 'lib/config';
+import { ApiError } from 'modules/app/api/ApiError';
 
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
@@ -20,14 +20,9 @@ export default withApiHandler(
         });
       }
 
-      return res.status(401).json({
-        auth: 'Not ok'
-      });
+      throw new ApiError('Unauthorized', 401, 'Unauthorized');
     } catch (e) {
-      logger.error(`auth: ${e.message}`);
-      return res.status(401).json({
-        auth: 'Not ok'
-      });
+      throw new ApiError(`auth: ${e.message}`, 401, 'Unauthorized');
     }
   },
   {

--- a/pages/api/cache/invalidate.ts
+++ b/pages/api/cache/invalidate.ts
@@ -10,6 +10,7 @@ import {
   githubExecutivesCacheKey
 } from 'modules/cache/constants/cache-keys';
 import { config } from 'lib/config';
+import { ApiError } from 'modules/app/api/ApiError';
 
 // Deletes cache for a tally
 export default withApiHandler(
@@ -31,19 +32,15 @@ export default withApiHandler(
       const { cacheKey } = req.body;
 
       if (!req.body?.password || req.body?.password !== config.DASHBOARD_PASSWORD) {
-        logger.error('invalidate-cache: invalid password');
-        return res.status(401).json({
-          invalidated: false
-        });
+        throw new ApiError('Invalidate cache, invalid password', 401, 'Unauthorized');
       }
+
       const isAllowed = allowedCacheKeys.reduce((prev, next) => {
         return prev || cacheKey.indexOf(next) !== -1;
       }, false);
 
       if (!isAllowed || !cacheKey) {
-        return res.status(401).json({
-          error: 'Unauthorized'
-        });
+        throw new ApiError('Invalidate cache, invalid request', 400, 'Invalid request');
       }
 
       logger.debug(`invalidate-cache request: ${cacheKey}`);
@@ -55,10 +52,7 @@ export default withApiHandler(
         cacheKey
       });
     } catch (e) {
-      logger.error(`invalidate-cache: ${e.message}`);
-      return res.status(200).json({
-        invalidated: false
-      });
+      throw new ApiError(`Invalidate cache, ${e.messaage}`, 500);
     }
   },
   {

--- a/pages/api/comments/polling/add.ts
+++ b/pages/api/comments/polling/add.ts
@@ -7,6 +7,8 @@ import { insertPollComments } from 'modules/comments/api/insertPollingComments';
 import logger from 'lib/logger';
 import validateQueryParam from 'modules/app/api/validateQueryParam';
 import { getGaslessNetwork } from 'modules/web3/helpers/chain';
+import { ApiError } from 'modules/app/api/ApiError';
+import { API_ERROR_CODES } from 'modules/app/constants/apiErrors';
 
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
@@ -31,9 +33,7 @@ export default withApiHandler(
       const gaslessNetworkMatches = gaslessNetwork && getGaslessNetwork(network) === gaslessNetwork;
 
       if (gaslessNetwork && !gaslessNetworkMatches) {
-        return res.status(400).json({
-          error: 'Invalid Gasless Network'
-        });
+        throw new ApiError('Invalid Gasless Network', 400, 'Invalid Gasless Network');
       }
 
       // Verifies the data
@@ -67,8 +67,7 @@ export default withApiHandler(
 
       res.status(200).json({ success: 'Added Successfully' });
     } catch (err) {
-      logger.error(`POST /api/comments/polling/add: ${err}`);
-      return res.status(500).json({});
+      throw new ApiError(`POST /api/comments/polling/add: ${err}`, 500, 'Error adding poll comments');
     }
   },
   { allowPost: true }

--- a/pages/api/executive/[proposal-id].ts
+++ b/pages/api/executive/[proposal-id].ts
@@ -7,6 +7,8 @@ import { CMSProposal } from 'modules/executive/types';
 import { NotFoundResponse } from 'modules/app/types/genericApiResponse';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
+import { API_ERROR_CODES } from 'modules/app/constants/apiErrors';
+import { ApiError } from 'modules/app/api/ApiError';
 
 /**
  * @swagger
@@ -75,9 +77,7 @@ export default withApiHandler(
     const response = await getExecutiveProposal(proposalId, network);
 
     if (!response) {
-      return res.status(404).json({
-        error: 'Not found'
-      });
+      throw new ApiError(`GET /api/executive/${proposalId}`, 404, 'Proposal not found');
     }
 
     res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');

--- a/pages/api/executive/all-locks.ts
+++ b/pages/api/executive/all-locks.ts
@@ -1,3 +1,4 @@
+import { ApiError } from 'modules/app/api/ApiError';
 import validateQueryParam from 'modules/app/api/validateQueryParam';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import fetchAllLocksSummed from 'modules/home/api/fetchAllLocksSummed';
@@ -30,9 +31,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   );
 
   if (!data) {
-    return res.status(404).json({
-      error: 'Not found'
-    });
+    throw new ApiError('Not found', 404);
   }
 
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');

--- a/pages/api/migration/link.ts
+++ b/pages/api/migration/link.ts
@@ -2,17 +2,18 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { config } from 'lib/config';
 import { postRequestToDiscord } from 'modules/app/api/postRequestToDiscord';
+import { ApiError } from 'modules/app/api/ApiError';
 
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
     if (!config.MIGRATION_WEBHOOK_URL) {
-      return res.status(500).json({ error: 'Discord webhook not properly configured' });
+      throw new ApiError('Migration discord webhook not properly configured', 500);
     }
 
     const body = JSON.parse(req.body);
 
     if (!body.sig || !body.msg) {
-      return res.status(400).json({ error: 'Request missing parameters' });
+      throw new ApiError('Migration discord: Missing parameters', 400, 'Invalid request parameters');
     }
 
     try {
@@ -24,7 +25,7 @@ export default withApiHandler(
       res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate');
       res.status(200).json({ data });
     } catch (err) {
-      return res.status(500).json({ error: 'Internal server error' });
+      throw new ApiError(`Migration Webhook ${err.message}`, 500);
     }
   },
   { allowPost: true }

--- a/pages/api/polling/[slug].ts
+++ b/pages/api/polling/[slug].ts
@@ -1,3 +1,4 @@
+import { ApiError } from 'modules/app/api/ApiError';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { fetchPollById, fetchPollBySlug } from 'modules/polling/api/fetchPollBy';
 import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
@@ -108,9 +109,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   }
 
   if (!poll) {
-    return res.status(404).json({
-      error: 'Not found'
-    });
+    throw new ApiError('Poll not found', 404, 'Poll not found');
   }
 
   res.setHeader('Cache-Control', 's-maxage=15, stale-while-revalidate');

--- a/pages/api/polling/__tests__/vote.spec.ts
+++ b/pages/api/polling/__tests__/vote.spec.ts
@@ -59,7 +59,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.VOTER_MUST_BE_STRING });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.VOTER_MUST_BE_STRING }
+    });
     // expect(res.getHeaders()).toEqual({ 'content-type': 'application/json' });
     expect(res.statusMessage).toEqual('OK');
   });
@@ -72,7 +74,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.POLLIDS_MUST_BE_ARRAY_NUMBERS });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.POLLIDS_MUST_BE_ARRAY_NUMBERS }
+    });
   });
 
   it('return 400 if optionIds is not an array of integers', async () => {
@@ -84,7 +88,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.OPTIONIDS_MUST_BE_ARRAY_NUMBERS });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.OPTIONIDS_MUST_BE_ARRAY_NUMBERS }
+    });
   });
 
   it('return 400 if nonce is not a number', async () => {
@@ -97,7 +103,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.NONCE_MUST_BE_NUMBER });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.NONCE_MUST_BE_NUMBER }
+    });
   });
 
   it('return 400 if expiry is not a number', async () => {
@@ -111,7 +119,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.EXPIRY_MUST_BE_NUMBER });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.EXPIRY_MUST_BE_NUMBER }
+    });
   });
 
   it('return 400 if expired', async () => {
@@ -125,7 +135,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.EXPIRED_VOTES });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.EXPIRED_VOTES }
+    });
   });
 
   it('return 400 if signature is not a string', async () => {
@@ -140,7 +152,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.SIGNATURE_MUST_BE_STRING });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.SIGNATURE_MUST_BE_STRING }
+    });
   });
 
   it('return 400 if network is not valid', async () => {
@@ -155,7 +169,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.INVALID_NETWORK });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.INVALID_NETWORK }
+    });
   });
 
   it('return 400 if nonce is not valid', async () => {
@@ -172,7 +188,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.INVALID_NONCE_FOR_ADDRESS });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.INVALID_NONCE_FOR_ADDRESS }
+    });
   });
 
   it('return 400 if MKR amount is not valid', async () => {
@@ -196,7 +214,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.LESS_THAN_MINIMUM_MKR_REQUIRED });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.LESS_THAN_MINIMUM_MKR_REQUIRED }
+    });
   });
 
   it('return 400 if any poll is expired', async () => {
@@ -231,7 +251,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.EXPIRED_POLLS });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.EXPIRED_POLLS }
+    });
   });
 
   it('return 400 if it used gasless voting recently', async () => {
@@ -269,7 +291,9 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.RATE_LIMITED });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.RATE_LIMITED }
+    });
   });
 
   it('return 400 if voter and signer do not match', async () => {
@@ -310,6 +334,8 @@ describe('/api/polling/vote API Endpoint', () => {
     await voteAPIHandler(req, res);
 
     expect(res.statusCode).toBe(400);
-    expect(res._getJSONData()).toEqual({ error: API_VOTE_ERRORS.VOTER_AND_SIGNER_DIFFER });
+    expect(res._getJSONData()).toEqual({
+      error: { code: 'invalid_request', message: API_VOTE_ERRORS.VOTER_AND_SIGNER_DIFFER }
+    });
   });
 });

--- a/pages/api/polling/precheck.ts
+++ b/pages/api/polling/precheck.ts
@@ -7,6 +7,7 @@ import { hasMkrRequiredVotingWeight } from 'modules/polling/helpers/hasMkrRequir
 import { MIN_MKR_REQUIRED_FOR_GASLESS_VOTING } from 'modules/polling/polling.constants';
 import { ballotIncludesAlreadyVoted } from 'modules/polling/helpers/ballotIncludesAlreadyVoted';
 import { getRelayerBalance } from 'modules/polling/api/getRelayerBalance';
+import { ApiError } from 'modules/app/api/ApiError';
 
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
   const network = (req.query.network as SupportedNetworks) || DEFAULT_NETWORK.network;
@@ -16,15 +17,11 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   const pollIdsArray = pollIds.split(',');
 
   if (!voter) {
-    return res.status(400).json({
-      error: 'no voter provided'
-    });
+    throw new ApiError('Gasless precheck: Missing parameters', 400, 'No voter provided');
   }
 
   if (!pollIds || pollIdsArray.length === 0) {
-    return res.status(400).json({
-      error: 'no poll ids provided'
-    });
+    throw new ApiError('Gasless precheck: Missing parameters', 400, 'No poll ids provided');
   }
 
   const cacheKey = getRecentlyUsedGaslessVotingKey(voter);

--- a/pages/api/polling/relayer-balance.ts
+++ b/pages/api/polling/relayer-balance.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import withApiHandler from 'modules/app/api/withApiHandler';
-import logger from 'lib/logger';
 import { isSupportedNetwork } from 'modules/web3/helpers/networks';
 import { getMessageFromCode, ERROR_CODES } from 'eth-rpc-errors';
 import { getRelayerBalance } from 'modules/polling/api/getRelayerBalance';
 import { DEFAULT_NETWORK } from 'modules/web3/constants/networks';
 import invariant from 'tiny-invariant';
+import { ApiError } from 'modules/app/api/ApiError';
 
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
@@ -22,10 +22,8 @@ export default withApiHandler(
         [...Object.values(ERROR_CODES.provider), ...Object.values(ERROR_CODES.rpc)].includes(err['code'])
           ? getMessageFromCode(err['code'])
           : err.message;
-      logger.error(errorMessage);
-      return res.status(400).json({
-        error: errorMessage
-      });
+
+      throw new ApiError(`Relayer balance: ${errorMessage}`, 500, errorMessage);
     }
   },
   { allowPost: true }

--- a/pages/api/polling/tally/[poll-id].ts
+++ b/pages/api/polling/tally/[poll-id].ts
@@ -5,6 +5,7 @@ import { getPollTally } from 'modules/polling/helpers/getPollTally';
 import { fetchPollById } from 'modules/polling/api/fetchPollBy';
 import { pollHasStarted } from 'modules/polling/helpers/utils';
 import { PollTally } from 'modules/polling/types';
+import { ApiError } from 'modules/app/api/ApiError';
 
 // Returns a PollTally given a pollID
 
@@ -125,11 +126,7 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   const poll = await fetchPollById(parseInt(req.query['poll-id'] as string, 10), network);
 
   if (!poll) {
-    res.status(404).json({
-      error: 'Not found'
-    });
-
-    return;
+    throw new ApiError('Poll not found', 404, 'Poll not found');
   }
 
   if (!pollHasStarted(poll)) {

--- a/pages/api/polling/vote.ts
+++ b/pages/api/polling/vote.ts
@@ -40,232 +40,168 @@ export const API_VOTE_ERRORS = {
   ALREADY_VOTED_IN_POLL: 'Address has already voted in this poll.'
 };
 
-import { getMessageFromCode, ERROR_CODES } from 'eth-rpc-errors';
+import { ApiError } from 'modules/app/api/ApiError';
 
-async function postError(error: string) {
+async function throwError(error: string, body: any, code = 400) {
+  // Post on discord
   try {
     if (config.GASLESS_WEBHOOK_URL) {
       await postRequestToDiscord({
         url: config.GASLESS_WEBHOOK_URL,
-        content: error,
+        content: JSON.stringify({
+          error,
+          ...body
+        }),
         // TODO turn this to true when ready to deploy
         notify: false
       });
     }
   } catch (err) {
-    logger.error(err);
+    logger.error('API Vote: Unable to post error to discord', err.message);
   }
+
+  // Return api error
+  throw new ApiError(`Poll Gasless Vote: ${error}`, code, error);
 }
 
 //TODO: add swagger documentation
 export default withApiHandler(
   async (req: NextApiRequest, res: NextApiResponse) => {
-    try {
-      const { voter, pollIds, optionIds, nonce, expiry, signature, network, secret } = req.body;
-
-      if (typeof voter !== 'string' || !voter) {
-        const error = { error: API_VOTE_ERRORS.VOTER_MUST_BE_STRING };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-      if (!Array.isArray(pollIds) || !pollIds.every(e => !isNaN(parseInt(e)))) {
-        const error = {
-          error: API_VOTE_ERRORS.POLLIDS_MUST_BE_ARRAY_NUMBERS
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-      if (!Array.isArray(optionIds) || !optionIds.every(e => !isNaN(parseInt(e)))) {
-        const error = {
-          error: API_VOTE_ERRORS.OPTIONIDS_MUST_BE_ARRAY_NUMBERS
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-      if (typeof nonce !== 'number') {
-        const error = {
-          error: API_VOTE_ERRORS.NONCE_MUST_BE_NUMBER
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-      if (typeof expiry !== 'number') {
-        const error = {
-          error: API_VOTE_ERRORS.EXPIRY_MUST_BE_NUMBER
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      if (expiry <= Date.now() / 1000) {
-        const error = {
-          error: API_VOTE_ERRORS.EXPIRED_VOTES
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      if (typeof signature !== 'string' || !signature) {
-        const error = {
-          error: API_VOTE_ERRORS.SIGNATURE_MUST_BE_STRING
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      if (!isSupportedNetwork(network)) {
-        const error = {
-          error: API_VOTE_ERRORS.INVALID_NETWORK
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      if (secret && secret !== config.GASLESS_BACKDOOR_SECRET) {
-        const error = {
-          error: API_VOTE_ERRORS.WRONG_SECRET
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      //get arbitrum polling contract with relayer's signer
-      const pollingContract = getArbitrumPollingContractRelayProvider(network);
-
-      // Extract the real address that will be used for voting (delegate contract, proxy contract or normal address)
-      const contracts = getContracts(networkNameToChainId(network), undefined, undefined, true);
-
-      // Find the voty proxy for the address (in case there's one)
-      const voteProxyAddress = await getVoteProxyAddresses(contracts.voteProxyFactory, voter, network);
-
-      // Find the delegate contract address if the address is a normal wallet
-      const voteDelegateAdress = await getDelegateContractAddress(contracts, voter);
-
-      const addressDisplayedAsVoter = voteDelegateAdress
-        ? voteDelegateAdress
-        : voteProxyAddress?.hotAddress
-        ? voteProxyAddress.hotAddress
-        : voter;
-
-      //verify valid nonce and expiry date
-      const nonceFromContract = await pollingContract.nonces(voter);
-      if (nonceFromContract.toNumber() !== nonce) {
-        const error = {
-          error: API_VOTE_ERRORS.INVALID_NONCE_FOR_ADDRESS
-        };
-        postError(JSON.stringify({ ...error, ...req.body }));
-        return res.status(400).json(error);
-      }
-
-      //verify that signature and address correspond
-      const recovered = recoverTypedSignature({
-        data: getTypedBallotData({ voter, pollIds, optionIds, nonce, expiry }, network),
-        signature,
-        version: SignTypedDataVersion.V4
-      });
-
-      if (ethers.utils.getAddress(recovered) !== ethers.utils.getAddress(voter)) {
-        return res.status(400).json({
-          error: API_VOTE_ERRORS.VOTER_AND_SIGNER_DIFFER
-        });
-      }
-
-      //run eligibility checks unless backdoor secret provided
-      if (!secret || secret !== config.GASLESS_BACKDOOR_SECRET) {
-        //verify address has a poll weight > 0.1 MKR
-        const hasMkrRequired = await hasMkrRequiredVotingWeight(
-          voter,
-          network,
-          MIN_MKR_REQUIRED_FOR_GASLESS_VOTING
-        );
-
-        if (!hasMkrRequired) {
-          //ether's bignumber library doesnt handle decimals
-          const error = { error: API_VOTE_ERRORS.LESS_THAN_MINIMUM_MKR_REQUIRED };
-          postError(JSON.stringify({ ...error, ...req.body }));
-          return res.status(400).json(error);
-        }
-
-        // Verify that all the polls are active
-        const filters = {
-          startDate: new Date(),
-          endDate: null,
-          tags: null
-        };
-
-        const pollsResponse = await getPolls(filters, network);
-        const areAllPollsActive = pollIds
-          .map(pollId => {
-            const poll = pollsResponse.polls.find(p => p.pollId === parseInt(pollId));
-            if (!poll || !isActivePoll(poll)) {
-              return false;
-            }
-            return true;
-          })
-          .reduce((prev, next) => {
-            return prev && next;
-          });
-
-        if (!areAllPollsActive) {
-          const error = {
-            error: API_VOTE_ERRORS.EXPIRED_POLLS
-          };
-          postError(JSON.stringify({ ...error, ...req.body }));
-          return res.status(400).json(error);
-        }
-
-        //check that address hasn't used gasless service recently
-        // use the "addressDisplayedAsVoter" in case the user created a delegate contract, so it does not use the user's wallet
-        const recentlyUsedGaslessVoting = await recentlyUsedGaslessVotingCheck(
-          addressDisplayedAsVoter,
-          network
-        );
-        if (recentlyUsedGaslessVoting) {
-          const error = {
-            error: API_VOTE_ERRORS.RATE_LIMITED
-          };
-          postError(JSON.stringify({ ...error, ...req.body }));
-          return res.status(400).json(error);
-        }
-
-        //can't use gasless service to vote in a poll you've already voted on
-        // use "addressDisplayedAsVoter" to make sure we match against the delegate contract votes or the normal votes.
-        const ballotHasVotedPolls = await ballotIncludesAlreadyVoted(
-          addressDisplayedAsVoter,
-          network,
-          pollIds
-        );
-        if (ballotHasVotedPolls) {
-          const error = { error: API_VOTE_ERRORS.ALREADY_VOTED_IN_POLL };
-          postError(JSON.stringify({ ...error, ...req.body }));
-          return res.status(400).json(error);
-        }
-      }
-
-      const r = signature.slice(0, 66);
-      const s = '0x' + signature.slice(66, 130);
-      const v = Number('0x' + signature.slice(130, 132));
-
-      const cacheKey = getRecentlyUsedGaslessVotingKey(addressDisplayedAsVoter);
-      cacheSet(cacheKey, JSON.stringify(Date.now()), network, GASLESS_RATE_LIMIT_IN_MS);
-
-      const tx = await pollingContract[
-        'vote(address,uint256,uint256,uint256[],uint256[],uint8,bytes32,bytes32)'
-      ](voter, nonce, expiry, pollIds, optionIds, v, r, s);
-
-      return res.status(200).json(tx);
-    } catch (err) {
-      const errorMessage =
-        'code' in err &&
-        [...Object.values(ERROR_CODES.provider), ...Object.values(ERROR_CODES.rpc)].includes(err['code'])
-          ? getMessageFromCode(err['code'])
-          : err.message;
-      postError(JSON.stringify(err));
-      logger.error(errorMessage);
-      return res.status(400).json({
-        error: errorMessage
-      });
+    const { voter, pollIds, optionIds, nonce, expiry, signature, network, secret } = req.body;
+    if (typeof voter !== 'string' || !voter) {
+      await throwError(API_VOTE_ERRORS.VOTER_MUST_BE_STRING, req.body);
     }
+    if (!Array.isArray(pollIds) || !pollIds.every(e => !isNaN(parseInt(e)))) {
+      await throwError(API_VOTE_ERRORS.POLLIDS_MUST_BE_ARRAY_NUMBERS, req.body);
+    }
+    if (!Array.isArray(optionIds) || !optionIds.every(e => !isNaN(parseInt(e)))) {
+      await throwError(API_VOTE_ERRORS.OPTIONIDS_MUST_BE_ARRAY_NUMBERS, req.body);
+    }
+    if (typeof nonce !== 'number') {
+      await throwError(API_VOTE_ERRORS.NONCE_MUST_BE_NUMBER, req.body);
+    }
+    if (typeof expiry !== 'number') {
+      await throwError(API_VOTE_ERRORS.EXPIRY_MUST_BE_NUMBER, req.body);
+    }
+
+    if (expiry <= Date.now() / 1000) {
+      await throwError(API_VOTE_ERRORS.EXPIRED_VOTES, req.body);
+    }
+
+    if (typeof signature !== 'string' || !signature) {
+      await throwError(API_VOTE_ERRORS.SIGNATURE_MUST_BE_STRING, req.body);
+    }
+
+    if (!isSupportedNetwork(network)) {
+      await throwError(API_VOTE_ERRORS.INVALID_NETWORK, req.body);
+    }
+
+    if (secret && secret !== config.GASLESS_BACKDOOR_SECRET) {
+      await throwError(API_VOTE_ERRORS.WRONG_SECRET, req.body);
+    }
+
+    //get arbitrum polling contract with relayer's signer
+    const pollingContract = getArbitrumPollingContractRelayProvider(network);
+
+    // Extract the real address that will be used for voting (delegate contract, proxy contract or normal address)
+    const contracts = getContracts(networkNameToChainId(network), undefined, undefined, true);
+
+    // Find the voty proxy for the address (in case there's one)
+    const voteProxyAddress = await getVoteProxyAddresses(contracts.voteProxyFactory, voter, network);
+
+    // Find the delegate contract address if the address is a normal wallet
+    const voteDelegateAdress = await getDelegateContractAddress(contracts, voter);
+
+    const addressDisplayedAsVoter = voteDelegateAdress
+      ? voteDelegateAdress
+      : voteProxyAddress?.hotAddress
+      ? voteProxyAddress.hotAddress
+      : voter;
+
+    //verify valid nonce and expiry date
+    const nonceFromContract = await pollingContract.nonces(voter);
+    if (nonceFromContract.toNumber() !== nonce) {
+      await throwError(API_VOTE_ERRORS.INVALID_NONCE_FOR_ADDRESS, req.body);
+    }
+
+    //verify that signature and address correspond
+    const recovered = recoverTypedSignature({
+      data: getTypedBallotData({ voter, pollIds, optionIds, nonce, expiry }, network),
+      signature,
+      version: SignTypedDataVersion.V4
+    });
+
+    if (ethers.utils.getAddress(recovered) !== ethers.utils.getAddress(voter)) {
+      await throwError(API_VOTE_ERRORS.VOTER_AND_SIGNER_DIFFER, req.body);
+    }
+
+    //run eligibility checks unless backdoor secret provided
+    if (!secret || secret !== config.GASLESS_BACKDOOR_SECRET) {
+      //verify address has a poll weight > 0.1 MKR
+      const hasMkrRequired = await hasMkrRequiredVotingWeight(
+        voter,
+        network,
+        MIN_MKR_REQUIRED_FOR_GASLESS_VOTING
+      );
+
+      if (!hasMkrRequired) {
+        //ether's bignumber library doesnt handle decimals
+        await throwError(API_VOTE_ERRORS.LESS_THAN_MINIMUM_MKR_REQUIRED, req.body);
+      }
+
+      // Verify that all the polls are active
+      const filters = {
+        startDate: new Date(),
+        endDate: null,
+        tags: null
+      };
+
+      const pollsResponse = await getPolls(filters, network);
+      const areAllPollsActive = pollIds
+        .map(pollId => {
+          const poll = pollsResponse.polls.find(p => p.pollId === parseInt(pollId));
+          if (!poll || !isActivePoll(poll)) {
+            return false;
+          }
+          return true;
+        })
+        .reduce((prev, next) => {
+          return prev && next;
+        });
+
+      if (!areAllPollsActive) {
+        await throwError(API_VOTE_ERRORS.EXPIRED_POLLS, req.body);
+      }
+
+      //check that address hasn't used gasless service recently
+      // use the "addressDisplayedAsVoter" in case the user created a delegate contract, so it does not use the user's wallet
+      const recentlyUsedGaslessVoting = await recentlyUsedGaslessVotingCheck(
+        addressDisplayedAsVoter,
+        network
+      );
+      if (recentlyUsedGaslessVoting) {
+        await throwError(API_VOTE_ERRORS.RATE_LIMITED, req.body);
+      }
+
+      //can't use gasless service to vote in a poll you've already voted on
+      // use "addressDisplayedAsVoter" to make sure we match against the delegate contract votes or the normal votes.
+      const ballotHasVotedPolls = await ballotIncludesAlreadyVoted(addressDisplayedAsVoter, network, pollIds);
+      if (ballotHasVotedPolls) {
+        await throwError(API_VOTE_ERRORS.ALREADY_VOTED_IN_POLL, req.body);
+      }
+    }
+
+    const r = signature.slice(0, 66);
+    const s = '0x' + signature.slice(66, 130);
+    const v = Number('0x' + signature.slice(130, 132));
+
+    const cacheKey = getRecentlyUsedGaslessVotingKey(addressDisplayedAsVoter);
+    cacheSet(cacheKey, JSON.stringify(Date.now()), network, GASLESS_RATE_LIMIT_IN_MS);
+    const tx = await pollingContract[
+      'vote(address,uint256,uint256,uint256[],uint256[],uint8,bytes32,bytes32)'
+    ](voter, nonce, expiry, pollIds, optionIds, v, r, s);
+
+    return res.status(200).json(tx);
   },
   { allowPost: true }
 );

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Heading, Box, Flex, Card, Text, Button } from 'theme-ui';
 import { GetStaticProps } from 'next';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { BigNumberJS } from 'lib/bigNumberJs';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import shallow from 'zustand/shallow';
@@ -274,7 +274,11 @@ export default function DelegatesPage({
   }
 
   if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching data" />;
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={500} title="Error fetching data" />;
+      </PrimaryLayout>
+    );
   }
 
   const props = {

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -3,7 +3,7 @@ import { Heading, Flex, Box, Button, Divider, Grid, Text, Badge, Spinner, Card }
 import { useEffect, useMemo, useRef } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import { GetStaticProps } from 'next';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 import { useHat } from 'modules/executive/hooks/useHat';
@@ -470,8 +470,18 @@ export default function ExecutiveOverviewPage({
     return <PageLoadingPlaceholder />;
   }
 
-  if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching data" />;
+  if (error && error.status === 404) {
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={404} title="Executive not found" />;
+      </PrimaryLayout>
+    );
+  } else if (error) {
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={500} title="Error fetching data" />;
+      </PrimaryLayout>
+    );
   }
 
   const props = {

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { Button, Card, Flex, Heading, Spinner, Box, Text, Divider } from 'theme-ui';
 import { BigNumberJS } from 'lib/bigNumberJs';
 import useSWR, { useSWRConfig } from 'swr';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useCallback } from 'react';
 import { GetStaticProps } from 'next';
 import { Heading, Text, Flex, useColorMode, Box } from 'theme-ui';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { isActivePoll } from 'modules/polling/helpers/utils';
 import PrimaryLayout from 'modules/app/components/layout/layouts/Primary';
 import Stack from 'modules/app/components/layout/layouts/Stack';
@@ -318,7 +318,11 @@ export default function Index({
   }
 
   if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching data" />;
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={500} title="Error fetching data" />;
+      </PrimaryLayout>
+    );
   }
 
   const props = {

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef, useMemo } from 'react';
 import { Heading, Box, Flex, Button, Text } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import { Icon } from '@makerdao/dai-ui-icons';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import shallow from 'zustand/shallow';
@@ -381,7 +381,11 @@ export default function PollingOverviewPage({
   }
 
   if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching data" />;
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={500} title="Error fetching data" />;
+      </PrimaryLayout>
+    );
   }
 
   const props = {

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { Card, Flex, Divider, Heading, Text, Box, Button, Badge } from 'theme-ui';
@@ -374,7 +374,12 @@ export default function PollPage({ poll: prefetchedPoll }: { poll?: Poll }): JSX
 
   if (!poll && (error || (isDefaultNetwork(network) && !isFallback && !prefetchedPoll?.multiHash))) {
     return (
-      <ErrorPage statusCode={404} title="Poll either does not exist, or could not be fetched at this time" />
+      <PrimaryLayout>
+        <ErrorPage
+          statusCode={404}
+          title="Poll either does not exist, or could not be fetched at this time"
+        />
+      </PrimaryLayout>
     );
   }
 

--- a/pages/polling/review.tsx
+++ b/pages/polling/review.tsx
@@ -2,7 +2,7 @@ import { GetStaticProps } from 'next';
 import { useContext, useMemo, useState } from 'react';
 import { Heading, Box, Button, Flex, Text } from 'theme-ui';
 import { Icon } from '@makerdao/dai-ui-icons';
-import ErrorPage from 'next/error';
+import ErrorPage from 'modules/app/components/ErrorPage';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import useSWR, { useSWRConfig } from 'swr';
 import { isActivePoll, findPollById, isInputFormatRankFree } from 'modules/polling/helpers/utils';
@@ -379,9 +379,12 @@ export default function PollingReviewPage({ polls: prefetchedPolls }: PollingRev
   }
 
   if (error) {
-    return <ErrorPage statusCode={500} title="Error fetching data" />;
+    return (
+      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+        <ErrorPage statusCode={500} title="Error fetching data" />;
+      </PrimaryLayout>
+    );
   }
-
   const props = {
     polls: isDefaultNetwork(network) ? prefetchedPolls : data?.polls || [],
     network


### PR DESCRIPTION
- [x] Added new  ApiError class to handle api errors 
- [x] withApiHandler now handles the errors returned by this internal class and formats the response, also logs all the errors with good format
- [x] fetchJSON handles errors with this format and gets the right message
- [x] GQL requests uses ApiError to return formatted error info
- [x] Custom error500 page to show more info about the error
- [ ] Do not break app if GQL requests fails

![image](https://user-images.githubusercontent.com/1152768/193295817-52533023-79c6-4dd1-a10b-c4d9a9cf1c53.png)
