### PR TITLE
better handle markdown in create page

### DIFF
--- a/pages/executive/create.tsx
+++ b/pages/executive/create.tsx
@@ -204,7 +204,10 @@ const ExecutiveCreate = (): JSX.Element => {
                     <tr key={'Markdown'}>
                       <TD>Markdown</TD>
                       <TD>
-                        <div dangerouslySetInnerHTML={{ __html: editMarkdown(markdown) }} />
+                        <Box
+                          sx={{ variant: 'markdown.default', p: [3, 4] }}
+                          dangerouslySetInnerHTML={{ __html: editMarkdown(markdown) }}
+                        />
                       </TD>
                     </tr>
                   </tbody>

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -193,7 +193,10 @@ const PollingCreate = (): React.ReactElement => {
                       )}
                       <Label>Proposal</Label>
                       <CreateText>
-                        <div dangerouslySetInnerHTML={{ __html: editMarkdown(contentHtml, poll?.title) }} />
+                        <Box
+                          sx={{ variant: 'markdown.default', p: [3, 4] }}
+                          dangerouslySetInnerHTML={{ __html: editMarkdown(contentHtml, poll?.title) }}
+                        />
                       </CreateText>
                       <Flex>
                         <Button


### PR DESCRIPTION
Display the markdown in the create page (both polling and exec) the same way it's displayed on the actual polling and exec pages

Before
<img width="858" alt="Screen Shot 2023-07-03 at 9 33 15 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/95f450f3-8186-41eb-ab5b-524f939e51b1">

After
<img width="889" alt="Screen Shot 2023-07-03 at 9 33 23 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/82d41f7b-296d-4e8d-897b-6da38234f671">
