### PR TITLE
Executive supporters batch requests + mobile delegate names

### DIFF
--- a/modules/address/components/AddressIconBox.tsx
+++ b/modules/address/components/AddressIconBox.tsx
@@ -74,9 +74,15 @@ export default function AddressIconBox({
         <Flex sx={{ flexDirection: ['column', 'row'] }}>
           <Flex sx={{ alignItems: 'center' }}>
             {delegate ? (
-              <Text>
-                {limitTextLength ? limitString(delegate.name, limitTextLength, '...') : delegate.name}
-              </Text>
+              limitTextLength ? (
+                <Flex sx={{ flexDirection: 'column' }}>
+                  {delegate.name.split(' - ').map((name, i) => (
+                    <Text key={delegate.name + '-' + i}>{limitString(name, limitTextLength, '...')}</Text>
+                  ))}
+                </Flex>
+              ) : (
+                <Text>{delegate.name}</Text>
+              )
             ) : (
               <Text>
                 <Address address={address} maxLength={limitTextLength} />

--- a/modules/address/components/AddressIconBox.tsx
+++ b/modules/address/components/AddressIconBox.tsx
@@ -16,8 +16,8 @@ import { useWeb3 } from 'modules/web3/hooks/useWeb3';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { useSingleDelegateInfo } from 'modules/delegates/hooks/useSingleDelegateInfo';
 import { useVoteProxyAddress } from 'modules/app/hooks/useVoteProxyAddress';
-import { limitString } from 'lib/string';
 import EtherscanLink from 'modules/web3/components/EtherscanLink';
+import splitDelegateName from 'modules/delegates/helpers/splitDelegateName';
 
 type PropTypes = {
   address: string;
@@ -76,8 +76,8 @@ export default function AddressIconBox({
             {delegate ? (
               limitTextLength ? (
                 <Flex sx={{ flexDirection: 'column' }}>
-                  {delegate.name.split(' - ').map((name, i) => (
-                    <Text key={delegate.name + '-' + i}>{limitString(name, limitTextLength, '...')}</Text>
+                  {splitDelegateName(delegate.name, limitTextLength).map((name, i) => (
+                    <Text key={delegate.name + '-' + i}>{name}</Text>
                   ))}
                 </Flex>
               ) : (

--- a/modules/delegates/helpers/splitDelegateName.ts
+++ b/modules/delegates/helpers/splitDelegateName.ts
@@ -1,0 +1,15 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { limitString } from 'lib/string';
+
+// Splits an Aligned Delegate name into two strings: one for the AVC name and one
+// for the actual delegate name, useful when displaying the name in small screens
+export default function splitDelegateName(delegateName: string, limitTextLength: number): string[] {
+  return delegateName.split(' - ').map(name => limitString(name, limitTextLength, '...'));
+}

--- a/modules/executive/api/fetchExecutiveVoteTally.ts
+++ b/modules/executive/api/fetchExecutiveVoteTally.ts
@@ -40,7 +40,8 @@ export async function fetchExecutiveVoteTally(chief: Chief): Promise<any | null>
     }
   });
 
-  // Split voters array into chunks of 1000 addresses
+  // We need to split the voters array into chunks of 1000 addresses because our
+  // Alchemy key doesn't support batch requests larger than 1000 queries each
   const chunkSize = 1000;
   const voterChunks = Array.from({ length: Math.ceil(voters.length / chunkSize) }, (_, i) =>
     voters.slice(i * chunkSize, i * chunkSize + chunkSize)


### PR DESCRIPTION
### What does this PR do?
- Fix an issue where executive supporters were not being fetched due to an Alchemy rate limitation for the batch RPC requests
- Split the aligned delegate names into 2 rows in mobile screens, that way the delegate name will always be visible regardless of the length of the AVC name