### PR TITLE
Render less poll voters and executive supporters on first page load

### DIFF
--- a/modules/polling/components/VotesByAddress.tsx
+++ b/modules/polling/components/VotesByAddress.tsx
@@ -26,6 +26,8 @@ type Props = {
   poll: Poll;
 };
 
+const INITIAL_VOTES_COUNT = 10;
+
 const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
   const bpi = useBreakpointIndex();
   const { votesByAddress: votes, totalMkrParticipation } = tally;
@@ -33,7 +35,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
     type: 'mkr',
     order: 1
   });
-  const [numVotes, setNumVotes] = useState(10);
+  const [showAllVotes, setShowAllVotes] = useState(false);
 
   const changeSort = type => {
     if (sortBy.type === type) {
@@ -50,7 +52,7 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
   };
 
   const loadMoreVotes = () => {
-    setNumVotes(prevCount => prevCount + 10);
+    setShowAllVotes(true);
   };
 
   const filteredVotes = useMemo(() => {
@@ -78,8 +80,8 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
         sorted = votes;
     }
 
-    return sorted?.slice(0, numVotes);
-  }, [votes, sortBy.type, sortBy.order, numVotes]);
+    return showAllVotes ? sorted : sorted?.slice(0, INITIAL_VOTES_COUNT);
+  }, [votes, sortBy.type, sortBy.order, showAllVotes]);
 
   return (
     <Flex sx={{ flexDirection: 'column', alignItems: 'center' }}>
@@ -246,23 +248,18 @@ const VotesByAddress = ({ tally, poll }: Props): JSX.Element => {
           )}
         </tbody>
       </table>
-      {filteredVotes &&
-        (votes && filteredVotes.length < votes.length ? (
-          <Button
-            onClick={loadMoreVotes}
-            variant="outline"
-            data-testid="button-show-more-poll-voters"
-            sx={{ mt: 3 }}
-          >
-            <Text color="text" variant="caps">
-              Show more votes
-            </Text>
-          </Button>
-        ) : (
-          <Text variant="caps" sx={{ mt: 4 }}>
-            No more votes to display
+      {filteredVotes && votes && filteredVotes.length < votes.length && (
+        <Button
+          onClick={loadMoreVotes}
+          variant="outline"
+          data-testid="button-show-more-poll-voters"
+          sx={{ mt: 3 }}
+        >
+          <Text color="text" variant="caps">
+            Show all votes
           </Text>
-        ))}
+        </Button>
+      )}
     </Flex>
   );
 };

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -6,11 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import { useRouter } from 'next/router';
 import ErrorPage from 'modules/app/components/ErrorPage';
-import { Button, Card, Flex, Heading, Spinner, Box, Text, Divider, Badge, Label, Checkbox } from 'theme-ui';
+import { Button, Card, Flex, Heading, Spinner, Box, Text, Divider, Badge } from 'theme-ui';
 import { BigNumberJS } from 'lib/bigNumberJs';
 import useSWR, { useSWRConfig } from 'swr';
 import { Icon } from '@makerdao/dai-ui-icons';
@@ -107,7 +107,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
   const supporters = allSupporters ? allSupporters[proposal.address.toLowerCase()] : null;
 
   const [voting, setVoting] = useState(false);
-  const [showSmallVoters, setShowSmallVoters] = useState(false);
+  const [numSupporters, setNumSupporters] = useState(10);
   const close = () => setVoting(false);
 
   const hasVotedFor =
@@ -116,9 +116,11 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
       proposalAddress => proposalAddress.toLowerCase() === proposal.address.toLowerCase()
     );
 
-  const handleSmallVotersChecked = () => {
-    setShowSmallVoters(!showSmallVoters);
+  const loadMoreSupporters = () => {
+    setNumSupporters(prevCount => prevCount + 10);
   };
+
+  const filteredSupporters = useMemo(() => supporters?.slice(0, numSupporters), [supporters, numSupporters]);
 
   return (
     <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
@@ -303,7 +305,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
             </Box>
           )}
           <Box>
-            <Flex sx={{ alignItems: 'center', justifyContent: 'space-between' }}>
+            <Flex sx={{ mt: 3, mb: 2, alignItems: 'center', justifyContent: 'space-between' }}>
               <Heading as="h3" variant="microHeading" sx={{ mr: 1 }}>
                 Supporters
               </Heading>
@@ -313,24 +315,6 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
                 </Box>
                 <Text sx={{ fontSize: 1, color: 'textSecondary' }}>Updated every five minutes</Text>
               </Flex>
-            </Flex>
-            <Flex sx={{ justifyContent: 'right' }}>
-              <Box sx={{ flexGrow: 0 }}>
-                <Label
-                  variant="thinLabel"
-                  sx={{
-                    fontSize: 1,
-                    alignItems: 'center',
-                    justifyContent: 'right',
-                    py: [0, 1],
-                    color: 'textSecondary',
-                    cursor: 'pointer'
-                  }}
-                >
-                  <Checkbox checked={showSmallVoters} onChange={handleSmallVotersChecked} />
-                  <Text variant="caps">Show &lt;0.05 MKR voters</Text>
-                </Label>
-              </Box>
             </Flex>
             <ErrorBoundary componentName="Executive Supporters">
               <Card variant="compact" p={3}>
@@ -372,11 +356,10 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
                     </Flex>
                   )}
 
-                  {supporters &&
-                    supporters.length > 0 &&
-                    supporters
-                      .filter(supporter => showSmallVoters || supporter.deposits >= 0.05)
-                      .map(supporter => (
+                  <Flex sx={{ flexDirection: 'column' }}>
+                    {filteredSupporters &&
+                      filteredSupporters.length > 0 &&
+                      filteredSupporters.map(supporter => (
                         <Flex
                           sx={{
                             justifyContent: 'space-between',
@@ -415,6 +398,25 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
                           </Box>
                         </Flex>
                       ))}
+
+                    {filteredSupporters &&
+                      (supporters && filteredSupporters.length < supporters.length ? (
+                        <Button
+                          onClick={loadMoreSupporters}
+                          variant="outline"
+                          data-testid="button-show-more-executive-supporters"
+                          sx={{ mt: 2, alignSelf: 'center' }}
+                        >
+                          <Text color="text" variant="caps">
+                            Show more supporters
+                          </Text>
+                        </Button>
+                      ) : (
+                        <Text variant="caps" sx={{ mt: 3, alignSelf: 'center' }}>
+                          No more supporters to display
+                        </Text>
+                      ))}
+                  </Flex>
                 </Box>
               </Card>
             </ErrorBoundary>

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -53,6 +53,8 @@ type Props = {
   spellDiffs: SpellDiff[];
 };
 
+const INITIAL_SUPPORTERS_COUNT = 10;
+
 const editMarkdown = content => {
   // hide the duplicate proposal title
   return content.replace(/^<h1>.*<\/h1>|^<h2>.*<\/h2>/, '');
@@ -107,7 +109,7 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
   const supporters = allSupporters ? allSupporters[proposal.address.toLowerCase()] : null;
 
   const [voting, setVoting] = useState(false);
-  const [numSupporters, setNumSupporters] = useState(10);
+  const [showAllSupporters, setShowAllSupporters] = useState(false);
   const close = () => setVoting(false);
 
   const hasVotedFor =
@@ -117,10 +119,13 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
     );
 
   const loadMoreSupporters = () => {
-    setNumSupporters(prevCount => prevCount + 10);
+    setShowAllSupporters(true);
   };
 
-  const filteredSupporters = useMemo(() => supporters?.slice(0, numSupporters), [supporters, numSupporters]);
+  const filteredSupporters = useMemo(
+    () => (showAllSupporters ? supporters : supporters?.slice(0, INITIAL_SUPPORTERS_COUNT)),
+    [supporters, showAllSupporters]
+  );
 
   return (
     <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
@@ -399,23 +404,18 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
                         </Flex>
                       ))}
 
-                    {filteredSupporters &&
-                      (supporters && filteredSupporters.length < supporters.length ? (
-                        <Button
-                          onClick={loadMoreSupporters}
-                          variant="outline"
-                          data-testid="button-show-more-executive-supporters"
-                          sx={{ mt: 2, alignSelf: 'center' }}
-                        >
-                          <Text color="text" variant="caps">
-                            Show more supporters
-                          </Text>
-                        </Button>
-                      ) : (
-                        <Text variant="caps" sx={{ mt: 3, alignSelf: 'center' }}>
-                          No more supporters to display
+                    {filteredSupporters && supporters && filteredSupporters.length < supporters.length && (
+                      <Button
+                        onClick={loadMoreSupporters}
+                        variant="outline"
+                        data-testid="button-show-more-executive-supporters"
+                        sx={{ mt: 2, alignSelf: 'center' }}
+                      >
+                        <Text color="text" variant="caps">
+                          Show all supporters
                         </Text>
-                      ))}
+                      </Button>
+                    )}
                   </Flex>
                 </Box>
               </Card>

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -11,7 +11,7 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import ErrorPage from 'modules/app/components/ErrorPage';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import { Card, Flex, Divider, Heading, Text, Box, Button, Badge, Label, Checkbox } from 'theme-ui';
+import { Card, Flex, Divider, Heading, Text, Box, Button, Badge } from 'theme-ui';
 import { useBreakpointIndex } from '@theme-ui/match-media';
 import { Icon } from '@makerdao/dai-ui-icons';
 import { fetchJson } from 'lib/fetchJson';
@@ -70,7 +70,6 @@ const PollView = ({ poll }: { poll: Poll }) => {
   const bpi = useBreakpointIndex({ defaultIndex: 2 });
   const [shownOptions, setShownOptions] = useState(6);
   const [overlayOpen, setOverlayOpen] = useState(false);
-  const [showSmallVoters, setShowSmallVoters] = useState(false);
 
   const VotingWeightComponent = dynamic(() => import('../../modules/polling/components/VoteWeightVisual'), {
     ssr: false
@@ -93,10 +92,6 @@ const PollView = ({ poll }: { poll: Poll }) => {
       setNextSlug(poll.ctx?.next?.slug);
     }
   }, [filteredPollData, poll]);
-
-  const handleSmallVotersChecked = () => {
-    setShowSmallVoters(!showSmallVoters);
-  };
 
   return (
     <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
@@ -307,34 +302,11 @@ const PollView = ({ poll }: { poll: Poll }) => {
                       sx={{ p: [3, 4], flexDirection: 'column' }}
                       key={'votes by address'}
                     >
-                      <Flex sx={{ justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-                        <Text variant="microHeading">Voting By Address</Text>
-                        <Box>
-                          <Label
-                            variant="thinLabel"
-                            sx={{
-                              fontSize: 1,
-                              alignItems: 'center',
-                              color: 'textSecondary',
-                              py: 0,
-                              cursor: 'pointer'
-                            }}
-                          >
-                            <Checkbox checked={showSmallVoters} onChange={handleSmallVotersChecked} />
-                            <Text variant="caps">Show &lt;0.05 MKR voters</Text>
-                          </Label>
-                        </Box>
-                      </Flex>
+                      <Text variant="microHeading" sx={{ mb: 3 }}>
+                        Voting By Address
+                      </Text>
                       {tally && tally.votesByAddress && tally.numVoters > 0 ? (
-                        <VotesByAddress
-                          tally={{
-                            ...tally,
-                            votesByAddress: tally.votesByAddress.filter(
-                              vote => showSmallVoters || +vote.mkrSupport >= 0.05
-                            )
-                          }}
-                          poll={poll}
-                        />
+                        <VotesByAddress tally={tally} poll={poll} />
                       ) : tally && tally.numVoters === 0 ? (
                         <Text sx={{ color: 'textSecondary' }}>No votes yet</Text>
                       ) : (


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/2152/limit-number-of-rendered-voters-on-poll-detail-executive-detail

### What does this PR do?
It reduces the number of poll voters and executive supporters rendered on the frontend during the first load and adds a `Load More` button to render 10 more entries on demand, as well as a text to let users know when there are no more voters to load.

### Screenshots (if relevant):
![image](https://github.com/makerdao/governance-portal-v2/assets/22449631/1bcf4727-819a-4561-a109-9ca68bb0696e)
![image](https://github.com/makerdao/governance-portal-v2/assets/22449631/7b1bd575-ad06-4319-aaee-b48b25f816b5)

