### PR TITLE
standardize days since Jan 1st calculation

### DIFF
--- a/modules/delegates/helpers/formatDelegationHistoryChart.ts
+++ b/modules/delegates/helpers/formatDelegationHistoryChart.ts
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { MKRLockedDelegateAPIResponse } from '../types/delegate';
 import { formatIsoDateConversion } from 'lib/datetime';
 import { MKRWeightHisory } from '../types/mkrWeight';
-import { format } from 'date-fns';
 import BigNumber from 'lib/bigNumberJs';
 import { differenceInCalendarYears, subDays } from 'date-fns';
 
@@ -25,11 +24,7 @@ export const formatDelegationHistoryChart = (
 
   const end =
     years * 365 +
-    parseInt(
-      format(new Date(), 'D', {
-        useAdditionalDayOfYearTokens: true
-      })
-    );
+    formatIsoDateConversion((new Date()).toISOString());
 
   const output: MKRWeightHisory[] = [];
 


### PR DESCRIPTION
### What does this PR do?

Fixes an inconsistency in the way the way that days since the start of a year is calculated, that would cause the metrics page to try to render a graph with no data points on it, causing an error.


Before: (on goerli) https://vote.makerdao.com/address/0xe2b5b6045ddfd171a5550a2ff4ffcf21f8a2d238#metrics
After: (on goerli) https://governance-portal-v2-7tfvtejvj-dux-core-unit.vercel.app/address/0xe2b5b6045ddfd171a5550a2ff4ffcf21f8a2d238#metrics

### Screenshots (if relevant):
Before:
<img width="620" alt="Screen Shot 2023-04-17 at 5 58 34 PM" src="https://user-images.githubusercontent.com/3388550/232662821-154d55f7-b320-4397-9902-b23e1fe65e46.png">

After:
<img width="886" alt="Screen Shot 2023-04-17 at 6 24 18 PM" src="https://user-images.githubusercontent.com/3388550/232661741-da8b6ffe-614c-434f-8f98-952459b2a6b6.png">

