### PR TITLE
Add swagger docs for supporters, all-locks endpoint

### DIFF
--- a/pages/api/address/[address]/delegated-to.ts
+++ b/pages/api/address/[address]/delegated-to.ts
@@ -24,6 +24,7 @@ import { validateAddress } from 'modules/web3/api/validateAddress';
  *   get:
  *     tags:
  *       - "delegates"
+ *     summary: Get information about the current delegate to MKR
  *     description: Get information about the current delegate to MKR
  *     parameters:
  *       - name: address

--- a/pages/api/address/[address]/index.ts
+++ b/pages/api/address/[address]/index.ts
@@ -47,6 +47,7 @@ import { validateAddress } from 'modules/web3/api/validateAddress';
  *   get:
  *     tags:
  *     - "address"
+ *     summary: Returns the address info
  *     description: Returns the address info
  *     produces:
  *     - "application/json"

--- a/pages/api/address/stats.ts
+++ b/pages/api/address/stats.ts
@@ -66,6 +66,7 @@ import { validateAddress } from 'modules/web3/api/validateAddress';
  *   get:
  *     tags:
  *     - "address"
+ *     summary: Returns stats for address
  *     description: Returns stats for address
  *     produces:
  *     - "application/json"

--- a/pages/api/comments/executive/[address].ts
+++ b/pages/api/comments/executive/[address].ts
@@ -48,6 +48,7 @@ import { validateAddress } from 'modules/web3/api/validateAddress';
  *   get:
  *     tags:
  *     - "comments"
+ *     summary: Returns all the comments for an executive
  *     description: Returns all the comments for an executive
  *     produces:
  *     - "application/json"

--- a/pages/api/comments/polling/[poll-id].ts
+++ b/pages/api/comments/polling/[poll-id].ts
@@ -45,6 +45,7 @@ import validateQueryParam from 'modules/app/api/validateQueryParam';
  *   get:
  *     tags:
  *     - "comments"
+ *     summary: Returns all the comments for a poll
  *     description: Returns all the comments for a poll
  *     produces:
  *     - "application/json"

--- a/pages/api/delegates/index.ts
+++ b/pages/api/delegates/index.ts
@@ -19,6 +19,7 @@ import validateQueryParam from 'modules/app/api/validateQueryParam';
  *    get:
  *      tags:
  *        - "delegates"
+ *      summary: Returns information about all delegates
  *      description: Returns information about all delegates
  *      produces:
  *        - "application/json"

--- a/pages/api/executive/[proposal-id].ts
+++ b/pages/api/executive/[proposal-id].ts
@@ -54,6 +54,7 @@ import { ApiError } from 'modules/app/api/ApiError';
  *   get:
  *     tags:
  *     - "executive"
+ *     summary: Returns a executive detail
  *     description: Returns a executive detail
  *     produces:
  *     - "application/json"

--- a/pages/api/executive/all-locks.ts
+++ b/pages/api/executive/all-locks.ts
@@ -6,6 +6,70 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
+/**
+ * @swagger
+ * /api/home/locks:
+ *   get:
+ *     summary: Returns the summary of all locks in the given time range for the specified network
+ *     description: Returns an array of objects containing summary of all locks in the given time range for the specified network.
+ *     tags:
+ *      - executive
+ *     parameters:
+ *       - name: network
+ *         in: query
+ *         required: false
+ *         description: The network to fetch the data from. If not specified, will use the default network.
+ *         schema:
+ *           type: string
+ *           enum: [goerli, goerlifork, mainnet]
+ *       - name: unixtimeStart
+ *         in: query
+ *         required: true
+ *         description: The start of the time range for which to fetch the data. Unix timestamp in seconds.
+ *         schema:
+ *           type: number
+ *       - name: unixtimeEnd
+ *         in: query
+ *         required: false
+ *         description: The end of the time range for which to fetch the data. Unix timestamp in seconds. If not specified, will use the current time.
+ *         schema:
+ *           type: number
+ *     responses:
+ *       '200':
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   fromAddress:
+ *                     type: string
+ *                   immediateCaller:
+ *                     type: string
+ *                   lockAmount:
+ *                     type: string
+ *                   blockNumber:
+ *                     type: string
+ *                   blockTimestamp:
+ *                     type: string
+ *                   lockTotal:
+ *                     type: string
+ *                   unixDate:
+ *                     type: number
+ *                   total:
+ *                     type: string
+ *                   month:
+ *                     type: string
+ *       '400':
+ *         description: Bad request
+ *       '404':
+ *         description: Not found
+ *       '500':
+ *         description: Internal server error
+ */
+
 import { ApiError } from 'modules/app/api/ApiError';
 import validateQueryParam from 'modules/app/api/validateQueryParam';
 import withApiHandler from 'modules/app/api/withApiHandler';

--- a/pages/api/executive/index.ts
+++ b/pages/api/executive/index.ts
@@ -28,6 +28,7 @@ import validateQueryParam from 'modules/app/api/validateQueryParam';
  *   get:
  *     tags:
  *     - "executive"
+ *     summary: Returns all executive proposals
  *     description: Returns all executive proposals
  *     produces:
  *     - "application/json"

--- a/pages/api/executive/supporters.ts
+++ b/pages/api/executive/supporters.ts
@@ -13,7 +13,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
  *     summary: Get the supporters of all executive spells
  *     description: Returns the list of supporters for each executive spell. Supports mainnet, goerli and goerlifork networks.
  *     tags:
- *       - Executive
+ *       - executive
  *     parameters:
  *       - name: network
  *         in: query

--- a/pages/api/executive/supporters.ts
+++ b/pages/api/executive/supporters.ts
@@ -6,6 +6,53 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
+/**
+ * @swagger
+ * /api/executive/supporters:
+ *   get:
+ *     summary: Get the supporters of all executive spells
+ *     description: Returns the list of supporters for each executive spell. Supports mainnet, goerli and goerlifork networks.
+ *     tags:
+ *       - Executive
+ *     parameters:
+ *       - name: network
+ *         in: query
+ *         description: The Ethereum network to use.
+ *         schema:
+ *           type: string
+ *         enum:
+ *           - goerli
+ *           - goerlifork
+ *           - mainnet
+ *     responses:
+ *       '200':
+ *         description: OK
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 {EXECUTIVE_SPELL}:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       address:
+ *                         type: string
+ *                       support:
+ *                         type: string
+ *                       votes:
+ *                         type: string
+ *                       percent:
+ *                         type: string
+ *       '400':
+ *         $ref: '#/components/responses/BadRequest'
+ *       '500':
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+
 import { NextApiRequest, NextApiResponse } from 'next';
 import { DEFAULT_NETWORK, SupportedNetworks } from 'modules/web3/constants/networks';
 import withApiHandler from 'modules/app/api/withApiHandler';

--- a/pages/api/executive/supporters.ts
+++ b/pages/api/executive/supporters.ts
@@ -48,9 +48,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
  *                       percent:
  *                         type: string
  *       '400':
- *         $ref: '#/components/responses/BadRequest'
+ *         description: Bad request
  *       '500':
- *         $ref: '#/components/responses/InternalServerError'
+ *         description: Internal server error
  */
 
 import { NextApiRequest, NextApiResponse } from 'next';

--- a/pages/api/polling/[slug].ts
+++ b/pages/api/polling/[slug].ts
@@ -87,6 +87,7 @@ import { isValidSlugParam } from '../../../modules/polling/helpers/isValidSlugPa
  *   get:
  *     tags:
  *     - "polls"
+ *     summary: Returns a poll detail
  *     description: Returns a poll detail
  *     produces:
  *     - "application/json"

--- a/pages/api/polling/all-polls.ts
+++ b/pages/api/polling/all-polls.ts
@@ -39,6 +39,7 @@ import validateQueryParam from 'modules/app/api/validateQueryParam';
  *   get:
  *     tags:
  *     - "polls"
+ *     summary: Returns all polls
  *     description: Returns all polls
  *     produces:
  *     - "application/json"

--- a/pages/api/polling/tally/[poll-id].ts
+++ b/pages/api/polling/tally/[poll-id].ts
@@ -112,6 +112,7 @@ import validateQueryParam from 'modules/app/api/validateQueryParam';
  *   get:
  *     tags:
  *     - "tally"
+ *     summary: Returns a poll tally
  *     description: Returns a poll tally
  *     produces:
  *     - "application/json"


### PR DESCRIPTION
Add docs for supporters and all-locks endpoints

Add summary for endpoints so it shows without having to click to drill down
<img width="1447" alt="Screenshot 2023-04-05 at 3 34 27 PM" src="https://user-images.githubusercontent.com/5225766/230096778-841e3133-0b90-4522-a520-66b52c7c5ab9.png">

