### PR TITLE
 Active polls cache fix

### DIFF
--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -275,21 +275,22 @@ export async function refetchPolls(
 export async function getActivePollIds(network: SupportedNetworks): Promise<number[]> {
   const { valid: cachedPollsAreValid, hash: githubHash } = await checkCachedPollsValidity(network);
 
-  let partialActivePolls: PartialActivePoll[] = [];
+  let partialActivePolls: PartialActivePoll[] | undefined;
 
   if (cachedPollsAreValid) {
     const cachedPartialActivePolls = await cacheGet(partialActivePollsCacheKey, network, ONE_WEEK_IN_MS);
     if (cachedPartialActivePolls) {
       partialActivePolls = JSON.parse(cachedPartialActivePolls);
     }
-  } else {
+  }
+
+  if (!partialActivePolls) {
     const { partialActivePolls: newPartialActivePolls } = await refetchPolls(network, githubHash as string);
     partialActivePolls = newPartialActivePolls;
   }
 
-  const activePollIds = partialActivePolls
-    .filter(poll => new Date(poll.endDate) > new Date())
-    .map(poll => poll.pollId);
+  const activePollIds =
+    partialActivePolls?.filter(poll => new Date(poll.endDate) > new Date()).map(poll => poll.pollId) || [];
 
   return activePollIds;
 }


### PR DESCRIPTION
### What does this PR do?
It ensure the `partial-active-polls` are re-fetched if their cache key is not valid or not found
