### PR TITLE
add support for injected browser wallet

### DIFF
--- a/lib/theme/icons.tsx
+++ b/lib/theme/icons.tsx
@@ -1178,6 +1178,7 @@ export const icons = {
     ),
     viewBox: '0 0 20 20'
   },
+  'Browser Wallet': brandIcons.ether_circle_color,
   WalletLink: {
     path: (
       <g>

--- a/modules/wagmi/config/config.default.ts
+++ b/modules/wagmi/config/config.default.ts
@@ -1,7 +1,7 @@
 import { createConfig, createStorage, fallback, http, noopStorage } from 'wagmi';
 import { arbitrum, arbitrumSepolia, mainnet } from 'wagmi/chains';
 import { SupportedChainId } from 'modules/web3/constants/chainID';
-import { coinbaseWallet, metaMask, safe, walletConnect } from 'wagmi/connectors';
+import { coinbaseWallet, metaMask, safe, walletConnect, injected } from 'wagmi/connectors';
 import { createPublicClient } from 'viem';
 
 export const tenderly = {
@@ -25,6 +25,17 @@ export const tenderly = {
 
 const connectors = [
   metaMask(),
+  injected({
+    target() {
+      return {
+        id: 'injected',
+        name: 'Browser Wallet',
+        provider(window) {
+          return window?.ethereum;
+        }
+      };
+    }
+  }),
   walletConnect({
     name: 'Sky Governance Portal',
     projectId: process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID || 'd5c6af7c0680adbaad12f33744ee4413'


### PR DESCRIPTION
### What does this PR do?
- adds an option for generic injected connector to support additional browser wallets like Rabby
