### PR TITLE
Fix mkr balances not showing for delegates

### DIFF
--- a/modules/address/components/AddressMKRDelegatedStats.tsx
+++ b/modules/address/components/AddressMKRDelegatedStats.tsx
@@ -22,7 +22,7 @@ export function AddressMKRDelegatedStats({
   totalMKRDelegated?: number;
   address: string;
 }): React.ReactElement {
-  const { data: votingWeight } = useMKRVotingWeight(false, address);
+  const { data: votingWeight } = useMKRVotingWeight({ address, excludeDelegateOwnerBalance: true });
 
   return (
     <Flex

--- a/modules/address/components/AddressMKRDelegatedStats.tsx
+++ b/modules/address/components/AddressMKRDelegatedStats.tsx
@@ -22,7 +22,7 @@ export function AddressMKRDelegatedStats({
   totalMKRDelegated?: number;
   address: string;
 }): React.ReactElement {
-  const { data: votingWeight } = useMKRVotingWeight(address);
+  const { data: votingWeight } = useMKRVotingWeight(false, address);
 
   return (
     <Flex

--- a/modules/app/components/layout/header/VotingWeight.tsx
+++ b/modules/app/components/layout/header/VotingWeight.tsx
@@ -18,7 +18,7 @@ import { getExecutiveVotingWeightCopy } from 'modules/polling/helpers/getExecuti
 
 export default function VotingWeight(): JSX.Element {
   const { account, voteDelegateContractAddress } = useAccount();
-  const { data: votingWeight } = useMKRVotingWeight(account);
+  const { data: votingWeight } = useMKRVotingWeight(true, account);
   const votingWeightCopy = getPollingVotingWeightCopy(!!voteDelegateContractAddress);
 
   return (

--- a/modules/app/components/layout/header/VotingWeight.tsx
+++ b/modules/app/components/layout/header/VotingWeight.tsx
@@ -18,7 +18,7 @@ import { getExecutiveVotingWeightCopy } from 'modules/polling/helpers/getExecuti
 
 export default function VotingWeight(): JSX.Element {
   const { account, voteDelegateContractAddress } = useAccount();
-  const { data: votingWeight } = useMKRVotingWeight(true, account);
+  const { data: votingWeight } = useMKRVotingWeight({ address: account });
   const votingWeightCopy = getPollingVotingWeightCopy(!!voteDelegateContractAddress);
 
   return (

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -30,7 +30,7 @@ export function DelegateMKRDelegatedStats({
   // TODO: Fetch addresses suporting through API fetching
 
   const { data: mkrStaked } = useMkrDelegated(account, delegate.voteDelegateAddress);
-  const { data: votingWeight } = useMKRVotingWeight(true, delegate.voteDelegateAddress);
+  const { data: votingWeight } = useMKRVotingWeight({ address: delegate.voteDelegateAddress });
 
   return (
     <Flex

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -30,7 +30,7 @@ export function DelegateMKRDelegatedStats({
   // TODO: Fetch addresses suporting through API fetching
 
   const { data: mkrStaked } = useMkrDelegated(account, delegate.voteDelegateAddress);
-  const { data: votingWeight } = useMKRVotingWeight(delegate.voteDelegateAddress);
+  const { data: votingWeight } = useMKRVotingWeight(true, delegate.voteDelegateAddress);
 
   return (
     <Flex

--- a/modules/mkr/helpers/getMKRVotingWeight.ts
+++ b/modules/mkr/helpers/getMKRVotingWeight.ts
@@ -26,12 +26,12 @@ export type MKRVotingWeightResponse = {
 export async function getMKRVotingWeight(
   address: string,
   network: SupportedNetworks,
-  checkDelegate: boolean
+  excludeDelegateOwnerBalance: boolean
 ): Promise<MKRVotingWeightResponse> {
   const contracts = getContracts(networkNameToChainId(network), undefined, undefined, true);
 
-  // first check if the address is a delegate contrac and if so return the balance locked in the delegate contract
-  const voteDelegateAddress = checkDelegate
+  // first check if the address is a delegate contract and if so return the balance locked in the delegate contract
+  const voteDelegateAddress = !excludeDelegateOwnerBalance
     ? await getDelegateContractAddress(contracts, address)
     : undefined;
   if (voteDelegateAddress) {

--- a/modules/mkr/hooks/useMKRVotingWeight.ts
+++ b/modules/mkr/hooks/useMKRVotingWeight.ts
@@ -17,7 +17,7 @@ type VotingWeightResponse = {
   mutate: () => void;
 };
 
-export const useMKRVotingWeight = (address?: string): VotingWeightResponse => {
+export const useMKRVotingWeight = (checkDelegate: boolean, address?: string): VotingWeightResponse => {
   const { network } = useWeb3();
   const { cache } = useSWRConfig();
 
@@ -26,7 +26,7 @@ export const useMKRVotingWeight = (address?: string): VotingWeightResponse => {
   // Only revalidate every 60 seconds, do not revalidate on mount if it's already fetched
   const { data, error, mutate } = useSWR(
     address ? dataKey : null,
-    () => getMKRVotingWeight(address as string, network, false),
+    () => getMKRVotingWeight(address as string, network, checkDelegate),
     {
       revalidateOnFocus: false,
       revalidateOnMount: !cache.get(dataKey),

--- a/modules/mkr/hooks/useMKRVotingWeight.ts
+++ b/modules/mkr/hooks/useMKRVotingWeight.ts
@@ -17,7 +17,15 @@ type VotingWeightResponse = {
   mutate: () => void;
 };
 
-export const useMKRVotingWeight = (checkDelegate: boolean, address?: string): VotingWeightResponse => {
+export const useMKRVotingWeight = ({
+  address,
+  excludeDelegateOwnerBalance = false
+}: {
+  address?: string;
+  // this needs to be "true" when displaying the MKR balance of a delegate contract
+  // they can have voting power through their delegate contract, but the balance is not theirs
+  excludeDelegateOwnerBalance?: boolean;
+}): VotingWeightResponse => {
   const { network } = useWeb3();
   const { cache } = useSWRConfig();
 
@@ -26,7 +34,7 @@ export const useMKRVotingWeight = (checkDelegate: boolean, address?: string): Vo
   // Only revalidate every 60 seconds, do not revalidate on mount if it's already fetched
   const { data, error, mutate } = useSWR(
     address ? dataKey : null,
-    () => getMKRVotingWeight(address as string, network, checkDelegate),
+    () => getMKRVotingWeight(address as string, network, excludeDelegateOwnerBalance),
     {
       revalidateOnFocus: false,
       revalidateOnMount: !cache.get(dataKey),

--- a/modules/polling/components/VotingWeight.tsx
+++ b/modules/polling/components/VotingWeight.tsx
@@ -67,7 +67,7 @@ export const getDescription = ({
 export default function VotingWeight(): JSX.Element {
   const { account, voteDelegateContractAddress } = useAccount();
 
-  const { data: votingWeight } = useMKRVotingWeight(account);
+  const { data: votingWeight } = useMKRVotingWeight(true, account);
 
   const votingWeightCopy = getPollingVotingWeightCopy(!!voteDelegateContractAddress);
 

--- a/modules/polling/components/VotingWeight.tsx
+++ b/modules/polling/components/VotingWeight.tsx
@@ -67,7 +67,7 @@ export const getDescription = ({
 export default function VotingWeight(): JSX.Element {
   const { account, voteDelegateContractAddress } = useAccount();
 
-  const { data: votingWeight } = useMKRVotingWeight(true, account);
+  const { data: votingWeight } = useMKRVotingWeight({ address: account });
 
   const votingWeightCopy = getPollingVotingWeightCopy(!!voteDelegateContractAddress);
 

--- a/modules/polling/components/poll-vote-input/QuickVote.tsx
+++ b/modules/polling/components/poll-vote-input/QuickVote.tsx
@@ -49,7 +49,7 @@ const QuickVote = ({
 }: Props): React.ReactElement => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING);
   const { account, voteDelegateContractAddress } = useAccount();
-  const { data: votingWeight, loading } = useMKRVotingWeight(true, account);
+  const { data: votingWeight, loading } = useMKRVotingWeight({ address: account });
   const { data: allUserVotes } = useAllUserVotes(
     voteDelegateContractAddress ? voteDelegateContractAddress : account
   );

--- a/modules/polling/components/poll-vote-input/QuickVote.tsx
+++ b/modules/polling/components/poll-vote-input/QuickVote.tsx
@@ -7,9 +7,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 import { useState, useEffect, useContext } from 'react';
-import { Text, Flex, Button, Box } from 'theme-ui';
+import { Text, Flex, Button } from 'theme-ui';
 import invariant from 'tiny-invariant';
-import isEqual from 'lodash/isEqual';
 import { Poll } from 'modules/polling/types';
 import {
   extractCurrentPollVote,
@@ -50,7 +49,7 @@ const QuickVote = ({
 }: Props): React.ReactElement => {
   const { trackButtonClick } = useAnalytics(ANALYTICS_PAGES.POLLING);
   const { account, voteDelegateContractAddress } = useAccount();
-  const { data: votingWeight, loading } = useMKRVotingWeight(account);
+  const { data: votingWeight, loading } = useMKRVotingWeight(true, account);
   const { data: allUserVotes } = useAllUserVotes(
     voteDelegateContractAddress ? voteDelegateContractAddress : account
   );


### PR DESCRIPTION
### What does this PR do?
It fixes the bug introduced during the last update that would not let delegates vote due to the MKR balance of their delegate contract not being fetched by passing a boolean value dynamically for the components that should display the MKR value of the owned delegate contract.

### Steps for testing:
If you have a delegate contract on Goerli, try to vote on polls.
The MKR balance of the delegate contract should be displayed on all of the account balance sections when connected to the account that owns the delegate contract.

### Screenshots (if relevant):
I set up a delegate contract on Goerli for testing and I was able to vote:
![image](https://user-images.githubusercontent.com/22449631/214422062-79de76a7-7f8a-4cf6-a992-2a904abf9592.png)
![image](https://user-images.githubusercontent.com/22449631/214422199-8fb51f01-2ef5-49fe-9b41-d714034ab214.png)
![image](https://user-images.githubusercontent.com/22449631/214422366-f2ef2fd1-5c52-413d-a892-c24432f2e535.png)

