### PR TITLE
Legacy app: Disable write contract interactions

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -59,5 +59,5 @@ export const config: SystemConfig = {
   TENDERLY_RPC_KEY: process.env.NEXT_PUBLIC_TENDERLY_RPC_KEY || '',
   USE_MOCK_WALLET: process.env.NEXT_PUBLIC_USE_MOCK_WALLET || '',
   SUBGRAPH_API_KEY: process.env.NEXT_PUBLIC_SUBGRAPH_API_KEY || '',
-  READ_ONLY: Boolean(process.env.READ_ONLY)
+  READ_ONLY: process.env.READ_ONLY === 'true'
 };

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -31,6 +31,7 @@ type SystemConfig = {
   TENDERLY_RPC_KEY: string;
   USE_MOCK_WALLET: string;
   SUBGRAPH_API_KEY: string;
+  READ_ONLY: boolean;
 };
 
 export const config: SystemConfig = {
@@ -57,5 +58,6 @@ export const config: SystemConfig = {
   GASLESS_DISABLED: process.env.GASLESS_DISABLED || '',
   TENDERLY_RPC_KEY: process.env.NEXT_PUBLIC_TENDERLY_RPC_KEY || '',
   USE_MOCK_WALLET: process.env.NEXT_PUBLIC_USE_MOCK_WALLET || '',
-  SUBGRAPH_API_KEY: process.env.NEXT_PUBLIC_SUBGRAPH_API_KEY || ''
+  SUBGRAPH_API_KEY: process.env.NEXT_PUBLIC_SUBGRAPH_API_KEY || '',
+  READ_ONLY: Boolean(process.env.READ_ONLY)
 };

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -26,6 +26,7 @@ import DelegateContractInfo from 'modules/migration/components/DelegateContractI
 import { DialogOverlay, DialogContent } from 'modules/app/components/Dialog';
 import BoxWithClose from 'modules/app/components/BoxWithClose';
 import { formatEther, parseEther } from 'viem';
+import { config } from 'lib/config';
 
 type PropTypes = {
   delegate: DelegatePaginated;
@@ -191,8 +192,7 @@ export const DelegateOverviewCard = memo(
                 <Button
                   variant="primaryLarge"
                   data-testid="button-delegate"
-                  // disabled={!account || !!delegate.next || delegate.expired}
-                  disabled={true}
+                  disabled={config.READ_ONLY || !account || !!delegate.next || delegate.expired}
                   onClick={() => {
                     setShowDelegateModal(true);
                   }}

--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -191,7 +191,8 @@ export const DelegateOverviewCard = memo(
                 <Button
                   variant="primaryLarge"
                   data-testid="button-delegate"
-                  disabled={!account || !!delegate.next || delegate.expired}
+                  // disabled={!account || !!delegate.next || delegate.expired}
+                  disabled={true}
                   onClick={() => {
                     setShowDelegateModal(true);
                   }}

--- a/modules/delegates/components/ManageDelegation.tsx
+++ b/modules/delegates/components/ManageDelegation.tsx
@@ -41,7 +41,8 @@ export default function ManageDelegation({
           <Button
             variant="primaryLarge"
             data-testid="button-delegate"
-            disabled={!account}
+            // disabled={!account}
+            disabled={true}
             onClick={() => {
               setShowDelegateModal(true);
             }}

--- a/modules/delegates/components/ManageDelegation.tsx
+++ b/modules/delegates/components/ManageDelegation.tsx
@@ -14,6 +14,7 @@ import { UndelegateModal } from './modals/UndelegateModal';
 import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 import { useMkrDelegatedByUser } from 'modules/mkr/hooks/useMkrDelegatedByUser';
 import { useAccount } from 'modules/app/hooks/useAccount';
+import { config } from 'lib/config';
 
 export default function ManageDelegation({
   delegate,
@@ -41,8 +42,7 @@ export default function ManageDelegation({
           <Button
             variant="primaryLarge"
             data-testid="button-delegate"
-            // disabled={!account}
-            disabled={true}
+            disabled={config.READ_ONLY || !account}
             onClick={() => {
               setShowDelegateModal(true);
             }}

--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -13,7 +13,7 @@ import { DelegatePicture } from './DelegatePicture';
 import { DelegatePaginated } from '../types';
 import { DelegateModal } from './modals/DelegateModal';
 import { useState } from 'react';
-import { useAccount } from 'modules/app/hooks/useAccount';
+// import { useAccount } from 'modules/app/hooks/useAccount';
 import { calculatePercentage } from 'lib/utils';
 import { parseEther } from 'viem';
 
@@ -24,7 +24,7 @@ export default function TopDelegates({
   topDelegates: DelegatePaginated[];
   totalMKRDelegated: bigint;
 }): React.ReactElement {
-  const { account } = useAccount();
+  // const { account } = useAccount();
   const [showDelegateModal, setShowDelegateModal] = useState<DelegatePaginated | null>(null);
 
   return (
@@ -125,7 +125,8 @@ export default function TopDelegates({
                   <Button
                     variant="outline"
                     data-testid="button-delegate"
-                    disabled={!account}
+                    // disabled={!account}
+                    disabled={true}
                     onClick={() => {
                       setShowDelegateModal(delegate);
                     }}

--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -13,9 +13,10 @@ import { DelegatePicture } from './DelegatePicture';
 import { DelegatePaginated } from '../types';
 import { DelegateModal } from './modals/DelegateModal';
 import { useState } from 'react';
-// import { useAccount } from 'modules/app/hooks/useAccount';
+import { useAccount } from 'modules/app/hooks/useAccount';
 import { calculatePercentage } from 'lib/utils';
 import { parseEther } from 'viem';
+import { config } from 'lib/config';
 
 export default function TopDelegates({
   topDelegates,
@@ -24,7 +25,7 @@ export default function TopDelegates({
   topDelegates: DelegatePaginated[];
   totalMKRDelegated: bigint;
 }): React.ReactElement {
-  // const { account } = useAccount();
+  const { account } = useAccount();
   const [showDelegateModal, setShowDelegateModal] = useState<DelegatePaginated | null>(null);
 
   return (
@@ -125,8 +126,7 @@ export default function TopDelegates({
                   <Button
                     variant="outline"
                     data-testid="button-delegate"
-                    // disabled={!account}
-                    disabled={true}
+                    disabled={config.READ_ONLY || !account}
                     onClick={() => {
                       setShowDelegateModal(delegate);
                     }}

--- a/modules/delegates/hooks/useDelegateCreate.ts
+++ b/modules/delegates/hooks/useDelegateCreate.ts
@@ -10,10 +10,11 @@ import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { voteDelegateFactoryAbi, voteDelegateFactoryAddress } from 'modules/contracts/generated';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
+import { config } from 'lib/config';
 
 export const useDelegateCreate = ({
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -25,8 +26,7 @@ export const useDelegateCreate = ({
     abi: voteDelegateFactoryAbi,
     functionName: 'create',
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/delegates/hooks/useDelegateCreate.ts
+++ b/modules/delegates/hooks/useDelegateCreate.ts
@@ -13,7 +13,7 @@ import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 
 export const useDelegateCreate = ({
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -25,7 +25,8 @@ export const useDelegateCreate = ({
     abi: voteDelegateFactoryAbi,
     functionName: 'create',
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/delegates/hooks/useDelegateLock.ts
+++ b/modules/delegates/hooks/useDelegateLock.ts
@@ -15,7 +15,7 @@ export const useDelegateLock = ({
   voteDelegateAddress,
   mkrToDeposit,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,7 +31,8 @@ export const useDelegateLock = ({
     functionName: 'lock',
     args: [mkrToDeposit],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/delegates/hooks/useDelegateLock.ts
+++ b/modules/delegates/hooks/useDelegateLock.ts
@@ -10,12 +10,13 @@ import { useChainId } from 'wagmi';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { voteDelegateAbi } from 'modules/contracts/ethers/abis';
+import { config } from 'lib/config';
 
 export const useDelegateLock = ({
   voteDelegateAddress,
   mkrToDeposit,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,8 +32,7 @@ export const useDelegateLock = ({
     functionName: 'lock',
     args: [mkrToDeposit],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/esm/hooks/useEsmBurn.ts
+++ b/modules/esm/hooks/useEsmBurn.ts
@@ -10,11 +10,12 @@ import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { esmAbi, esmAddress } from 'modules/contracts/generated';
+import { config } from 'lib/config';
 
 export const useEsmBurn = ({
   burnAmount,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,8 +30,7 @@ export const useEsmBurn = ({
     functionName: 'join',
     args: [burnAmount],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/esm/hooks/useEsmBurn.ts
+++ b/modules/esm/hooks/useEsmBurn.ts
@@ -14,7 +14,7 @@ import { esmAbi, esmAddress } from 'modules/contracts/generated';
 export const useEsmBurn = ({
   burnAmount,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,7 +29,8 @@ export const useEsmBurn = ({
     functionName: 'join',
     args: [burnAmount],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/esm/hooks/useEsmShutdown.ts
+++ b/modules/esm/hooks/useEsmShutdown.ts
@@ -13,7 +13,7 @@ import { esmAbi, esmAddress } from 'modules/contracts/generated';
 
 export const useEsmShutdown = ({
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -25,7 +25,8 @@ export const useEsmShutdown = ({
     abi: esmAbi,
     functionName: 'fire',
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/esm/hooks/useEsmShutdown.ts
+++ b/modules/esm/hooks/useEsmShutdown.ts
@@ -10,10 +10,11 @@ import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { esmAbi, esmAddress } from 'modules/contracts/generated';
+import { config } from 'lib/config';
 
 export const useEsmShutdown = ({
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -25,8 +26,7 @@ export const useEsmShutdown = ({
     abi: esmAbi,
     functionName: 'fire',
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -22,7 +22,8 @@ import { CardSummary } from 'modules/app/components/Card/CardSummary';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { StatBox } from 'modules/app/components/StatBox';
 import { StatusText } from 'modules/app/components/StatusText';
-// import { useMigrationStatus } from 'modules/migration/hooks/useMigrationStatus';
+import { config } from 'lib/config';
+import { useMigrationStatus } from 'modules/migration/hooks/useMigrationStatus';
 
 type Props = {
   proposal: Proposal;
@@ -64,7 +65,7 @@ export default function ExecutiveOverviewCard({
 
   const canVote = !!account;
 
-  // const { isDelegateContractExpired } = useMigrationStatus();
+  const { isDelegateContractExpired } = useMigrationStatus();
 
   return (
     <Card
@@ -144,11 +145,11 @@ export default function ExecutiveOverviewCard({
                 <Button
                   variant="primaryOutline"
                   sx={{ width: 122 }}
-                  // disabled={
-                  //   (hasVotedFor && votedProposals && votedProposals.length === 1) ||
-                  //   isDelegateContractExpired
-                  // }
-                  disabled={true}
+                  disabled={
+                    config.READ_ONLY ||
+                    (hasVotedFor && votedProposals && votedProposals.length === 1) ||
+                    isDelegateContractExpired
+                  }
                   onClick={ev => {
                     setVoting(true);
                     ev.stopPropagation();

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -22,7 +22,7 @@ import { CardSummary } from 'modules/app/components/Card/CardSummary';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { StatBox } from 'modules/app/components/StatBox';
 import { StatusText } from 'modules/app/components/StatusText';
-import { useMigrationStatus } from 'modules/migration/hooks/useMigrationStatus';
+// import { useMigrationStatus } from 'modules/migration/hooks/useMigrationStatus';
 
 type Props = {
   proposal: Proposal;
@@ -64,7 +64,7 @@ export default function ExecutiveOverviewCard({
 
   const canVote = !!account;
 
-  const { isDelegateContractExpired } = useMigrationStatus();
+  // const { isDelegateContractExpired } = useMigrationStatus();
 
   return (
     <Card
@@ -144,10 +144,11 @@ export default function ExecutiveOverviewCard({
                 <Button
                   variant="primaryOutline"
                   sx={{ width: 122 }}
-                  disabled={
-                    (hasVotedFor && votedProposals && votedProposals.length === 1) ||
-                    isDelegateContractExpired
-                  }
+                  // disabled={
+                  //   (hasVotedFor && votedProposals && votedProposals.length === 1) ||
+                  //   isDelegateContractExpired
+                  // }
+                  disabled={true}
                   onClick={ev => {
                     setVoting(true);
                     ev.stopPropagation();

--- a/modules/executive/hooks/useChiefVote.ts
+++ b/modules/executive/hooks/useChiefVote.ts
@@ -14,7 +14,7 @@ import { chiefAbi, chiefAddress } from 'modules/contracts/generated';
 export const useChiefVote = ({
   slateOrProposals,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,7 +29,8 @@ export const useChiefVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/hooks/useChiefVote.ts
+++ b/modules/executive/hooks/useChiefVote.ts
@@ -10,11 +10,12 @@ import { useChainId } from 'wagmi';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { chiefAbi, chiefAddress } from 'modules/contracts/generated';
+import { config } from 'lib/config';
 
 export const useChiefVote = ({
   slateOrProposals,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,8 +30,7 @@ export const useChiefVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/hooks/useDelegateVote.ts
+++ b/modules/executive/hooks/useDelegateVote.ts
@@ -11,11 +11,12 @@ import { useChainId } from 'wagmi';
 import { voteDelegateAbi } from 'modules/contracts/ethers/abis';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
+import { config } from 'lib/config';
 
 export const useDelegateVote = ({
   slateOrProposals,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,8 +32,7 @@ export const useDelegateVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/hooks/useDelegateVote.ts
+++ b/modules/executive/hooks/useDelegateVote.ts
@@ -15,7 +15,7 @@ import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 export const useDelegateVote = ({
   slateOrProposals,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,7 +31,8 @@ export const useDelegateVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/hooks/useVoteProxyVote.ts
+++ b/modules/executive/hooks/useVoteProxyVote.ts
@@ -11,11 +11,12 @@ import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { voteProxyAbi } from 'modules/contracts/ethers/abis';
+import { config } from 'lib/config';
 
 export const useVoteProxyVote = ({
   slateOrProposals,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,8 +32,7 @@ export const useVoteProxyVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/executive/hooks/useVoteProxyVote.ts
+++ b/modules/executive/hooks/useVoteProxyVote.ts
@@ -15,7 +15,7 @@ import { voteProxyAbi } from 'modules/contracts/ethers/abis';
 export const useVoteProxyVote = ({
   slateOrProposals,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -31,7 +31,8 @@ export const useVoteProxyVote = ({
     functionName: 'vote',
     args: [slateOrProposals],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/mkr/components/Deposit.tsx
+++ b/modules/mkr/components/Deposit.tsx
@@ -247,6 +247,7 @@ const Deposit = ({
           onClick={() => {
             open();
           }}
+          disabled={true}
           data-testid="deposit-button"
         >
           Deposit

--- a/modules/mkr/components/Deposit.tsx
+++ b/modules/mkr/components/Deposit.tsx
@@ -24,6 +24,7 @@ import { ExternalLink } from 'modules/app/components/ExternalLink';
 import { useChainId } from 'wagmi';
 import { chiefAddress } from 'modules/contracts/generated';
 import { TxStatus } from 'modules/web3/constants/transaction';
+import { config } from 'lib/config';
 
 const ModalContent = ({
   close,
@@ -247,7 +248,7 @@ const Deposit = ({
           onClick={() => {
             open();
           }}
-          disabled={true}
+          disabled={config.READ_ONLY}
           data-testid="deposit-button"
         >
           Deposit

--- a/modules/mkr/hooks/useLock.ts
+++ b/modules/mkr/hooks/useLock.ts
@@ -16,7 +16,7 @@ import { voteProxyAbi } from 'modules/contracts/ethers/abis';
 export const useLock = ({
   mkrToDeposit,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -30,7 +30,8 @@ export const useLock = ({
     functionName: 'lock',
     args: [mkrToDeposit],
     chainId,
-    enabled: paramEnabled,
+    // enabled: paramEnabled,
+    enabled: false,
     gas,
     onSuccess,
     onError,

--- a/modules/mkr/hooks/useLock.ts
+++ b/modules/mkr/hooks/useLock.ts
@@ -12,11 +12,12 @@ import { useChainId } from 'wagmi';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { voteProxyAbi } from 'modules/contracts/ethers/abis';
+import { config } from 'lib/config';
 
 export const useLock = ({
   mkrToDeposit,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -30,8 +31,7 @@ export const useLock = ({
     functionName: 'lock',
     args: [mkrToDeposit],
     chainId,
-    // enabled: paramEnabled,
-    enabled: false,
+    enabled: paramEnabled && !config.READ_ONLY,
     gas,
     onSuccess,
     onError,

--- a/modules/polling/components/BallotBox.tsx
+++ b/modules/polling/components/BallotBox.tsx
@@ -56,7 +56,8 @@ export default function BallotBox({ activePollCount, network, activePollIds }: P
           <Flex p={3} sx={{ flexDirection: 'column' }}>
             <Button
               variant="primaryLarge"
-              disabled={!ballotCount}
+              // disabled={!ballotCount}
+              disabled={true}
               sx={{ width: '100%', cursor: !ballotCount ? 'not-allowed' : 'pointer' }}
             >
               <InternalLink href="/polling/review" title="Review & submit your ballot">

--- a/modules/polling/components/BallotBox.tsx
+++ b/modules/polling/components/BallotBox.tsx
@@ -14,6 +14,7 @@ import { useContext } from 'react';
 import { BallotContext } from '../context/BallotContext';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import EtherscanLink from 'modules/web3/components/EtherscanLink';
+import { config } from 'lib/config';
 
 type Props = {
   activePollCount: number;
@@ -56,8 +57,7 @@ export default function BallotBox({ activePollCount, network, activePollIds }: P
           <Flex p={3} sx={{ flexDirection: 'column' }}>
             <Button
               variant="primaryLarge"
-              // disabled={!ballotCount}
-              disabled={true}
+              disabled={!ballotCount || config.READ_ONLY}
               sx={{ width: '100%', cursor: !ballotCount ? 'not-allowed' : 'pointer' }}
               data-testid="review-ballot-button"
             >

--- a/modules/polling/components/ChoiceSummary.tsx
+++ b/modules/polling/components/ChoiceSummary.tsx
@@ -106,7 +106,7 @@ const ChoiceSummary = ({
       </Flex>
       {showReviewButton && onBallot && (
         <InternalLink href="/polling/review" title="Review & submit your ballot">
-          <Button variant="primaryLarge" sx={{ width: '100%', cursor: 'pointer', mt: 3 }}>
+          <Button variant="primaryLarge" sx={{ width: '100%', cursor: 'pointer', mt: 3 }} disabled={true}>
             Review & Submit Your Ballot
           </Button>
         </InternalLink>

--- a/modules/polling/components/ChoiceSummary.tsx
+++ b/modules/polling/components/ChoiceSummary.tsx
@@ -15,6 +15,7 @@ import { useContext } from 'react';
 import { BallotContext } from '../context/BallotContext';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import { isInputFormatChooseFree, isInputFormatRankFree, isInputFormatSingleChoice } from '../helpers/utils';
+import { config } from 'lib/config';
 
 const ChoiceSummary = ({
   choice,
@@ -106,7 +107,11 @@ const ChoiceSummary = ({
       </Flex>
       {showReviewButton && onBallot && (
         <InternalLink href="/polling/review" title="Review & submit your ballot">
-          <Button variant="primaryLarge" sx={{ width: '100%', cursor: 'pointer', mt: 3 }} disabled={true}>
+          <Button
+            variant="primaryLarge"
+            sx={{ width: '100%', cursor: 'pointer', mt: 3 }}
+            disabled={config.READ_ONLY}
+          >
             Review & Submit Your Ballot
           </Button>
         </InternalLink>

--- a/modules/polling/components/poll-vote-input/QuickVote.tsx
+++ b/modules/polling/components/poll-vote-input/QuickVote.tsx
@@ -27,6 +27,7 @@ import { BallotContext } from '../../context/BallotContext';
 import ChooseFreeSelect from './ChooseFreeSelect';
 import { useMKRVotingWeight } from 'modules/mkr/hooks/useMKRVotingWeight';
 import { useMigrationStatus } from 'modules/migration/hooks/useMigrationStatus';
+import { config } from 'lib/config';
 
 type Props = {
   poll: PollListItem | Poll;
@@ -141,10 +142,13 @@ const QuickVote = ({
               submit();
             }}
             mt={2}
-            // disabled={
-            //   !isChoiceValid || !votingWeight || !(votingWeight.total > 0n) || isDelegateContractExpired
-            // }
-            disabled={true}
+            disabled={
+              !isChoiceValid ||
+              !votingWeight ||
+              !(votingWeight.total > 0n) ||
+              isDelegateContractExpired ||
+              config.READ_ONLY
+            }
           >
             {loading
               ? 'Loading MKR balance...'

--- a/modules/polling/components/poll-vote-input/QuickVote.tsx
+++ b/modules/polling/components/poll-vote-input/QuickVote.tsx
@@ -141,9 +141,10 @@ const QuickVote = ({
               submit();
             }}
             mt={2}
-            disabled={
-              !isChoiceValid || !votingWeight || !(votingWeight.total > 0n) || isDelegateContractExpired
-            }
+            // disabled={
+            //   !isChoiceValid || !votingWeight || !(votingWeight.total > 0n) || isDelegateContractExpired
+            // }
+            disabled={true}
           >
             {loading
               ? 'Loading MKR balance...'

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { fetchJson } from 'lib/fetchJson';
 import { localStorage } from 'modules/app/client/storage/localStorage';
 import { useAccount } from 'modules/app/hooks/useAccount';
-import { signTypedBallotData } from 'modules/web3/helpers/signTypedBallotData';
+// import { signTypedBallotData } from 'modules/web3/helpers/signTypedBallotData';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
 import useTransactionsStore, {
   transactionsApi,
@@ -298,7 +298,8 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
     functionName: 'votePoll',
     args: [pollIds, optionIds],
     chainId,
-    enabled: !!voteDelegateContractAddress,
+    // enabled: !!voteDelegateContractAddress,
+    enabled: false,
     onStart: (txHash: string) => {
       onPendingHandler(txHash);
     },
@@ -316,7 +317,8 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
     functionName: 'vote',
     args: [pollIds, optionIds],
     chainId,
-    enabled: !voteDelegateContractAddress,
+    // enabled: !voteDelegateContractAddress,
+    enabled: false,
     onStart: (txHash: string) => {
       onPendingHandler(txHash);
     },
@@ -381,8 +383,9 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
 
     let signature;
     try {
-      signature = await signTypedBallotData(signatureValues, signTypedDataAsync, network);
-      setStep('awaiting-relayer');
+      signature = undefined;
+      // signature = await signTypedBallotData(signatureValues, signTypedDataAsync, network);
+      // setStep('awaiting-relayer');
     } catch (error) {
       toast.error(error);
       setSubmissionError(parseTxError(error));

--- a/modules/polling/context/BallotContext.tsx
+++ b/modules/polling/context/BallotContext.tsx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { fetchJson } from 'lib/fetchJson';
 import { localStorage } from 'modules/app/client/storage/localStorage';
 import { useAccount } from 'modules/app/hooks/useAccount';
-// import { signTypedBallotData } from 'modules/web3/helpers/signTypedBallotData';
+import { signTypedBallotData } from 'modules/web3/helpers/signTypedBallotData';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
 import useTransactionsStore, {
   transactionsApi,
@@ -56,6 +56,7 @@ import {
 } from 'modules/contracts/generated';
 import { getGaslessPublicClient } from 'modules/web3/helpers/getPublicClient';
 import { SupportedChainId } from 'modules/web3/constants/chainID';
+import { config } from 'lib/config';
 
 interface ContextProps {
   ballot: Ballot;
@@ -298,8 +299,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
     functionName: 'votePoll',
     args: [pollIds, optionIds],
     chainId,
-    // enabled: !!voteDelegateContractAddress,
-    enabled: false,
+    enabled: !!voteDelegateContractAddress && !config.READ_ONLY,
     onStart: (txHash: string) => {
       onPendingHandler(txHash);
     },
@@ -317,8 +317,7 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
     functionName: 'vote',
     args: [pollIds, optionIds],
     chainId,
-    // enabled: !voteDelegateContractAddress,
-    enabled: false,
+    enabled: !voteDelegateContractAddress && !config.READ_ONLY,
     onStart: (txHash: string) => {
       onPendingHandler(txHash);
     },
@@ -383,9 +382,8 @@ export const BallotProvider = ({ children }: PropTypes): React.ReactElement => {
 
     let signature;
     try {
-      signature = undefined;
-      // signature = await signTypedBallotData(signatureValues, signTypedDataAsync, network);
-      // setStep('awaiting-relayer');
+      signature = await signTypedBallotData(signatureValues, signTypedDataAsync, network);
+      setStep('awaiting-relayer');
     } catch (error) {
       toast.error(error);
       setSubmissionError(parseTxError(error));

--- a/modules/polling/hooks/usePollCreate.ts
+++ b/modules/polling/hooks/usePollCreate.ts
@@ -17,7 +17,7 @@ export const usePollCreate = ({
   multiHash,
   url,
   gas,
-  enabled: paramEnabled = true,
+  // enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,7 +29,8 @@ export const usePollCreate = ({
 }): WriteHook => {
   const chainId = useChainId();
 
-  const enabled = paramEnabled && !!startDate && !!endDate && !!multiHash && !!url;
+  // const enabled = paramEnabled && !!startDate && !!endDate && !!multiHash && !!url;
+  const enabled = false;
 
   return useWriteContractFlow({
     address: pollingOldAddress[chainId],

--- a/modules/polling/hooks/usePollCreate.ts
+++ b/modules/polling/hooks/usePollCreate.ts
@@ -10,6 +10,7 @@ import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from 'modules/web3/hooks/useWriteContractFlow';
 import { pollingOldAbi, pollingOldAddress } from 'modules/contracts/generated';
 import { WriteHook, WriteHookParams } from 'modules/web3/types/hooks';
+import { config } from 'lib/config';
 
 export const usePollCreate = ({
   startDate,
@@ -17,7 +18,7 @@ export const usePollCreate = ({
   multiHash,
   url,
   gas,
-  // enabled: paramEnabled = true,
+  enabled: paramEnabled = true,
   onSuccess,
   onError,
   onStart
@@ -29,8 +30,7 @@ export const usePollCreate = ({
 }): WriteHook => {
   const chainId = useChainId();
 
-  // const enabled = paramEnabled && !!startDate && !!endDate && !!multiHash && !!url;
-  const enabled = false;
+  const enabled = paramEnabled && !!startDate && !!endDate && !!multiHash && !!url && !config.READ_ONLY;
 
   return useWriteContractFlow({
     address: pollingOldAddress[chainId],

--- a/modules/web3/hooks/useApproveUnlimitedToken.ts
+++ b/modules/web3/hooks/useApproveUnlimitedToken.ts
@@ -27,13 +27,16 @@ export const useApproveUnlimitedToken = ({
   const chainId = useChainId();
   const tokenConfig = tokenNameToConfig(name);
 
+  // Only enable token approvals for IOU tokens, used for undelegating and withdrawing MKR
+  const enabled = paramEnabled && (name === 'iou' || name === 'iouOld');
+
   return useWriteContractFlow({
     address: tokenConfig?.address[chainId],
     abi: tokenConfig?.abi,
     functionName: 'approve',
     args: [addressToApprove as `0x${string}`],
     chainId,
-    enabled: paramEnabled,
+    enabled,
     gas,
     onSuccess,
     onError,

--- a/modules/web3/hooks/useApproveUnlimitedToken.ts
+++ b/modules/web3/hooks/useApproveUnlimitedToken.ts
@@ -11,6 +11,7 @@ import { useChainId } from 'wagmi';
 import { useWriteContractFlow } from './useWriteContractFlow';
 import { tokenNameToConfig } from '../helpers/tokenNameToConfig';
 import { WriteHook, WriteHookParams } from '../types/hooks';
+import { config } from 'lib/config';
 
 export const useApproveUnlimitedToken = ({
   name,
@@ -27,8 +28,8 @@ export const useApproveUnlimitedToken = ({
   const chainId = useChainId();
   const tokenConfig = tokenNameToConfig(name);
 
-  // Only enable token approvals for IOU tokens, used for undelegating and withdrawing MKR
-  const enabled = paramEnabled && (name === 'iou' || name === 'iouOld');
+  // If on read-only mode, only enable token approvals for IOU tokens, used for undelegating and withdrawing MKR
+  const enabled = paramEnabled && (config.READ_ONLY ? name === 'iou' || name === 'iouOld' : true);
 
   return useWriteContractFlow({
     address: tokenConfig?.address[chainId],

--- a/next.config.js
+++ b/next.config.js
@@ -53,7 +53,8 @@ const moduleExports = {
   env: {
     INFURA_KEY: process.env.INFURA_KEY || '84842078b09946638c03157f83405213', // ethers default infura key
     ALCHEMY_KEY: process.env.ALCHEMY_KEY || '_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC', // ethers default alchemy key
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    READ_ONLY: process.env.READ_ONLY
   },
 
   // Opt-in SWC minification (next 12.0.2)

--- a/pages/esmodule.tsx
+++ b/pages/esmodule.tsx
@@ -207,6 +207,7 @@ const ESModule = (): React.ReactElement => {
           {totalStaked && account ? (
             <Button
               onClick={() => setShowDialog(true)}
+              disabled={true}
               variant="outline"
               sx={{ color: 'onNotice', borderColor: 'notice' }}
             >

--- a/pages/esmodule.tsx
+++ b/pages/esmodule.tsx
@@ -28,6 +28,7 @@ import { useCageTime } from 'modules/esm/hooks/useCageTime';
 import { useLockedMkr } from 'modules/mkr/hooks/useLockedMkr';
 import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
 import { ExternalLink } from 'modules/app/components/ExternalLink';
+import { config } from 'lib/config';
 
 const ESModule = (): React.ReactElement => {
   const loader = useRef<HTMLDivElement>(null);
@@ -207,7 +208,7 @@ const ESModule = (): React.ReactElement => {
           {totalStaked && account ? (
             <Button
               onClick={() => setShowDialog(true)}
-              disabled={true}
+              disabled={config.READ_ONLY}
               variant="outline"
               sx={{ color: 'onNotice', borderColor: 'notice' }}
             >

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -23,7 +23,7 @@ import Hash from 'ipfs-only-hash';
 import { formatDateWithTime } from 'lib/datetime';
 import { markdownToHtml } from 'lib/markdown';
 import { HeadComponent } from 'modules/app/components/layout/Head';
-import { useAccount } from 'modules/app/hooks/useAccount';
+// import { useAccount } from 'modules/app/hooks/useAccount';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import { ExternalLink } from 'modules/app/components/ExternalLink';
 import { PollMarkdownEditor } from 'modules/polling/components/PollMarkdownEditor';
@@ -66,7 +66,7 @@ const PollingCreate = (): React.ReactElement => {
   const [pollErrors, setPollErrors] = useState<string[]>([]);
   const [contentHtml, setContentHtml] = useState<string>('');
   const [creating, setCreating] = useState(false);
-  const { account } = useAccount();
+  // const { account } = useAccount();
 
   const resetForm = () => {
     setPoll(undefined);
@@ -203,7 +203,8 @@ const PollingCreate = (): React.ReactElement => {
                           variant="primary"
                           data-testid="button-create-poll"
                           onClick={() => setCreating(true)}
-                          disabled={typeof poll === 'undefined' || pollErrors.length > 0 || !account}
+                          // disabled={typeof poll === 'undefined' || pollErrors.length > 0 || !account}
+                          disabled={true}
                         >
                           Create Poll
                         </Button>

--- a/pages/polling/create.tsx
+++ b/pages/polling/create.tsx
@@ -23,10 +23,11 @@ import Hash from 'ipfs-only-hash';
 import { formatDateWithTime } from 'lib/datetime';
 import { markdownToHtml } from 'lib/markdown';
 import { HeadComponent } from 'modules/app/components/layout/Head';
-// import { useAccount } from 'modules/app/hooks/useAccount';
+import { useAccount } from 'modules/app/hooks/useAccount';
 import { InternalLink } from 'modules/app/components/InternalLink';
 import { ExternalLink } from 'modules/app/components/ExternalLink';
 import { PollMarkdownEditor } from 'modules/polling/components/PollMarkdownEditor';
+import { config } from 'lib/config';
 
 const generateIPFSHash = async (data, options) => {
   // options object has the key encoding which defines the encoding type
@@ -66,7 +67,7 @@ const PollingCreate = (): React.ReactElement => {
   const [pollErrors, setPollErrors] = useState<string[]>([]);
   const [contentHtml, setContentHtml] = useState<string>('');
   const [creating, setCreating] = useState(false);
-  // const { account } = useAccount();
+  const { account } = useAccount();
 
   const resetForm = () => {
     setPoll(undefined);
@@ -203,8 +204,12 @@ const PollingCreate = (): React.ReactElement => {
                           variant="primary"
                           data-testid="button-create-poll"
                           onClick={() => setCreating(true)}
-                          // disabled={typeof poll === 'undefined' || pollErrors.length > 0 || !account}
-                          disabled={true}
+                          disabled={
+                            typeof poll === 'undefined' ||
+                            pollErrors.length > 0 ||
+                            !account ||
+                            config.READ_ONLY
+                          }
                         >
                           Create Poll
                         </Button>

--- a/tenderlyTestnetData.json
+++ b/tenderlyTestnetData.json
@@ -1,1 +1,1 @@
-{ "TENDERLY_TESTNET_ID": "", "TENDERLY_RPC_URL": "" }
+{"TENDERLY_TESTNET_ID":"39c0f00a-c075-4be8-98e1-7dfaa7b4340d","TENDERLY_RPC_URL":"https://virtual.mainnet.rpc.tenderly.co/1eae13a2-f58d-49d7-886d-49890f1e61a9"}


### PR DESCRIPTION
TODO:
- [ ] set the `READ_ONLY` env var to `true` in the deployment to disable all contract interactions except for undelegation and chief free

### What does this PR do?
- Add a `READ_ONLY` env var that can be used to determine if contract interactions will be disabled
- Disable all write contract interactions in the web app except for chief free (withdraw MKR), old chief free, delegate free (undelegating) and IOU tokens approval when the `READ_ONLY` env var is set to `true`
- Disable some buttons based on the `READ_ONLY` env var to avoid triggering modals with dead ends

List of interactions disabled:
- Poll creation
- Poll vote (legacy and gasless)
- Token approvals for DAI and MKR (still allowed for IOU and IOU_OLD as those are required for withdrawing)
- Chief lock - MKR deposit (EOA and proxy contract)
- Executive vote (EOA, proxy contract and delegate)
- Delegate contract creation
- Delegate lock
- ESM burn and ESM shutdown

### Steps for testing:
Attempt to perform any of the write contract interactions specified in the disabled list above, you shouldn't be able to do so