### PR TITLE
only one option when defaulting to default value

### DIFF
--- a/modules/polling/components/PollWinningOptionBox.tsx
+++ b/modules/polling/components/PollWinningOptionBox.tsx
@@ -38,12 +38,6 @@ export default function PollWinningOptionBox({
       result.mkrSupport === tally.results[0].mkrSupport
   ).length;
 
-  // Winner will be null if the winning conditions are not met, but we want to display the leading option too
-  const leadingOption = typeof tally.winner === 'number' ? tally.winner : tally.results[0].optionId;
-  const leadingOptionName = `${
-    typeof tally.winner === 'number' ? tally.winningOptionName : tally.results[0].optionName
-  }${numberOfLeadingOptions > 1 ? ` & ${numberOfLeadingOptions - 1} more` : ''}`;
-
   const winningVictoryCondition = tally.parameters.victoryConditions.find(
     (v, index) => index === tally.victoryConditionMatched
   );
@@ -65,6 +59,13 @@ export default function PollWinningOptionBox({
     textWin = `No winner condition met.${comparisonText ? comparisonText : ' '}Defaulting to`;
     isDefault = true;
   }
+
+    // Winner will be null if the winning conditions are not met, but we want to display the leading option too
+    const leadingOption = typeof tally.winner === 'number' ? tally.winner : tally.results[0].optionId;
+    const leadingOptionName = `${
+      typeof tally.winner === 'number' ? tally.winningOptionName : tally.results[0].optionName
+      //don't show "& n more" if isDefault since there's only ever 1 default option
+    }${!isDefault && numberOfLeadingOptions > 1 ? ` & ${numberOfLeadingOptions - 1} more` : ''}`;
 
   return (
     <Flex sx={{ py: 2, justifyContent: 'center' }}>


### PR DESCRIPTION
If we're showing the default option in the poll banner text, then don't show any of the other leading options.

Before:
<img width="718" alt="Screen Shot 2023-09-14 at 6 54 26 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/7e136e8b-81ef-4a36-8a64-754e507337f6">

After:
<img width="699" alt="Screen Shot 2023-09-14 at 7 09 00 PM" src="https://github.com/makerdao/governance-portal-v2/assets/3388550/e6b72855-4d55-420c-8ac7-eda6c4ca67f7">

This poll on goerli on prod shows the & 1 more, when it shouldn't: https://vote.makerdao.com/polling/QmNgQhcX

