### PR TITLE
Prevent empty array from getting set in cache

### DIFF
--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -238,7 +238,9 @@ export async function refetchPolls(
   cacheSet(isPollsHashValidCacheKey, 'true', network, THIRTY_MINUTES_IN_MS);
   cacheSet(pollsHashCacheKey, githubHash, network, ONE_WEEK_IN_MS);
   cacheSet(pollListCacheKey, JSON.stringify(pollList), network, ONE_WEEK_IN_MS);
-  cacheSet(partialActivePollsCacheKey, JSON.stringify(partialActivePolls), network, ONE_WEEK_IN_MS);
+  if (partialActivePolls.length > 0) {
+    cacheSet(partialActivePollsCacheKey, JSON.stringify(partialActivePolls), network, ONE_WEEK_IN_MS);
+  }
 
   const pollTags = getPollTags();
 


### PR DESCRIPTION
### What does this PR do?

Prevent empty array of partial active polls from getting set in cache