### PR TITLE
Disable active wallet button

### DIFF
--- a/modules/app/components/layout/header/AccountSelect.tsx
+++ b/modules/app/components/layout/header/AccountSelect.tsx
@@ -106,8 +106,9 @@ const AccountSelect = (): React.ReactElement => {
         key={connector.id}
         onClick={() => connect({ connector })}
         data-testid={`select-wallet-${connector.id}`}
+        disabled={connectedConnector?.id === connector.id}
       >
-        Select
+        {connectedConnector?.id === connector.id ? 'Connected' : 'Select'}
       </Button>
     </Flex>
   ));


### PR DESCRIPTION
### What does this PR do?
Update AccountSelect component to display 'Connected' when the wallet is selected and disable the button accordingly

### Steps for testing:
Connect to wallet, then go to "change", see that the active wallet button is disabled and reads "Connected"

### Screenshots (if relevant):
![Screenshot 2025-03-25 at 10 51 57 AM](https://github.com/user-attachments/assets/ccd3b21f-e1b7-4f8c-8453-b734d6a88594)
