### PR TITLE
add a link to manual on etherscan poll voting

### DIFF
--- a/modules/app/components/ResourceBox.tsx
+++ b/modules/app/components/ResourceBox.tsx
@@ -54,7 +54,7 @@ const resources: Record<ResourceType, Resource> = {
         url: 'https://makerdao.world/en/learn/governance/how-voting-works#governance-polls-and-executive-votes'
       },
       {
-        linkTitle: 'How to manually vote in a poll with Etherscan',
+        linkTitle: 'How to manually vote in a poll with Etherscan?',
         url: 'https://makerdux.notion.site/How-to-manually-vote-in-a-Maker-poll-with-Etherscan-d61a8fbac15a4bfc840ecb2d5c19cd80'
       },
       {
@@ -79,7 +79,7 @@ const resources: Record<ResourceType, Resource> = {
         url: 'https://makerdao.world/en/learn/governance/how-voting-works#executive-votes'
       },
       {
-        linkTitle: 'How to manually verify Executive Spells',
+        linkTitle: 'How to manually verify Executive Spells?',
         url: 'https://makerdao.world/en/learn/governance/audit-exec-spells'
       },
       {

--- a/modules/app/components/ResourceBox.tsx
+++ b/modules/app/components/ResourceBox.tsx
@@ -54,6 +54,10 @@ const resources: Record<ResourceType, Resource> = {
         url: 'https://makerdao.world/en/learn/governance/how-voting-works#governance-polls-and-executive-votes'
       },
       {
+        linkTitle: 'How to manually vote in a poll with Etherscan',
+        url: 'https://makerdux.notion.site/How-to-manually-vote-in-a-Maker-poll-with-Etherscan-d61a8fbac15a4bfc840ecb2d5c19cd80'
+      },
+      {
         linkTitle: 'How to set up your wallet for voting?',
         url: 'https://makerdao.world/en/learn/governance/voting-setup/'
       },


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/2068/create-documentation-for-manual-poll-voting-on-etherscan
### What does this PR do?
Adds link to voting with etherscan manual on polling page
### Screenshots (if relevant):
<img width="438" alt="Screen Shot 2023-03-09 at 6 35 13 PM" src="https://user-images.githubusercontent.com/3388550/224208711-ee4b6cae-b033-4ba8-a156-cd991685fa3b.png">


