### PR TITLE
Delegates list QA - Sorting filter and go back from detail screen

### DIFF
--- a/modules/app/components/filters/SearchBar.tsx
+++ b/modules/app/components/filters/SearchBar.tsx
@@ -17,6 +17,7 @@ type Props = {
   value: string | null;
   placeholder?: string;
   withSearchButton?: boolean;
+  performSearchOnClear?: boolean;
 };
 
 export const SearchBar = ({
@@ -24,6 +25,7 @@ export const SearchBar = ({
   value,
   placeholder = 'Search',
   withSearchButton,
+  performSearchOnClear,
   ...props
 }: Props): JSX.Element => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -36,7 +38,7 @@ export const SearchBar = ({
 
   const handleInput = event => {
     setSearchTerm(event.target.value);
-    if (!withSearchButton) {
+    if (!withSearchButton || (performSearchOnClear && event.target.value === '')) {
       debounce(onChange(event.target.value));
     }
   };

--- a/modules/delegates/components/DelegateAvatarName.tsx
+++ b/modules/delegates/components/DelegateAvatarName.tsx
@@ -15,16 +15,18 @@ import { useAccount } from 'modules/app/hooks/useAccount';
 import { Address } from 'modules/address/components/Address';
 
 export default function DelegateAvatarName({
-  delegate
+  delegate,
+  onVisitDelegate
 }: {
   delegate: Delegate | DelegatePaginated | DelegateInfo;
+  onVisitDelegate?: () => void;
 }): React.ReactElement {
   const { account } = useAccount();
   const isOwner = account?.toLowerCase() === delegate.address.toLowerCase();
 
   return (
     <InternalLink href={`/address/${delegate.voteDelegateAddress}`} title="View profile details">
-      <Flex>
+      <Flex onClick={() => onVisitDelegate?.()}>
         <DelegatePicture delegate={delegate} />
 
         <Box sx={{ ml: 2 }}>

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -31,7 +31,7 @@ import { formatEther, parseEther } from 'ethers/lib/utils';
 type PropTypes = {
   delegate: DelegatePaginated;
   setStateDelegates: Dispatch<SetStateAction<DelegatePaginated[]>>;
-  onVisitDelegate?: () => void;
+  onVisitDelegate: () => void;
 };
 
 const DelegateVotingStatsModal = () => {
@@ -257,7 +257,7 @@ export function DelegateOverviewCard({
                   <Button
                     variant="outline"
                     sx={{ borderColor: 'text', color: 'text', whiteSpace: 'nowrap', mt: 3, mr: 3 }}
-                    onClick={() => onVisitDelegate?.()}
+                    onClick={() => onVisitDelegate()}
                   >
                     {`View ${isOwner ? 'Your' : 'Profile'} Details`}
                   </Button>

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, memo, SetStateAction, useState } from 'react';
 import { Card, Box, Flex, Button, Text, Heading } from 'theme-ui';
 import SkeletonThemed from 'modules/app/components/SkeletonThemed';
 import { formatValue } from 'lib/string';
@@ -72,274 +72,277 @@ const DelegateVotingStatsModal = () => {
   );
 };
 
-export function DelegateOverviewCard({
-  delegate,
-  setStateDelegates,
-  onVisitDelegate
-}: PropTypes): React.ReactElement {
-  const { account, voteDelegateContractAddress } = useAccount();
+export const DelegateOverviewCard = memo(
+  function DelegateOverviewCard({
+    delegate,
+    setStateDelegates,
+    onVisitDelegate
+  }: PropTypes): React.ReactElement {
+    const { account, voteDelegateContractAddress } = useAccount();
 
-  const [showDelegateModal, setShowDelegateModal] = useState(false);
-  const [showUndelegateModal, setShowUndelegateModal] = useState(false);
-  const [showCoreUnitModal, setShowCoreUnitModal] = useState(false);
+    const [showDelegateModal, setShowDelegateModal] = useState(false);
+    const [showUndelegateModal, setShowUndelegateModal] = useState(false);
+    const [showCoreUnitModal, setShowCoreUnitModal] = useState(false);
 
-  const handleInfoClick = () => {
-    setShowCoreUnitModal(!showCoreUnitModal);
-  };
+    const handleInfoClick = () => {
+      setShowCoreUnitModal(!showCoreUnitModal);
+    };
 
-  const { data: mkrDelegated, mutate: mutateMKRDelegated } = useMkrDelegated(
-    account,
-    delegate.voteDelegateAddress
-  );
-  const hasMkrDelegated = account && mkrDelegated?.gt(0);
+    const { data: mkrDelegated, mutate: mutateMKRDelegated } = useMkrDelegated(
+      account,
+      delegate.voteDelegateAddress
+    );
+    const hasMkrDelegated = account && mkrDelegated?.gt(0);
 
-  const mutateDelegateTotalMkr = (amount: BigNumber) => {
-    setStateDelegates(prevDelegates => {
-      const mutatedDelegateArray = prevDelegates.map(d => {
-        if (d.voteDelegateAddress === delegate.voteDelegateAddress) {
-          return {
-            ...d,
-            mkrDelegated: formatEther(parseEther(d.mkrDelegated).add(amount))
-          };
-        }
-        return d;
+    const mutateDelegateTotalMkr = (amount: BigNumber) => {
+      setStateDelegates(prevDelegates => {
+        const mutatedDelegateArray = prevDelegates.map(d => {
+          if (d.voteDelegateAddress === delegate.voteDelegateAddress) {
+            return {
+              ...d,
+              mkrDelegated: formatEther(parseEther(d.mkrDelegated).add(amount))
+            };
+          }
+          return d;
+        });
+
+        return mutatedDelegateArray;
       });
+    };
 
-      return mutatedDelegateArray;
-    });
-  };
+    const isOwner = delegate.voteDelegateAddress.toLowerCase() === voteDelegateContractAddress?.toLowerCase();
 
-  const isOwner = delegate.voteDelegateAddress.toLowerCase() === voteDelegateContractAddress?.toLowerCase();
-
-  return (
-    <Card
-      sx={{
-        p: 0
-      }}
-      data-testid="delegate-card"
-    >
-      <Box px={[3, 4]} pb={3} pt={3}>
-        <Flex
-          sx={{
-            flexDirection: ['column', 'row'],
-            mb: 2,
-            justifyContent: 'space-between',
-            alignItems: 'flex-start'
-          }}
-        >
+    return (
+      <Card
+        sx={{
+          p: 0
+        }}
+        data-testid="delegate-card"
+      >
+        <Box px={[3, 4]} pb={3} pt={3}>
           <Flex
             sx={{
               flexDirection: ['column', 'row'],
-              justifyContent: 'flex-start'
+              mb: 2,
+              justifyContent: 'space-between',
+              alignItems: 'flex-start'
             }}
           >
-            <LastVoted
-              expired={delegate.expired}
-              date={delegate ? (delegate.lastVoteDate ? delegate.lastVoteDate : null) : undefined}
-              left
-            />
-          </Flex>
-          <Flex sx={{ flexDirection: 'column', alignItems: ['flex-start', 'flex-end'], mt: [1, 0] }}>
-            <DelegateExpiryDate delegate={delegate} />
-            {delegate.cuMember && (
-              <Flex sx={{ mt: 1 }}>
-                <CoreUnitButton handleInfoClick={handleInfoClick} />
-              </Flex>
-            )}
-          </Flex>
-        </Flex>
-
-        <Flex
-          sx={{
-            flexDirection: 'column'
-          }}
-        >
-          <Flex
-            sx={{
-              flexDirection: ['column', 'row'],
-              alignItems: ['flex-start', 'center'],
-              justifyContent: 'space-between'
-            }}
-          >
-            <Box sx={{ mr: 2, my: 2 }}>
-              <DelegateAvatarName delegate={delegate} onVisitDelegate={onVisitDelegate} />
-            </Box>
-
             <Flex
               sx={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                ml: 2,
-                my: 2,
-                justifyContent: 'right'
+                flexDirection: ['column', 'row'],
+                justifyContent: 'flex-start'
               }}
             >
-              {hasMkrDelegated && (
-                <Button
-                  variant="primaryOutline"
-                  disabled={!hasMkrDelegated}
-                  onClick={() => {
-                    setShowUndelegateModal(true);
-                  }}
-                  sx={{ width: '135px', height: '45px', maxWidth: '135px', mr: [2, 2] }}
-                  data-testid="button-undelegate"
-                >
-                  Undelegate
-                </Button>
+              <LastVoted
+                expired={delegate.expired}
+                date={delegate ? (delegate.lastVoteDate ? delegate.lastVoteDate : null) : undefined}
+                left
+              />
+            </Flex>
+            <Flex sx={{ flexDirection: 'column', alignItems: ['flex-start', 'flex-end'], mt: [1, 0] }}>
+              <DelegateExpiryDate delegate={delegate} />
+              {delegate.cuMember && (
+                <Flex sx={{ mt: 1 }}>
+                  <CoreUnitButton handleInfoClick={handleInfoClick} />
+                </Flex>
               )}
-              <Button
-                variant="primaryLarge"
-                data-testid="button-delegate"
-                disabled={!account || !!delegate.next || delegate.expired}
-                onClick={() => {
-                  setShowDelegateModal(true);
-                }}
+            </Flex>
+          </Flex>
+
+          <Flex
+            sx={{
+              flexDirection: 'column'
+            }}
+          >
+            <Flex
+              sx={{
+                flexDirection: ['column', 'row'],
+                alignItems: ['flex-start', 'center'],
+                justifyContent: 'space-between'
+              }}
+            >
+              <Box sx={{ mr: 2, my: 2 }}>
+                <DelegateAvatarName delegate={delegate} onVisitDelegate={onVisitDelegate} />
+              </Box>
+
+              <Flex
                 sx={{
-                  width: '135px',
-                  maxWidth: '135px',
-                  height: '45px',
-                  ml: hasMkrDelegated ? 3 : 0
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  ml: 2,
+                  my: 2,
+                  justifyContent: 'right'
                 }}
               >
-                Delegate MKR
-              </Button>
-            </Flex>
-          </Flex>
-
-          <Flex sx={{ mt: 3, flexDirection: 'column' }}>
-            <Flex
-              sx={{
-                flexDirection: 'row',
-                flexWrap: 'wrap'
-              }}
-            >
-              <Box sx={{ mr: 3, mb: 1 }}>
-                <Flex sx={{ alignItems: 'center' }}>
-                  <Icon name="participation" />
-                  <Text as="p" variant="caps" color="onSecondary" sx={{ fontSize: 1 }} ml={1}>
-                    {delegate.combinedParticipation === 'No Data'
-                      ? 'No Participation Data'
-                      : delegate.combinedParticipation
-                      ? delegate.combinedParticipation + ' Participation'
-                      : 'Untracked Participation'}
-                  </Text>
-                </Flex>
-              </Box>
-              <Box>
-                <Flex sx={{ alignItems: 'center' }}>
-                  <Icon name="comment" />
-                  <Text as="p" variant="caps" color="onSecondary" sx={{ fontSize: 1 }} ml={1}>
-                    {delegate.communication === 'No Data'
-                      ? 'No Communication Data'
-                      : delegate.communication
-                      ? delegate.communication + ' Communication'
-                      : 'Untracked Communication'}
-                  </Text>
-                </Flex>
-              </Box>
-              <Box>
-                <DelegateVotingStatsModal />
-              </Box>
-            </Flex>
-            <Flex
-              sx={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                flexWrap: 'wrap-reverse'
-              }}
-            >
-              <Flex sx={{ height: '100%' }}>
-                <InternalLink
-                  href={`/address/${delegate.voteDelegateAddress}`}
-                  title={`View ${isOwner ? 'Your' : 'Profile'} Details`}
-                  styles={{ mt: 'auto' }}
-                >
+                {hasMkrDelegated && (
                   <Button
-                    variant="outline"
-                    sx={{ borderColor: 'text', color: 'text', whiteSpace: 'nowrap', mt: 3, mr: 3 }}
-                    onClick={() => onVisitDelegate()}
+                    variant="primaryOutline"
+                    disabled={!hasMkrDelegated}
+                    onClick={() => {
+                      setShowUndelegateModal(true);
+                    }}
+                    sx={{ width: '135px', height: '45px', maxWidth: '135px', mr: [2, 2] }}
+                    data-testid="button-undelegate"
                   >
-                    {`View ${isOwner ? 'Your' : 'Profile'} Details`}
+                    Undelegate
                   </Button>
-                </InternalLink>
+                )}
+                <Button
+                  variant="primaryLarge"
+                  data-testid="button-delegate"
+                  disabled={!account || !!delegate.next || delegate.expired}
+                  onClick={() => {
+                    setShowDelegateModal(true);
+                  }}
+                  sx={{
+                    width: '135px',
+                    maxWidth: '135px',
+                    height: '45px',
+                    ml: hasMkrDelegated ? 3 : 0
+                  }}
+                >
+                  Delegate MKR
+                </Button>
               </Flex>
-              <Flex sx={{ justifyContent: 'flex-end', mt: '3' }}>
-                {account && (
-                  <Box>
-                    {mkrDelegated ? (
+            </Flex>
+
+            <Flex sx={{ mt: 3, flexDirection: 'column' }}>
+              <Flex
+                sx={{
+                  flexDirection: 'row',
+                  flexWrap: 'wrap'
+                }}
+              >
+                <Box sx={{ mr: 3, mb: 1 }}>
+                  <Flex sx={{ alignItems: 'center' }}>
+                    <Icon name="participation" />
+                    <Text as="p" variant="caps" color="onSecondary" sx={{ fontSize: 1 }} ml={1}>
+                      {delegate.combinedParticipation === 'No Data'
+                        ? 'No Participation Data'
+                        : delegate.combinedParticipation
+                        ? delegate.combinedParticipation + ' Participation'
+                        : 'Untracked Participation'}
+                    </Text>
+                  </Flex>
+                </Box>
+                <Box>
+                  <Flex sx={{ alignItems: 'center' }}>
+                    <Icon name="comment" />
+                    <Text as="p" variant="caps" color="onSecondary" sx={{ fontSize: 1 }} ml={1}>
+                      {delegate.communication === 'No Data'
+                        ? 'No Communication Data'
+                        : delegate.communication
+                        ? delegate.communication + ' Communication'
+                        : 'Untracked Communication'}
+                    </Text>
+                  </Flex>
+                </Box>
+                <Box>
+                  <DelegateVotingStatsModal />
+                </Box>
+              </Flex>
+              <Flex
+                sx={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  flexWrap: 'wrap-reverse'
+                }}
+              >
+                <Flex sx={{ height: '100%' }}>
+                  <InternalLink
+                    href={`/address/${delegate.voteDelegateAddress}`}
+                    title={`View ${isOwner ? 'Your' : 'Profile'} Details`}
+                    styles={{ mt: 'auto' }}
+                  >
+                    <Button
+                      variant="outline"
+                      sx={{ borderColor: 'text', color: 'text', whiteSpace: 'nowrap', mt: 3, mr: 3 }}
+                      onClick={() => onVisitDelegate()}
+                    >
+                      {`View ${isOwner ? 'Your' : 'Profile'} Details`}
+                    </Button>
+                  </InternalLink>
+                </Flex>
+                <Flex sx={{ justifyContent: 'flex-end', mt: '3' }}>
+                  {account && (
+                    <Box>
+                      {mkrDelegated ? (
+                        <Text
+                          as="p"
+                          variant="microHeading"
+                          sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
+                          data-testid="mkr-delegated-by-you"
+                        >
+                          {formatValue(mkrDelegated)}
+                        </Text>
+                      ) : (
+                        <SkeletonThemed />
+                      )}
                       <Text
                         as="p"
-                        variant="microHeading"
-                        sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
-                        data-testid="mkr-delegated-by-you"
+                        variant="secondary"
+                        color="onSecondary"
+                        sx={{ textAlign: 'right', fontSize: [1, 2, 3] }}
                       >
-                        {formatValue(mkrDelegated)}
+                        MKR delegated by you
                       </Text>
-                    ) : (
-                      <SkeletonThemed />
-                    )}
+                    </Box>
+                  )}
+                  <Box sx={{ ml: account ? 4 : 0 }}>
+                    <Text
+                      as="p"
+                      variant="microHeading"
+                      sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
+                      data-testid="total-mkr-delegated"
+                    >
+                      {formatValue(parseEther(delegate.mkrDelegated))}
+                    </Text>
                     <Text
                       as="p"
                       variant="secondary"
                       color="onSecondary"
                       sx={{ textAlign: 'right', fontSize: [1, 2, 3] }}
                     >
-                      MKR delegated by you
+                      Total MKR delegated
                     </Text>
                   </Box>
-                )}
-                <Box sx={{ ml: account ? 4 : 0 }}>
-                  <Text
-                    as="p"
-                    variant="microHeading"
-                    sx={{ fontSize: [3, 5], textAlign: ['left', 'right'] }}
-                    data-testid="total-mkr-delegated"
-                  >
-                    {formatValue(parseEther(delegate.mkrDelegated))}
-                  </Text>
-                  <Text
-                    as="p"
-                    variant="secondary"
-                    color="onSecondary"
-                    sx={{ textAlign: 'right', fontSize: [1, 2, 3] }}
-                  >
-                    Total MKR delegated
-                  </Text>
-                </Box>
+                </Flex>
               </Flex>
             </Flex>
           </Flex>
-        </Flex>
-      </Box>
-      <CurrentlySupportingExecutive
-        proposalsSupported={delegate.proposalsSupported}
-        execSupported={delegate.execSupported}
-      />
-
-      {showDelegateModal && (
-        <DelegateModal
-          delegate={delegate}
-          isOpen={showDelegateModal}
-          onDismiss={() => setShowDelegateModal(false)}
-          mutateTotalStaked={mutateDelegateTotalMkr}
-          mutateMKRDelegated={mutateMKRDelegated}
-          refetchOnDelegation={false}
+        </Box>
+        <CurrentlySupportingExecutive
+          proposalsSupported={delegate.proposalsSupported}
+          execSupported={delegate.execSupported}
         />
-      )}
-      {showUndelegateModal && (
-        <UndelegateModal
-          delegate={delegate}
-          isOpen={showUndelegateModal}
-          onDismiss={() => setShowUndelegateModal(false)}
-          mutateTotalStaked={mutateDelegateTotalMkr}
-          mutateMKRDelegated={mutateMKRDelegated}
-          refetchOnDelegation={false}
-        />
-      )}
 
-      {showCoreUnitModal && (
-        <CoreUnitModal isOpen={showCoreUnitModal} onDismiss={() => setShowCoreUnitModal(false)} />
-      )}
-    </Card>
-  );
-}
+        {showDelegateModal && (
+          <DelegateModal
+            delegate={delegate}
+            isOpen={showDelegateModal}
+            onDismiss={() => setShowDelegateModal(false)}
+            mutateTotalStaked={mutateDelegateTotalMkr}
+            mutateMKRDelegated={mutateMKRDelegated}
+            refetchOnDelegation={false}
+          />
+        )}
+        {showUndelegateModal && (
+          <UndelegateModal
+            delegate={delegate}
+            isOpen={showUndelegateModal}
+            onDismiss={() => setShowUndelegateModal(false)}
+            mutateTotalStaked={mutateDelegateTotalMkr}
+            mutateMKRDelegated={mutateMKRDelegated}
+            refetchOnDelegation={false}
+          />
+        )}
+
+        {showCoreUnitModal && (
+          <CoreUnitModal isOpen={showCoreUnitModal} onDismiss={() => setShowCoreUnitModal(false)} />
+        )}
+      </Card>
+    );
+  },
+  ({ delegate: prevDelegate }, { delegate: nextDelegate }) => Object.is(prevDelegate, nextDelegate)
+);

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -31,6 +31,7 @@ import { formatEther, parseEther } from 'ethers/lib/utils';
 type PropTypes = {
   delegate: DelegatePaginated;
   setStateDelegates: Dispatch<SetStateAction<DelegatePaginated[]>>;
+  onVisitDelegate?: () => void;
 };
 
 const DelegateVotingStatsModal = () => {
@@ -71,7 +72,11 @@ const DelegateVotingStatsModal = () => {
   );
 };
 
-export function DelegateOverviewCard({ delegate, setStateDelegates }: PropTypes): React.ReactElement {
+export function DelegateOverviewCard({
+  delegate,
+  setStateDelegates,
+  onVisitDelegate
+}: PropTypes): React.ReactElement {
   const { account, voteDelegateContractAddress } = useAccount();
 
   const [showDelegateModal, setShowDelegateModal] = useState(false);
@@ -252,6 +257,7 @@ export function DelegateOverviewCard({ delegate, setStateDelegates }: PropTypes)
                   <Button
                     variant="outline"
                     sx={{ borderColor: 'text', color: 'text', whiteSpace: 'nowrap', mt: 3, mr: 3 }}
+                    onClick={() => onVisitDelegate?.()}
                   >
                     {`View ${isOwner ? 'Your' : 'Profile'} Details`}
                   </Button>

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -201,7 +201,7 @@ export function DelegateOverviewCard({
                   ml: hasMkrDelegated ? 3 : 0
                 }}
               >
-                Delegate
+                Delegate MKR
               </Button>
             </Flex>
           </Flex>

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -162,7 +162,7 @@ export function DelegateOverviewCard({
             }}
           >
             <Box sx={{ mr: 2, my: 2 }}>
-              <DelegateAvatarName delegate={delegate} />
+              <DelegateAvatarName delegate={delegate} onVisitDelegate={onVisitDelegate} />
             </Box>
 
             <Flex

--- a/modules/delegates/components/filters/DelegatesSortFilter.tsx
+++ b/modules/delegates/components/filters/DelegatesSortFilter.tsx
@@ -10,13 +10,12 @@ import useDelegatesFiltersStore from '../../stores/delegatesFiltersStore';
 import { ListboxInput, ListboxButton, ListboxPopover, ListboxList, ListboxOption } from '@reach/listbox';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { DelegateOrderByEnum, OrderDirectionEnum } from 'modules/delegates/delegates.constants';
+import { useMemo } from 'react';
 
 export function DelegatesSortFilter(): JSX.Element {
-  const [sort, setSort, setSortDirection] = useDelegatesFiltersStore(state => [
-    state.sort,
-    state.setSort,
-    state.setSortDirection
-  ]);
+  const [sort, sortDirection, setSort, setSortDirection] = useDelegatesFiltersStore(state => {
+    return [state.sort, state.sortDirection, state.setSort, state.setSortDirection];
+  });
 
   const setSortMethodAndDirection = (sortString: string) => {
     const [sortOption, sortDirectionOption] = sortString.split(',') as [
@@ -30,8 +29,13 @@ export function DelegatesSortFilter(): JSX.Element {
     }
   };
 
+  const calculatedSortValue = useMemo(() => {
+    if (sort === DelegateOrderByEnum.RANDOM) return sort;
+    return sort + ',' + sortDirection;
+  }, [sort, sortDirection]);
+
   return (
-    <ListboxInput onChange={setSortMethodAndDirection} defaultValue={sort}>
+    <ListboxInput onChange={setSortMethodAndDirection} value={calculatedSortValue}>
       <ListboxButton
         sx={{ variant: 'listboxes.default.button', fontWeight: 'semiBold', py: [2] }}
         arrow={<Icon name="chevron_down" size={2} />}

--- a/modules/delegates/stores/delegatesFiltersStore.ts
+++ b/modules/delegates/stores/delegatesFiltersStore.ts
@@ -31,8 +31,8 @@ type StoreDelegates = {
   resetFilters: () => void;
   resetSort: () => void;
   resetSortDirection: () => void;
-  keepState: boolean;
-  setKeepState: (keepState: boolean) => void;
+  fetchOnLoad: boolean;
+  setFetchOnLoad: (fetchOnLoad: boolean) => void;
 };
 
 const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
@@ -46,7 +46,7 @@ const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
   },
   sort: DelegateOrderByEnum.RANDOM,
   sortDirection: OrderDirectionEnum.DESC,
-  keepState: false,
+  fetchOnLoad: false,
   setName: (name: string) => {
     set({
       filters: {
@@ -135,9 +135,9 @@ const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
     });
   },
 
-  setKeepState: keepState => {
+  setFetchOnLoad: fetchOnLoad => {
     set({
-      keepState
+      fetchOnLoad
     });
   }
 }));

--- a/modules/delegates/stores/delegatesFiltersStore.ts
+++ b/modules/delegates/stores/delegatesFiltersStore.ts
@@ -29,6 +29,8 @@ type StoreDelegates = {
   setCvcFilter: (cvc: string[]) => void;
   setName: (text: string) => void;
   resetFilters: () => void;
+  resetSort: () => void;
+  resetSortDirection: () => void;
   keepState: boolean;
   setKeepState: (keepState: boolean) => void;
 };
@@ -124,6 +126,12 @@ const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
   resetSort: () => {
     set({
       sort: DelegateOrderByEnum.RANDOM
+    });
+  },
+
+  resetSortDirection: () => {
+    set({
+      sortDirection: OrderDirectionEnum.DESC
     });
   },
 

--- a/modules/delegates/stores/delegatesFiltersStore.ts
+++ b/modules/delegates/stores/delegatesFiltersStore.ts
@@ -29,6 +29,8 @@ type StoreDelegates = {
   setCvcFilter: (cvc: string[]) => void;
   setName: (text: string) => void;
   resetFilters: () => void;
+  keepState: boolean;
+  setKeepState: (keepState: boolean) => void;
 };
 
 const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
@@ -42,7 +44,7 @@ const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
   },
   sort: DelegateOrderByEnum.RANDOM,
   sortDirection: OrderDirectionEnum.DESC,
-
+  keepState: false,
   setName: (name: string) => {
     set({
       filters: {
@@ -122,6 +124,12 @@ const [useDelegatesFiltersStore] = create<StoreDelegates>((set, get) => ({
   resetSort: () => {
     set({
       sort: DelegateOrderByEnum.RANDOM
+    });
+  },
+
+  setKeepState: keepState => {
+    set({
+      keepState
     });
   }
 }));

--- a/modules/gql/queries/delegates.ts
+++ b/modules/gql/queries/delegates.ts
@@ -11,22 +11,29 @@ import { gql } from 'graphql-request';
 export const delegatesQuery = gql`
   query delegates(
     $first: Int = 20
+    $offset: Int
     $after: Cursor
     $orderBy: DelegateOrderByType
     $orderDirection: OrderDirectionType
     $includeExpired: Boolean
+    $seed: Float
+    $filter: DelegateEntryFilter
   ) {
     delegates(
       first: $first
       _first: $first
+      offset: $offset
       after: $after
       orderBy: $orderBy
       orderDirection: $orderDirection
       includeExpired: $includeExpired
+      seed: $seed
+      filter: $filter
     ) {
       totalCount
       pageInfo {
         hasNextPage
+        startCursor
         endCursor
       }
       nodes {

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -67,7 +67,9 @@ const Delegates = ({
     setCvcFilter,
     setName,
     setKeepState,
-    resetFilters
+    resetFilters,
+    resetSort,
+    resetSortDirection
   ] = useDelegatesFiltersStore(
     state => [
       state.filters.showConstitutional,
@@ -81,13 +83,22 @@ const Delegates = ({
       state.setCvcFilter,
       state.setName,
       state.setKeepState,
-      state.resetFilters
+      state.resetFilters,
+      state.resetSort,
+      state.resetSortDirection
     ],
     shallow
   );
 
   const onVisitDelegate = () => {
     setKeepState(true);
+  };
+
+  const onResetClick = () => {
+    resetFilters();
+    resetSort();
+    resetSortDirection();
+    setKeepState(false);
   };
 
   const [loading, setLoading] = useState(keepState);
@@ -162,7 +173,6 @@ const Delegates = ({
         };
 
         const res = await fetchDelegatesPageData(network, true, queryParams);
-
         setLoading(false);
         setDelegates(prevDelegates => [...prevDelegates, ...res.delegates]);
         setPaginationInfo(res.paginationInfo);
@@ -178,7 +188,6 @@ const Delegates = ({
   }, [filters]);
 
   useEffect(() => {
-    resetFilters();
     setDelegates(keepState ? delegates : propDelegates);
     setPaginationInfo(propPaginationInfo);
     setSeed(propSeed);
@@ -278,7 +287,7 @@ const Delegates = ({
                   color: 'textSecondary',
                   border: 'none'
                 }}
-                onClick={resetFilters}
+                onClick={onResetClick}
               >
                 Reset filters
               </Button>
@@ -312,7 +321,7 @@ const Delegates = ({
                     <Button
                       variant={'textual'}
                       sx={{ color: 'primary', textDecoration: 'underline', mt: 2, fontSize: 3 }}
-                      onClick={resetFilters}
+                      onClick={onResetClick}
                     >
                       Reset filters
                     </Button>

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -63,8 +63,10 @@ const Delegates = ({
     sortDirection,
     name,
     delegateCvcs,
+    keepState,
     setCvcFilter,
     setName,
+    setKeepState,
     resetFilters
   ] = useDelegatesFiltersStore(
     state => [
@@ -75,17 +77,23 @@ const Delegates = ({
       state.sortDirection,
       state.filters.name,
       state.filters.cvcs,
+      state.keepState,
       state.setCvcFilter,
       state.setName,
+      state.setKeepState,
       state.resetFilters
     ],
     shallow
   );
 
-  const [loading, setLoading] = useState(false);
+  const onVisitDelegate = () => {
+    setKeepState(true);
+  };
+
+  const [loading, setLoading] = useState(keepState);
   const [isRendering, setIsRendering] = useState(true);
   const [shouldLoadMore, setShouldLoadMore] = useState(false);
-  const [delegates, setDelegates] = useState(propDelegates);
+  const [delegates, setDelegates] = useState(keepState ? [] : propDelegates);
   const [paginationInfo, setPaginationInfo] = useState(propPaginationInfo);
   const [seed, setSeed] = useState(propSeed);
   const [delegateCvcsLength, setDelegateCvcsLength] = useState(delegateCvcs.length);
@@ -139,7 +147,7 @@ const Delegates = ({
   }, [shouldLoadMore]);
 
   useEffect(() => {
-    if (!isRendering) {
+    if (!isRendering || keepState) {
       let mounted = true;
       const fetchDelegates = async () => {
         const queryParams = {
@@ -171,10 +179,10 @@ const Delegates = ({
 
   useEffect(() => {
     resetFilters();
-    setDelegates(propDelegates);
+    setDelegates(keepState ? delegates : propDelegates);
     setPaginationInfo(propPaginationInfo);
     setSeed(propSeed);
-  }, [propDelegates, propPaginationInfo, propSeed]);
+  }, [propDelegates, propPaginationInfo, propSeed, keepState]);
 
   useEffect(() => {
     setDelegateCvcsLength(delegateCvcs.length);
@@ -318,7 +326,11 @@ const Delegates = ({
                   {constitutionalDelegates.map(delegate => (
                     <Box key={delegate.voteDelegateAddress} sx={{ mb: 3 }}>
                       <ErrorBoundary componentName="Delegate Card">
-                        <DelegateOverviewCard delegate={delegate} setStateDelegates={setDelegates} />
+                        <DelegateOverviewCard
+                          delegate={delegate}
+                          setStateDelegates={setDelegates}
+                          onVisitDelegate={onVisitDelegate}
+                        />
                       </ErrorBoundary>
                     </Box>
                   ))}
@@ -332,7 +344,11 @@ const Delegates = ({
                   {shadowDelegates.map(delegate => (
                     <Box key={delegate.voteDelegateAddress} sx={{ mb: 3 }}>
                       <ErrorBoundary componentName="Delegate Card">
-                        <DelegateOverviewCard delegate={delegate} setStateDelegates={setDelegates} />
+                        <DelegateOverviewCard
+                          delegate={delegate}
+                          setStateDelegates={setDelegates}
+                          onVisitDelegate={onVisitDelegate}
+                        />
                       </ErrorBoundary>
                     </Box>
                   ))}
@@ -346,7 +362,11 @@ const Delegates = ({
                   {expiredDelegates.map(delegate => (
                     <Box key={delegate.voteDelegateAddress} sx={{ mb: 3 }}>
                       <ErrorBoundary componentName="Delegate Card">
-                        <DelegateOverviewCard delegate={delegate} setStateDelegates={setDelegates} />
+                        <DelegateOverviewCard
+                          delegate={delegate}
+                          setStateDelegates={setDelegates}
+                          onVisitDelegate={onVisitDelegate}
+                        />
                       </ErrorBoundary>
                     </Box>
                   ))}

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -273,6 +273,7 @@ const Delegates = ({
                   value={name}
                   placeholder="Search by name"
                   withSearchButton={true}
+                  performSearchOnClear={true}
                 />
                 <DelegatesSortFilter />
                 <DelegatesCvcFilter cvcs={cvcs} sx={{ m: 2 }} />

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -63,10 +63,10 @@ const Delegates = ({
     sortDirection,
     name,
     delegateCvcs,
-    keepState,
+    fetchOnLoad,
     setCvcFilter,
     setName,
-    setKeepState,
+    setFetchOnLoad,
     resetFilters,
     resetSort,
     resetSortDirection
@@ -79,10 +79,10 @@ const Delegates = ({
       state.sortDirection,
       state.filters.name,
       state.filters.cvcs,
-      state.keepState,
+      state.fetchOnLoad,
       state.setCvcFilter,
       state.setName,
-      state.setKeepState,
+      state.setFetchOnLoad,
       state.resetFilters,
       state.resetSort,
       state.resetSortDirection
@@ -91,20 +91,20 @@ const Delegates = ({
   );
 
   const onVisitDelegate = () => {
-    setKeepState(true);
+    setFetchOnLoad(true);
   };
 
   const onResetClick = () => {
     resetFilters();
     resetSort();
     resetSortDirection();
-    setKeepState(false);
+    setFetchOnLoad(false);
   };
 
-  const [loading, setLoading] = useState(keepState);
+  const [loading, setLoading] = useState(fetchOnLoad);
   const [isRendering, setIsRendering] = useState(true);
   const [shouldLoadMore, setShouldLoadMore] = useState(false);
-  const [delegates, setDelegates] = useState(keepState ? [] : propDelegates);
+  const [delegates, setDelegates] = useState(fetchOnLoad ? [] : propDelegates);
   const [paginationInfo, setPaginationInfo] = useState(propPaginationInfo);
   const [seed, setSeed] = useState(propSeed);
   const [delegateCvcsLength, setDelegateCvcsLength] = useState(delegateCvcs.length);
@@ -158,7 +158,7 @@ const Delegates = ({
   }, [shouldLoadMore]);
 
   useEffect(() => {
-    if (!isRendering || keepState) {
+    if (!isRendering || fetchOnLoad) {
       let mounted = true;
       const fetchDelegates = async () => {
         const queryParams = {
@@ -188,10 +188,10 @@ const Delegates = ({
   }, [filters]);
 
   useEffect(() => {
-    setDelegates(keepState ? delegates : propDelegates);
+    setDelegates(fetchOnLoad ? delegates : propDelegates);
     setPaginationInfo(propPaginationInfo);
     setSeed(propSeed);
-  }, [propDelegates, propPaginationInfo, propSeed, keepState]);
+  }, [propDelegates, propPaginationInfo, propSeed, fetchOnLoad]);
 
   useEffect(() => {
     setDelegateCvcsLength(delegateCvcs.length);


### PR DESCRIPTION
This PR tries to fix some issues discovered during QA

- Keep filters when you visit a delegate detail page and the press the "< Back to all delegates" button.
- Sort filter button shows right selected value after coming from delegate detail page. It was showing the filter without text.
- Change from "Delegate" to "Delegate MKR" in the delegate card.
- Apply reset to the sort button
- FIX: When you search by text (applying filters optionally), visit the profile and back the search term disappeared and the filter by text isn't applied.
- Perform request keeping active filters when user clears the name field.