### PR TITLE
Fix MKRInput set max for large amounts

### DIFF
--- a/modules/mkr/components/MKRInput.tsx
+++ b/modules/mkr/components/MKRInput.tsx
@@ -66,7 +66,8 @@ export function MKRInput({
   const onClickSetMax = () => {
     const val = balance ? balance : 0n;
     onChange(val);
-    setCurrentValueStr(formatValue(val, 'wad', 6));
+    const formattedValue = formatValue(val, 'wad', 6).replace(/,/g, '');
+    setCurrentValueStr(formattedValue);
   };
 
   const errorMax = value !== undefined && value > (balance || 0n);


### PR DESCRIPTION
### What does this PR do?
Fix MKRInput component to remove commas from formatted value before setting current value string

### Steps for testing:
Try to use "Set max" with a number over 999 on the MKRInput component