### PR TITLE
Batch some contract reads

### DIFF
--- a/modules/delegates/helpers/getDelegateContractAddress.ts
+++ b/modules/delegates/helpers/getDelegateContractAddress.ts
@@ -21,18 +21,21 @@ export async function getDelegateContractAddress(
 ): Promise<string | undefined> {
   const publicClient = getPublicClient(chainId);
 
-  const voteDelegateAddress = await publicClient.readContract({
-    address: voteDelegateFactoryAddress[chainId],
-    abi: voteDelegateFactoryAbi,
-    functionName: 'delegates',
-    args: [address as `0x${string}`]
-  });
-
-  const voteDelegateAddressOld = await publicClient.readContract({
-    address: voteDelegateFactoryOldAddress[chainId],
-    abi: voteDelegateFactoryOldAbi,
-    functionName: 'delegates',
-    args: [address as `0x${string}`]
+  const [{ result: voteDelegateAddress }, { result: voteDelegateAddressOld }] = await publicClient.multicall({
+    contracts: [
+      {
+        address: voteDelegateFactoryAddress[chainId],
+        abi: voteDelegateFactoryAbi,
+        functionName: 'delegates',
+        args: [address as `0x${string}`]
+      },
+      {
+        address: voteDelegateFactoryOldAddress[chainId],
+        abi: voteDelegateFactoryOldAbi,
+        functionName: 'delegates',
+        args: [address as `0x${string}`]
+      }
+    ]
   });
 
   return voteDelegateAddressOld !== ZERO_ADDRESS

--- a/modules/wagmi/config/config.default.ts
+++ b/modules/wagmi/config/config.default.ts
@@ -20,7 +20,8 @@ export const tenderly = {
   },
   blockExplorers: {
     default: { name: '', url: '' }
-  }
+  },
+  contracts: mainnet.contracts
 };
 
 const connectors = [


### PR DESCRIPTION
### What does this PR do?
- Add the `multcall3` contract from mainnet to the Tenderly chain config
- Batch some contract reads into a single multicall read to reduce RPC requests
