### PR TITLE
Fix vote modal width and content

### DIFF
--- a/modules/executive/components/VoteModal/DefaultView.tsx
+++ b/modules/executive/components/VoteModal/DefaultView.tsx
@@ -198,7 +198,7 @@ export default function DefaultVoteModalView({
       <Text sx={{ display: ['none', 'block'], marginTop: 3, color: 'onSecondary', fontSize: [3, 4] }}>
         You are voting for the following executive proposal:
       </Text>
-      <Box
+      <Flex
         sx={{
           mt: 2,
           p: 3,
@@ -206,14 +206,16 @@ export default function DefaultVoteModalView({
           mx: 3,
           backgroundColor: 'background',
           textAlign: 'center',
-          fontSize: [3, 4]
+          fontSize: [3, 4],
+          flexDirection: 'column',
+          alignItems: 'center'
         }}
       >
-        <Text as="p" sx={{ fontSize: [3, 4], fontWeight: 'bold' }}>
+        <Text as="p" sx={{ fontSize: [3, 4], fontWeight: 'bold', mb: 3 }}>
           {proposal ? proposal.title : 'Unknown Spell'}
         </Text>
         <EtherscanLink hash={spellAddress} type="address" network={network} showAddress />
-      </Box>
+      </Flex>
       <Grid
         columns={[1, 3, 3, 3]}
         gap={0}

--- a/modules/executive/components/VoteModal/index.tsx
+++ b/modules/executive/components/VoteModal/index.tsx
@@ -30,7 +30,7 @@ const VoteModal = ({ close, proposal, address }: Props): JSX.Element => {
 
   return (
     <DialogOverlay isOpen={true} onDismiss={close}>
-      <DialogContent aria-label="Executive Vote">
+      <DialogContent aria-label="Executive Vote" widthDesktop="640px">
         {step === 'confirm' && (
           <DefaultVoteModalView
             proposal={proposal}


### PR DESCRIPTION
Before:
![Screen_Shot_2022-11-10_at_11 30 29_AM](https://user-images.githubusercontent.com/5225766/201362752-b53606cc-4984-4a17-bd7d-31ceac486a91.jpg)


After:
<img width="745" alt="Screenshot 2022-11-11 at 3 39 00 PM" src="https://user-images.githubusercontent.com/5225766/201362700-a9a84122-66a4-4fd7-83d9-c84846099a49.png">
