### PR TITLE
SKY: address(0) vote

### DIFF
--- a/modules/contracts/ethers/abis.ts
+++ b/modules/contracts/ethers/abis.ts
@@ -481,3 +481,212 @@ export const dsSpellAbi = [
     type: 'function'
   }
 ] as const;
+
+export const newChiefAbi = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'gov_', type: 'address' },
+      { internalType: 'uint256', name: 'maxYays_', type: 'uint256' },
+      { internalType: 'uint256', name: 'launchThreshold_', type: 'uint256' },
+      { internalType: 'uint256', name: 'liftCooldown_', type: 'uint256' }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: 'bytes32', name: 'slate', type: 'bytes32' },
+      { indexed: false, internalType: 'address[]', name: 'yays', type: 'address[]' }
+    ],
+    name: 'Etch',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: false, internalType: 'uint256', name: 'wad', type: 'uint256' }],
+    name: 'Free',
+    type: 'event'
+  },
+  { anonymous: false, inputs: [], name: 'Launch', type: 'event' },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'address', name: 'whom', type: 'address' }],
+    name: 'Lift',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: false, internalType: 'uint256', name: 'wad', type: 'uint256' }],
+    name: 'Lock',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [{ indexed: true, internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    name: 'Vote',
+    type: 'event'
+  },
+  {
+    inputs: [],
+    name: 'EMPTY_SLATE',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'GOV',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'MAX_YAYS',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'yay', type: 'address' }],
+    name: 'approvals',
+    outputs: [{ internalType: 'uint256', name: 'amt', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'caller', type: 'address' },
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'bytes4', name: '', type: 'bytes4' }
+    ],
+    name: 'canCall',
+    outputs: [{ internalType: 'bool', name: 'ok', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'usr', type: 'address' }],
+    name: 'deposits',
+    outputs: [{ internalType: 'uint256', name: 'amt', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address[]', name: 'yays', type: 'address[]' }],
+    name: 'etch',
+    outputs: [{ internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'wad', type: 'uint256' }],
+    name: 'free',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'gov',
+    outputs: [{ internalType: 'contract GemLike', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'hat',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'last',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  { inputs: [], name: 'launch', outputs: [], stateMutability: 'nonpayable', type: 'function' },
+  {
+    inputs: [],
+    name: 'launchThreshold',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    name: 'length',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'whom', type: 'address' }],
+    name: 'lift',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'liftCooldown',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'live',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'wad', type: 'uint256' }],
+    name: 'lock',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'maxYays',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'bytes32', name: 'slate', type: 'bytes32' },
+      { internalType: 'uint256', name: '', type: 'uint256' }
+    ],
+    name: 'slates',
+    outputs: [{ internalType: 'address', name: 'yays', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    name: 'vote',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address[]', name: 'yays', type: 'address[]' }],
+    name: 'vote',
+    outputs: [{ internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'usr', type: 'address' }],
+    name: 'votes',
+    outputs: [{ internalType: 'bytes32', name: 'slate', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+] as const;

--- a/modules/contracts/generated.ts
+++ b/modules/contracts/generated.ts
@@ -994,6 +994,242 @@ export const mkrAddress = {
 export const mkrConfig = { address: mkrAddress, abi: mkrAbi } as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// newChief
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export const newChiefAbi = [
+  {
+    type: 'constructor',
+    inputs: [
+      { name: 'gov_', internalType: 'address', type: 'address' },
+      { name: 'maxYays_', internalType: 'uint256', type: 'uint256' },
+      { name: 'launchThreshold_', internalType: 'uint256', type: 'uint256' },
+      { name: 'liftCooldown_', internalType: 'uint256', type: 'uint256' }
+    ],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'slate',
+        internalType: 'bytes32',
+        type: 'bytes32',
+        indexed: true
+      },
+      {
+        name: 'yays',
+        internalType: 'address[]',
+        type: 'address[]',
+        indexed: false
+      }
+    ],
+    name: 'Etch'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'wad', internalType: 'uint256', type: 'uint256', indexed: false }],
+    name: 'Free'
+  },
+  { type: 'event', anonymous: false, inputs: [], name: 'Launch' },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'whom', internalType: 'address', type: 'address', indexed: true }],
+    name: 'Lift'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'wad', internalType: 'uint256', type: 'uint256', indexed: false }],
+    name: 'Lock'
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'slate',
+        internalType: 'bytes32',
+        type: 'bytes32',
+        indexed: true
+      }
+    ],
+    name: 'Vote'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'EMPTY_SLATE',
+    outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'GOV',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'MAX_YAYS',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'yay', internalType: 'address', type: 'address' }],
+    name: 'approvals',
+    outputs: [{ name: 'amt', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'caller', internalType: 'address', type: 'address' },
+      { name: '', internalType: 'address', type: 'address' },
+      { name: '', internalType: 'bytes4', type: 'bytes4' }
+    ],
+    name: 'canCall',
+    outputs: [{ name: 'ok', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address' }],
+    name: 'deposits',
+    outputs: [{ name: 'amt', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'yays', internalType: 'address[]', type: 'address[]' }],
+    name: 'etch',
+    outputs: [{ name: 'slate', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'wad', internalType: 'uint256', type: 'uint256' }],
+    name: 'free',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'gov',
+    outputs: [{ name: '', internalType: 'contract GemLike', type: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'hat',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'last',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'launch',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'launchThreshold',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'slate', internalType: 'bytes32', type: 'bytes32' }],
+    name: 'length',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'whom', internalType: 'address', type: 'address' }],
+    name: 'lift',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'liftCooldown',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'live',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'wad', internalType: 'uint256', type: 'uint256' }],
+    name: 'lock',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'maxYays',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'slate', internalType: 'bytes32', type: 'bytes32' },
+      { name: '', internalType: 'uint256', type: 'uint256' }
+    ],
+    name: 'slates',
+    outputs: [{ name: 'yays', internalType: 'address', type: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'slate', internalType: 'bytes32', type: 'bytes32' }],
+    name: 'vote',
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'yays', internalType: 'address[]', type: 'address[]' }],
+    name: 'vote',
+    outputs: [{ name: 'slate', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'usr', internalType: 'address', type: 'address' }],
+    name: 'votes',
+    outputs: [{ name: 'slate', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'view'
+  }
+] as const;
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // pause
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/modules/executive/hooks/useVotedProposals.ts
+++ b/modules/executive/hooks/useVotedProposals.ts
@@ -17,7 +17,7 @@ type VotedProposalsResponse = {
   data: string[];
   loading: boolean;
   error: Error;
-  mutate: any;
+  mutate: () => void;
 };
 
 export const useVotedProposals = (passedAddress?: string): VotedProposalsResponse => {

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -222,7 +222,7 @@ const AccountPage = (): React.ReactElement => {
                     </Button>
                   </Box>
                 )}
-                {!!voteDelegateContractAddress && !votedForAddressZero && !isChiefLive && (
+                {!!voteDelegateContractAddress && (
                   <Box>
                     <Label>Support the Launch of SKY Governance</Label>
                     {txStatus !== TxStatus.IDLE && (
@@ -250,7 +250,12 @@ const AccountPage = (): React.ReactElement => {
                       to your delegate contract will immediately count toward launching the new chief.
                     </Alert>
                     <Button
-                      disabled={addressZeroVote.isLoading || !addressZeroVote.prepared}
+                      disabled={
+                        addressZeroVote.isLoading ||
+                        !addressZeroVote.prepared ||
+                        votedForAddressZero ||
+                        isChiefLive
+                      }
                       onClick={() => {
                         setTxStatus(TxStatus.INITIALIZED);
                         setModalOpen(true);
@@ -261,6 +266,12 @@ const AccountPage = (): React.ReactElement => {
                     >
                       Support address(0)
                     </Button>
+                    {votedForAddressZero && (
+                      <Text as="p" sx={{ mt: 2 }}>
+                        You are supporting address(0). Thank you for contributing to the launch of SKY
+                        governance.
+                      </Text>
+                    )}
                   </Box>
                 )}
                 {chiefBalance && chiefBalance > 0n && (

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -37,7 +37,7 @@ import { useDelegateVote } from 'modules/executive/hooks/useDelegateVote';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { useVotedProposals } from 'modules/executive/hooks/useVotedProposals';
 import { useReadContract } from 'wagmi';
-import { chiefAbi, chiefAddress } from 'modules/contracts/generated';
+import { chiefAddress, newChiefAbi } from 'modules/contracts/generated';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 
 const AccountPage = (): React.ReactElement => {
@@ -55,7 +55,7 @@ const AccountPage = (): React.ReactElement => {
 
   const { data: live } = useReadContract({
     address: chiefAddress[chainId],
-    abi: chiefAbi,
+    abi: newChiefAbi,
     chainId,
     functionName: 'live',
     scopeKey: `chief-live-${chainId}`

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -33,9 +33,16 @@ import EtherscanLink from 'modules/web3/components/EtherscanLink';
 import { DialogContent, DialogOverlay } from 'modules/app/components/Dialog';
 import { useNetwork } from 'modules/app/hooks/useNetwork';
 import { TxStatus } from 'modules/web3/constants/transaction';
+import { useDelegateVote } from 'modules/executive/hooks/useDelegateVote';
+import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
+import { useVotedProposals } from 'modules/executive/hooks/useVotedProposals';
+import { useReadContract } from 'wagmi';
+import { chiefAbi, chiefAddress } from 'modules/contracts/generated';
+import { networkNameToChainId } from 'modules/web3/helpers/chain';
 
 const AccountPage = (): React.ReactElement => {
   const network = useNetwork();
+  const chainId = networkNameToChainId(network);
   const { account, mutate: mutateAccount, voteDelegateContractAddress, votingAccount } = useAccount();
 
   const { data: addressInfo, error: errorLoadingAddressInfo } = useAddressInfo(votingAccount, network);
@@ -45,6 +52,19 @@ const AccountPage = (): React.ReactElement => {
   const [warningRead, setWarningRead] = useState(false);
   const [txStatus, setTxStatus] = useState<TxStatus>(TxStatus.IDLE);
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>();
+
+  const { data: live } = useReadContract({
+    address: chiefAddress[chainId],
+    abi: chiefAbi,
+    chainId,
+    functionName: 'live',
+    scopeKey: `chief-live-${chainId}`
+  });
+  const isChiefLive = live === 1n;
+
+  const { data: votedProposals, mutate: mutateVotedProposals } =
+    useVotedProposals(voteDelegateContractAddress);
+  const votedForAddressZero = votedProposals.includes(ZERO_ADDRESS);
 
   const createDelegate = useDelegateCreate({
     onStart: (hash: `0x${string}`) => {
@@ -60,6 +80,24 @@ const AccountPage = (): React.ReactElement => {
     onError: () => {
       setTxStatus(TxStatus.ERROR);
     }
+  });
+
+  const addressZeroVote = useDelegateVote({
+    slateOrProposals: [ZERO_ADDRESS],
+    onStart: (hash: `0x${string}`) => {
+      setTxHash(hash);
+      setTxStatus(TxStatus.LOADING);
+    },
+    onSuccess: (hash: `0x${string}`) => {
+      setTxHash(hash);
+      setTxStatus(TxStatus.SUCCESS);
+      mutateVotedProposals();
+      setModalOpen(false);
+    },
+    onError: () => {
+      setTxStatus(TxStatus.ERROR);
+    },
+    enabled: !!voteDelegateContractAddress && !votedForAddressZero && !isChiefLive
   });
 
   return (
@@ -183,6 +221,47 @@ const AccountPage = (): React.ReactElement => {
                       data-testid="create-button"
                     >
                       Create delegate contract
+                    </Button>
+                  </Box>
+                )}
+                {!!voteDelegateContractAddress && !votedForAddressZero && !isChiefLive && (
+                  <Box>
+                    <Label>Support the Launch of SKY Governance</Label>
+                    {txStatus !== TxStatus.IDLE && (
+                      <DialogOverlay
+                        isOpen={modalOpen}
+                        onDismiss={() => {
+                          setModalOpen(false);
+                        }}
+                      >
+                        <DialogContent ariaLabel="Vote for address(0) modal" widthDesktop="580px">
+                          <TxDisplay
+                            txStatus={txStatus}
+                            setTxStatus={setTxStatus}
+                            txHash={txHash}
+                            setTxHash={setTxHash}
+                            onDismiss={() => {
+                              setModalOpen(false);
+                            }}
+                          />
+                        </DialogContent>
+                      </DialogOverlay>
+                    )}
+                    <Alert variant="notice" sx={{ mt: 2, flexDirection: 'column', alignItems: 'flex-start' }}>
+                      Voting for address(0) now, even with 0 SKY delegated, ensures that any future delegation
+                      to your delegate contract will immediately count toward launching the new chief.
+                    </Alert>
+                    <Button
+                      disabled={addressZeroVote.isLoading || !addressZeroVote.prepared}
+                      onClick={() => {
+                        setTxStatus(TxStatus.INITIALIZED);
+                        setModalOpen(true);
+                        addressZeroVote.execute();
+                      }}
+                      sx={{ mt: 3, mb: 1 }}
+                      data-testid="vote-button"
+                    >
+                      Support address(0)
                     </Button>
                   </Box>
                 )}

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -75,7 +75,6 @@ const AccountPage = (): React.ReactElement => {
       setTxHash(hash);
       setTxStatus(TxStatus.SUCCESS);
       mutateAccount?.();
-      setModalOpen(false);
     },
     onError: () => {
       setTxStatus(TxStatus.ERROR);
@@ -92,7 +91,6 @@ const AccountPage = (): React.ReactElement => {
       setTxHash(hash);
       setTxStatus(TxStatus.SUCCESS);
       mutateVotedProposals();
-      setModalOpen(false);
     },
     onError: () => {
       setTxStatus(TxStatus.ERROR);

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -222,7 +222,7 @@ const AccountPage = (): React.ReactElement => {
                     </Button>
                   </Box>
                 )}
-                {!!voteDelegateContractAddress && (
+                {!!voteDelegateContractAddress && !isChiefLive && (
                   <Box>
                     <Label>Support the Launch of SKY Governance</Label>
                     {txStatus !== TxStatus.IDLE && (

--- a/wagmi.config.ts
+++ b/wagmi.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, loadEnv } from '@wagmi/cli';
 import { etherscan } from '@wagmi/cli/plugins';
 import { arbitrum, mainnet } from 'wagmi/chains';
 import { contracts, arbitrumContracts } from './modules/contracts/contracts';
-import { dsSpellAbi, voteDelegateAbi } from './modules/contracts/ethers/abis';
+import { dsSpellAbi, newChiefAbi, voteDelegateAbi } from './modules/contracts/ethers/abis';
 
 export default defineConfig(() => {
   const env = loadEnv({
@@ -20,6 +20,10 @@ export default defineConfig(() => {
       {
         name: 'dsSpell',
         abi: dsSpellAbi
+      },
+      {
+        name: 'newChief',
+        abi: newChiefAbi
       }
     ],
     plugins: [


### PR DESCRIPTION
### What does this PR do?
- Add logic for delegates to vote for address(0) after they create their delegate contract, while the chief contract is not `live`
- Add copy and UI elements to handle the address(0) voting and states

Video of the flow (it was too large to paste in GitHub):
https://discord.com/channels/836646301986848768/850083386260324382/1357446818895626322

