### PR TITLE
Use v4 for artifact action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run E2E Test
         run: yarn run e2e ${{ matrix.test }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report-${{ matrix.test }}


### PR DESCRIPTION
### What does this PR do?

Use v4 for artifact action as v3 has been deprecated