### PR TITLE
Batch cached execs fetches and deletions

### DIFF
--- a/modules/app/components/TxIndicators.tsx
+++ b/modules/app/components/TxIndicators.tsx
@@ -8,7 +8,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Box, ThemeUIStyleObject } from 'theme-ui';
 import { useEffect } from 'react';
-import lottie from 'lottie-web';
 
 import txFailedAnimation from 'lib/animation/txFailed.json';
 import txSuccessAnimation from 'lib/animation/txSuccess.json';
@@ -16,14 +15,23 @@ import txPendingAnimation from 'lib/animation/txPending.json';
 
 const Failed = ({ done, ...props }: { done?: () => void; sx?: ThemeUIStyleObject }): React.ReactElement => {
   useEffect(() => {
-    const animation = lottie.loadAnimation({
-      container: document.getElementById('tx-failed-animation-container') as HTMLElement,
-      loop: false,
-      autoplay: true,
-      animationData: txFailedAnimation
-    });
+    const loadLottie = async () => {
+      const lottie = await import('lottie-web');
+      const animation = lottie.default.loadAnimation({
+        container: document.getElementById('tx-failed-animation-container') as HTMLElement,
+        loop: false,
+        autoplay: true,
+        animationData: txFailedAnimation
+      });
 
-    done && animation.addEventListener('complete', () => setTimeout(done, 200));
+      done && animation.addEventListener('complete', () => setTimeout(done, 200));
+
+      return () => {
+        animation.destroy();
+      };
+    };
+
+    loadLottie();
   }, []);
 
   return <Box sx={{ width: '100%' }} id="tx-failed-animation-container" {...props} />;
@@ -31,14 +39,23 @@ const Failed = ({ done, ...props }: { done?: () => void; sx?: ThemeUIStyleObject
 
 const Success = ({ done, ...props }: { done?: () => void; sx?: ThemeUIStyleObject }): React.ReactElement => {
   useEffect(() => {
-    const animation = lottie.loadAnimation({
-      container: document.getElementById('tx-success-animation-container') as HTMLElement,
-      loop: false,
-      autoplay: true,
-      animationData: txSuccessAnimation
-    });
+    const loadLottie = async () => {
+      const lottie = await import('lottie-web');
+      const animation = lottie.default.loadAnimation({
+        container: document.getElementById('tx-success-animation-container') as HTMLElement,
+        loop: false,
+        autoplay: true,
+        animationData: txSuccessAnimation
+      });
 
-    done && animation.addEventListener('complete', () => setTimeout(done, 200));
+      done && animation.addEventListener('complete', () => setTimeout(done, 200));
+
+      return () => {
+        animation.destroy();
+      };
+    };
+
+    loadLottie();
   }, []);
 
   return <Box sx={{ width: '100%' }} id="tx-success-animation-container" {...props} />;
@@ -46,14 +63,23 @@ const Success = ({ done, ...props }: { done?: () => void; sx?: ThemeUIStyleObjec
 
 const Pending = ({ done, ...props }: { done?: () => void; sx?: ThemeUIStyleObject }): React.ReactElement => {
   useEffect(() => {
-    const animation = lottie.loadAnimation({
-      container: document.getElementById('tx-pending-animation-container') as HTMLElement,
-      loop: true,
-      autoplay: true,
-      animationData: txPendingAnimation
-    });
+    const loadLottie = async () => {
+      const lottie = await import('lottie-web');
+      const animation = lottie.default.loadAnimation({
+        container: document.getElementById('tx-pending-animation-container') as HTMLElement,
+        loop: true,
+        autoplay: true,
+        animationData: txPendingAnimation
+      });
 
-    done && animation.addEventListener('complete', () => setTimeout(done, 200));
+      done && animation.addEventListener('complete', () => setTimeout(done, 200));
+
+      return () => {
+        animation.destroy();
+      };
+    };
+
+    loadLottie();
   }, []);
 
   return <Box sx={{ width: '100%' }} id="tx-pending-animation-container" {...props} />;

--- a/modules/polling/components/MobileVoteSheet.tsx
+++ b/modules/polling/components/MobileVoteSheet.tsx
@@ -12,7 +12,6 @@ import { Text, Button, Box, Flex } from 'theme-ui';
 import invariant from 'tiny-invariant';
 import range from 'lodash/range';
 import isNil from 'lodash/isNil';
-import lottie from 'lottie-web';
 import { Poll } from 'modules/polling/types';
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import { useRouter } from 'next/router';
@@ -198,14 +197,23 @@ export default function MobileVoteSheet({
 
 const AddingView = ({ done }: { done: () => void }) => {
   useEffect(() => {
-    const animation = lottie.loadAnimation({
-      container: document.getElementById('ballot-animation-container') as HTMLElement,
-      loop: false,
-      autoplay: true,
-      animationData: ballotAnimation
-    });
+    const loadLottie = async () => {
+      const lottie = await import('lottie-web');
+      const animation = lottie.default.loadAnimation({
+        container: document.getElementById('ballot-animation-container') as HTMLElement,
+        loop: false,
+        autoplay: true,
+        animationData: ballotAnimation
+      });
 
-    animation.addEventListener('complete', () => setTimeout(done, 200));
+      animation.addEventListener('complete', () => setTimeout(done, 200));
+
+      return () => {
+        animation.destroy();
+      };
+    };
+
+    loadLottie();
   }, []);
 
   return (


### PR DESCRIPTION
### What does this PR do?
- Replace the use of `redis.keys()` for `redis.scan()` which is optimized for production
- Batch exec proposals scans to 100 at a time
- Batch exec proposals deletions so they are deleted in groups of 100 instead of deleting them one by one