### PR TITLE
Feat: poll review link & no delegate migration for shadow delegates

### DIFF
--- a/modules/delegates/hooks/useDelegateContractExpirationDate.ts
+++ b/modules/delegates/hooks/useDelegateContractExpirationDate.ts
@@ -10,7 +10,10 @@ import useSWR from 'swr';
 import { useCurrentUserVoteDelegateContract } from './useCurrentUserVoteDelegateContract';
 
 type VoteDelegateAddressResponse = {
-  data?: Date | null;
+  data: {
+    expiration?: Date | null;
+    voteDelegateContractAddress?: string;
+  };
   loading: boolean;
   error: Error;
 };
@@ -19,7 +22,7 @@ type VoteDelegateAddressResponse = {
 export const useDelegateContractExpirationDate = (): VoteDelegateAddressResponse => {
   const { data: voteDelegateContract } = useCurrentUserVoteDelegateContract();
 
-  const { data, error } = useSWR(
+  const { data: expirationData, error } = useSWR(
     voteDelegateContract ? `${voteDelegateContract}/expiration-date` : null,
     async () => {
       const expiration = await voteDelegateContract?.expiration();
@@ -28,8 +31,11 @@ export const useDelegateContractExpirationDate = (): VoteDelegateAddressResponse
     }
   );
   return {
-    data,
-    loading: !error && !data,
+    data: {
+      expiration: expirationData,
+      voteDelegateContractAddress: voteDelegateContract?.address
+    },
+    loading: !error && !expirationData,
     error
   };
 };

--- a/modules/migration/components/MigrationBanner.tsx
+++ b/modules/migration/components/MigrationBanner.tsx
@@ -20,19 +20,20 @@ export function MigrationBanner(): React.ReactElement | null {
     isDelegatedToExpiringContract,
     isDelegatedToExpiredContract,
     isDelegateContractExpired,
-    isDelegateContractExpiring
+    isDelegateContractExpiring,
+    isShadowDelegate
   } = useMigrationStatus();
   const showDelegationMigrationBanner =
-    isDelegateContractExpired ||
-    isDelegateContractExpiring ||
+    (isDelegateContractExpired && !isShadowDelegate) ||
+    (isDelegateContractExpiring && !isShadowDelegate) ||
     isDelegatedToExpiringContract ||
     isDelegatedToExpiredContract;
 
   const { variant, href, copy } = getMigrationBannerContent({
     isDelegatedToExpiredContract,
-    isDelegateContractExpired,
+    isDelegateContractExpired: isDelegateContractExpired && !isShadowDelegate,
     isDelegatedToExpiringContract,
-    isDelegateContractExpiring
+    isDelegateContractExpiring: isDelegateContractExpiring && !isShadowDelegate
   });
 
   return showDelegationMigrationBanner ? (

--- a/modules/migration/hooks/useLinkedDelegateInfo.tsx
+++ b/modules/migration/hooks/useLinkedDelegateInfo.tsx
@@ -19,7 +19,9 @@ export function useLinkedDelegateInfo(): {
 } {
   const { account: address, network } = useWeb3();
 
-  const { data: delegateContractExpirationDate } = useDelegateContractExpirationDate();
+  const {
+    data: { expiration: delegateContractExpirationDate }
+  } = useDelegateContractExpirationDate();
 
   // Means the old delegate in a mapping is connected
   const previousOwnerConnected = address ? !!getNewOwnerFromPrevious(address, network) : false;

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -61,6 +61,13 @@ const editMarkdown = (content: string) => {
   );
 };
 
+// Replaces the raw GitHub domain name, adds the 'blob' path and adds the link to the review section
+const parseRawUrl = (rawUrl: string) => {
+  const [protocol, separator, , org, repo, ...route] = rawUrl.split('/');
+  const url = [protocol, separator, 'github.com', org, repo, 'blob', ...route].join('/');
+  return url + '#review';
+};
+
 const PollView = ({ poll }: { poll: Poll }) => {
   const filteredPollData = usePollsStore(state => state.filteredPolls);
   const [prevSlug, setPrevSlug] = useState(poll.ctx?.prev?.slug);
@@ -213,12 +220,22 @@ const PollView = ({ poll }: { poll: Poll }) => {
                     )}
                   </Flex>
 
-                  <Flex sx={{ justifyContent: 'space-between', mb: 2, flexDirection: ['column', 'row'] }}>
+                  <Flex sx={{ justifyContent: 'space-between', mb: 2, flexDirection: 'column' }}>
                     {poll.discussionLink && (
                       <Box>
-                        <ExternalLink title="Discussion" href={poll.discussionLink}>
+                        <ExternalLink title="Forum Discussion" href={poll.discussionLink}>
                           <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
-                            Discussion
+                            Forum Discussion
+                            <Icon ml={2} name="arrowTopRight" size={2} />
+                          </Text>
+                        </ExternalLink>
+                      </Box>
+                    )}
+                    {poll.url && (
+                      <Box>
+                        <ExternalLink title="Review resources on GitHub" href={parseRawUrl(poll.url)}>
+                          <Text sx={{ fontSize: 3, fontWeight: 'semiBold' }}>
+                            Review resources on GitHub
                             <Icon ml={2} name="arrowTopRight" size={2} />
                           </Text>
                         </ExternalLink>


### PR DESCRIPTION
### Link to Shortcut ticket:
https://app.shortcut.com/dux-makerdao/story/2412/update-poll-detail-links
https://app.shortcut.com/dux-makerdao/story/2405/remove-migration-banner-for-shadow-delegates

### What does this PR do?
- Add a link to the poll copy review section in the poll detail page
- Check if the user delegate address is a shadow delegate, and if so, hide the delegate migration banner