### PR TITLE
Fix/gasless

### DIFF
--- a/modules/comments/api/getCommentTransaction.ts
+++ b/modules/comments/api/getCommentTransaction.ts
@@ -20,11 +20,7 @@ export async function getCommentTransactionStatus(
 
   try {
     const transaction = txHash ? await provider.getTransaction(txHash as string) : null;
-
-    const isValid =
-      transaction &&
-      ethers.utils.getAddress(transaction.from).toLowerCase() ===
-        ethers.utils.getAddress(comment.hotAddress).toLowerCase();
+    const isValid = !!transaction;
 
     const completed = transaction && transaction.confirmations > 10;
     const response = { completed: !!completed, isValid: !!isValid };

--- a/modules/comments/api/getCommentsByAddress.ts
+++ b/modules/comments/api/getCommentsByAddress.ts
@@ -30,10 +30,8 @@ export async function getCommentsByAddress(
     .find({ voterAddress: { $in: addresses }, network: { $in: [network, gaslessNetwork] } })
     .sort({ date: -1 })
     .toArray();
-
   const provider = await getProvider(network);
   const gaslessProvider = await getGaslessProvider(network);
-  const providers = { [network]: provider, [gaslessNetwork]: gaslessProvider };
 
   const comments: CommentsAPIResponseItem[] = await Promise.all(
     commentsFromDB.map(async comment => {
@@ -42,7 +40,7 @@ export async function getCommentsByAddress(
       // verify tx ownership
       const { completed, isValid } = await getCommentTransactionStatus(
         network,
-        providers[comment.network],
+        comment.gaslessNetwork ? gaslessProvider : provider,
         comment
       );
 
@@ -62,6 +60,6 @@ export async function getCommentsByAddress(
   );
 
   return {
-    comments
+    comments: comments.filter(i => i.isValid)
   };
 }

--- a/modules/comments/types/comments.ts
+++ b/modules/comments/types/comments.ts
@@ -55,6 +55,7 @@ export type ExecutiveComment = {
   spellAddress: string;
   network: SupportedNetworks;
   txHash?: string;
+  gaslessNetwork?: SupportedNetworks;
 };
 
 export type ExecutiveCommentFromDB = ExecutiveComment & {

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -419,9 +419,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
             () =>
               fetchJson(url).then(tx => {
                 // gaslessTx.status can be: 'pending' | 'sent' | 'submitted' | 'inmempool' | 'mined' | 'confirmed' | 'failed'
-                if (tx.status === 'mined') {
-                  // check if mined, if so, do nothing ????
-                } else if (tx.status === 'failed') {
+                if (tx.status === 'failed') {
                   // check if failed
                   setStep('tx-error');
                 } else if (isBefore(new Date(gaslessTx.sentAt), sub(new Date(), { seconds: 30 }))) {

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -409,6 +409,9 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
 
         const gaslessProvider = getGaslessProvider(network);
 
+        const voteTxCreator = () => getGaslessTransaction(gaslessProvider, gaslessTx.hash);
+        trackPollVote(voteTxCreator, getGaslessNetwork(network));
+
         if (gaslessTx.status !== 'mined') {
           const url = `/api/polling/relayer-tx?network=${network}&txId=${gaslessTx.transactionId}`;
           backoffRetry(
@@ -416,11 +419,9 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
             () =>
               fetchJson(url).then(tx => {
                 // gaslessTx.status can be: 'pending' | 'sent' | 'submitted' | 'inmempool' | 'mined' | 'confirmed' | 'failed'
-                if (gaslessTx.status === 'mined') {
-                  // check if mined, if so, track the tx
-                  const voteTxCreator = () => getGaslessTransaction(gaslessProvider, gaslessTx.hash);
-                  trackPollVote(voteTxCreator, getGaslessNetwork(network));
-                } else if (gaslessTx.status === 'failed') {
+                if (tx.status === 'mined') {
+                  // check if mined, if so, do nothing ????
+                } else if (tx.status === 'failed') {
                   // check if failed
                   setStep('tx-error');
                 } else if (isBefore(new Date(gaslessTx.sentAt), sub(new Date(), { seconds: 30 }))) {


### PR DESCRIPTION
-Start racking gasless tranasctions before they gets mined
-don't check from address when verifying comment transactions, since gasless votes come from the relayer, not the voter
-fix comment filtering when fetching comments by address (pass in the right provider, and filter out invalid txs)