### PR TITLE
Defaulting to text in polling banner

### DIFF
--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -141,6 +141,28 @@ export default function TopDelegates({
             }}
           >
             <InternalLink
+              href={'/avcs'}
+              title="View delegates"
+              styles={{
+                borderColor: 'secondaryMuted',
+                color: 'text',
+                ':hover': {
+                  color: 'text',
+                  borderColor: 'onSecondary',
+                  backgroundColor: 'background'
+                }
+              }}
+            >
+              <Button variant="outline">See all AVCs</Button>
+            </InternalLink>
+          </Box>
+          <Box
+            sx={{
+              ml: [0, 3],
+              mr: [2, 3]
+            }}
+          >
+            <InternalLink
               href={'/delegates'}
               title="View delegates"
               styles={{
@@ -162,21 +184,20 @@ export default function TopDelegates({
               mr: [0, 3]
             }}
           >
-            <InternalLink href={'/account'} title="View account">
-              <Button
-                variant="outline"
-                sx={{
-                  borderColor: 'secondaryMuted',
+            <InternalLink
+              href={'/account'}
+              title="View account"
+              styles={{
+                borderColor: 'secondaryMuted',
+                color: 'text',
+                ':hover': {
                   color: 'text',
-                  ':hover': {
-                    color: 'text',
-                    borderColor: 'onSecondary',
-                    backgroundColor: 'background'
-                  }
-                }}
-              >
-                Become a delegate
-              </Button>
+                  borderColor: 'onSecondary',
+                  backgroundColor: 'background'
+                }
+              }}
+            >
+              <Button variant="outline">Become a delegate</Button>
             </InternalLink>
           </Box>
         </Flex>

--- a/modules/home/components/InformationParticipateMakerGovernance/InfoPoints.tsx
+++ b/modules/home/components/InformationParticipateMakerGovernance/InfoPoints.tsx
@@ -65,7 +65,7 @@ export const infoPoints: InfoPoint[] = [
     links: [],
 
     description:
-      'Connect a web3 wallet (eg. MetaMask, WalletConnect) that holds your MKR tokens and start participating! Users that hold many MKR tokens or use their wallet for other uses besides Maker governance might want to consider more secure methods of setting up a voting wallet, such as using a hardware wallet or setting up a vote proxy (available soon).'
+      'Connect a web3 wallet (eg. MetaMask, WalletConnect) that holds your MKR tokens and start participating! Users that hold many MKR tokens or use their wallet for other uses besides Maker governance might want to consider more secure methods of setting up a voting wallet, such as using a hardware wallet or setting up a vote proxy.'
   },
   {
     number: '04',

--- a/modules/mkr/components/Deposit.tsx
+++ b/modules/mkr/components/Deposit.tsx
@@ -142,18 +142,20 @@ const ModalContent = ({
             </Button>
             {showProxyInfo && (
               <Text as="p" sx={{ fontSize: 2, mt: 3, color: 'textSecondary', textAlign: 'center' }}>
-                Interested in creating a proxy contract instead of depositing directly into Chief? Learn more{' '}
+                Advanced users interested in creating a{' '}
                 <ExternalLink
                   href="https://blog.makerdao.com/the-makerdao-voting-proxy-contract/"
                   title="Read about proxy contracts"
                 >
-                  <Text sx={{ color: 'accentBlue', fontSize: 2 }}>here</Text>
+                  <Text sx={{ color: 'accentBlue', fontSize: 2 }}>vote proxy contract</Text>
                 </ExternalLink>{' '}
-                and create one{' '}
-                <ExternalLink href="https://v1.vote.makerdao.com/proxysetup" title="Go to proxy setup">
+                instead of depositing directly into Chief can learn how to create one{' '}
+                <ExternalLink
+                  href="https://dux.makerdao.network/how-to-create-a-vote-proxy-manually-using-etherscan"
+                  title="Etherscan guide"
+                >
                   <Text sx={{ color: 'accentBlue', fontSize: 2 }}>here</Text>
                 </ExternalLink>
-                .
               </Text>
             )}
           </Stack>

--- a/modules/polling/components/PollWinningOptionBox.tsx
+++ b/modules/polling/components/PollWinningOptionBox.tsx
@@ -38,12 +38,6 @@ export default function PollWinningOptionBox({
       result.mkrSupport === tally.results[0].mkrSupport
   ).length;
 
-  // Winner will be null if the winning conditions are not met, but we want to display the leading option too
-  const leadingOption = typeof tally.winner === 'number' ? tally.winner : tally.results[0].optionId;
-  const leadingOptionName = `${
-    typeof tally.winner === 'number' ? tally.winningOptionName : tally.results[0].optionName
-  }${numberOfLeadingOptions > 1 ? ` & ${numberOfLeadingOptions - 1} more` : ''}`;
-
   const winningVictoryCondition = tally.parameters.victoryConditions.find(
     (v, index) => index === tally.victoryConditionMatched
   );
@@ -65,6 +59,13 @@ export default function PollWinningOptionBox({
     textWin = `No winner condition met.${comparisonText ? comparisonText : ' '}Defaulting to`;
     isDefault = true;
   }
+
+    // Winner will be null if the winning conditions are not met, but we want to display the leading option too
+    const leadingOption = typeof tally.winner === 'number' ? tally.winner : tally.results[0].optionId;
+    const leadingOptionName = `${
+      typeof tally.winner === 'number' ? tally.winningOptionName : tally.results[0].optionName
+      //don't show "& n more" if isDefault since there's only ever 1 default option
+    }${!isDefault && numberOfLeadingOptions > 1 ? ` & ${numberOfLeadingOptions - 1} more` : ''}`;
 
   return (
     <Flex sx={{ py: 2, justifyContent: 'center' }}>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "governance-portal-v2",
   "license": "AGPL-3.0-only",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@adobe/css-tools@^4.0.1":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.2.0.tgz#e1a84fca468f4b337816fcb7f0964beb620ba855"
-  integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
+  integrity sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
@@ -12562,9 +12562,9 @@ property-information@^6.0.0:
   integrity sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==
 
 protobufjs@^6.10.2:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
+  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
If we're showing the default option in the poll banner text, then don't show any of the other leading options.

Before:
<img width="718" alt="Screen Shot 2023-09-14 at 6 54 26 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/7e136e8b-81ef-4a36-8a64-754e507337f6">

After:
<img width="699" alt="Screen Shot 2023-09-14 at 7 09 00 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/e6b72855-4d55-420c-8ac7-eda6c4ca67f7">

This poll on goerli on prod shows the & 1 more, when it shouldn't: https://vote.makerdao.com/polling/QmNgQhcX

