### PR TITLE
Generate test signature api

### DIFF
--- a/pages/api/generate-test-signature.ts
+++ b/pages/api/generate-test-signature.ts
@@ -5,6 +5,7 @@ import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util';
 import { ApiError } from 'modules/app/api/ApiError';
 import { isSupportedNetwork } from 'modules/web3/helpers/networks';
 import { ethers } from 'ethers';
+import { ONE_HOUR_IN_MS } from 'modules/app/constants/time';
 
 const genRanHex = size => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
 
@@ -20,8 +21,8 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   const pollIds = ['1'];
   const optionIds = ['0'];
   const nonce = 0;
-  const expiry = Math.trunc((Date.now() + 8 * 60 * 60 * 1000) / 1000); //8 hour expiry
-  const signatureValues = { 
+  const expiry = Math.trunc((Date.now() + 8 * ONE_HOUR_IN_MS) / 1000); //8 hour expiry
+  const signatureValues = {
     voter: voter.toLowerCase(),
     pollIds,
     optionIds,
@@ -30,7 +31,6 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   };
   const data = getTypedBallotData(signatureValues, network);
   const version = SignTypedDataVersion.V4;
-  const signature = await signTypedData({privateKey, data, version});
-  res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate');
-  res.status(200).json({signature, voter, nonce, expiry, pollIds, optionIds, network });
+  const signature = await signTypedData({ privateKey, data, version });
+  res.status(200).json({ signature, voter, nonce, expiry, pollIds, optionIds, network });
 });

--- a/pages/api/generate-test-signature.ts
+++ b/pages/api/generate-test-signature.ts
@@ -7,7 +7,7 @@ import { ApiError } from 'modules/app/api/ApiError';
 import { isSupportedNetwork } from 'modules/web3/helpers/networks';
 
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
-  const address = '0x43F0A171658791C562FCE5eC6624ca6bb7487c76';
+  const voter = '0x43F0A171658791C562FCE5eC6624ca6bb7487c76';
   const privateKey = Buffer.from('1caf1b303b81525e8c7780376bb335bd7750543206ecb86cec654a085ba3832c', 'hex');
   const { network } = req.query;
   if (typeof network !== 'string' || !network || !isSupportedNetwork(network)) {
@@ -17,16 +17,18 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
 //   const nonce = await contract.nonces(address);
   const pollIds = ['1'];
   const optionIds = ['0'];
+  const nonce = 0;
+  const expiry = Math.trunc((Date.now() + 8 * 60 * 60 * 1000) / 1000); //8 hour expiry
   const signatureValues = { 
-    voter: address.toLowerCase(),
+    voter: voter.toLowerCase(),
     pollIds,
     optionIds,
-    nonce: 0,
-    expiry: Math.trunc((Date.now() + 8 * 60 * 60 * 1000) / 1000) //8 hour expiry
+    nonce,
+    expiry
   };
   const data = getTypedBallotData(signatureValues, network);
   const version = SignTypedDataVersion.V4;
   const signature = await signTypedData({privateKey, data, version});
   res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate');
-  res.status(200).json({address, signature});
+  res.status(200).json({signature, voter, nonce, expiry, pollIds, optionIds });
 });

--- a/pages/api/generate-test-signature.ts
+++ b/pages/api/generate-test-signature.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import withApiHandler from 'modules/app/api/withApiHandler';
+import { getTypedBallotData } from 'modules/web3/helpers/signTypedBallotData';
+import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util';
+import { getArbitrumPollingContractReadOnly } from 'modules/polling/helpers/getArbitrumPollingContractReadOnly';
+import { ApiError } from 'modules/app/api/ApiError';
+import { isSupportedNetwork } from 'modules/web3/helpers/networks';
+
+export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
+  const address = '0x43F0A171658791C562FCE5eC6624ca6bb7487c76';
+  const privateKey = Buffer.from('1caf1b303b81525e8c7780376bb335bd7750543206ecb86cec654a085ba3832c', 'hex');
+  const { network } = req.query;
+  if (typeof network !== 'string' || !network || !isSupportedNetwork(network)) {
+    throw new ApiError('Invalid network');
+  }
+//   const contract = getArbitrumPollingContractReadOnly(network);
+//   const nonce = await contract.nonces(address);
+  const pollIds = ['1'];
+  const optionIds = ['0'];
+  const signatureValues = { 
+    voter: address.toLowerCase(),
+    pollIds,
+    optionIds,
+    nonce: 0,
+    expiry: Math.trunc((Date.now() + 8 * 60 * 60 * 1000) / 1000) //8 hour expiry
+  };
+  const data = getTypedBallotData(signatureValues, network);
+  const version = SignTypedDataVersion.V4;
+  const signature = await signTypedData({privateKey, data, version});
+  res.setHeader('Cache-Control', 's-maxage=30, stale-while-revalidate');
+  res.status(200).json({address, signature});
+});

--- a/pages/api/generate-test-signature.ts
+++ b/pages/api/generate-test-signature.ts
@@ -13,11 +13,10 @@ export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) 
   if (typeof network !== 'string' || !network || !isSupportedNetwork(network)) {
     throw new ApiError('Invalid network');
   }
-//   const contract = getArbitrumPollingContractReadOnly(network);
-//   const nonce = await contract.nonces(address);
+  const contract = getArbitrumPollingContractReadOnly(network);
+  const nonce = await contract.nonces(voter);
   const pollIds = ['1'];
   const optionIds = ['0'];
-  const nonce = 0;
   const expiry = Math.trunc((Date.now() + 8 * 60 * 60 * 1000) / 1000); //8 hour expiry
   const signatureValues = { 
     voter: voter.toLowerCase(),


### PR DESCRIPTION
An api endpoint that uses metamask/eth-sig-util and a psuedo-randomly generated private key to create a valid signature for gasless voting that TechOps can use to test the relayer

To test: visit https://governance-portal-v2-git-generate-signature-api-dux-core-unit.vercel.app/api/generate-test-signature?network=goerli

 or 

https://governance-portal-v2-git-generate-signature-api-dux-core-unit.vercel.app/api/generate-test-signature?network=mainnet