### PR TITLE
Add loading indicator for proposal page, prevent 404 showing prematurely

### DIFF
--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -407,6 +407,17 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
   );
 };
 
+const LoadingIndicator = () => (
+  <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
+    <Flex sx={{ justifyContent: 'center', alignItems: 'center', minHeight: '300px' }}>
+      <Spinner size={48} />{' '}
+      <Text ml={3} sx={{ fontSize: 4 }}>
+        Loading proposal...
+      </Text>
+    </Flex>
+  </PrimaryLayout>
+);
+
 // HOC to fetch the proposal depending on the network
 export default function ProposalPage({
   proposal: prefetchedProposal
@@ -417,7 +428,8 @@ export default function ProposalPage({
 }): JSX.Element {
   const [_proposal, _setProposal] = useState<Proposal>();
   const [error, setError] = useState<string>();
-  const { query } = useRouter();
+  const router = useRouter();
+  const { query } = router;
   const network = useNetwork();
 
   /**Disabling spell-effects until multi-transactions endpoint is ready */
@@ -444,6 +456,12 @@ export default function ProposalPage({
     }
   }, [query['proposal-id'], network]);
 
+  // Check for fallback state first
+  if (router.isFallback) {
+    return <LoadingIndicator />;
+  }
+
+  // Now check for actual errors or missing proposals AFTER fallback is resolved
   if (error || (isDefaultNetwork(network) && !prefetchedProposal?.key)) {
     return (
       <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
@@ -455,12 +473,10 @@ export default function ProposalPage({
     );
   }
 
-  if (!isDefaultNetwork(network) && !_proposal)
-    return (
-      <PrimaryLayout sx={{ maxWidth: 'dashboard' }}>
-        <p>Loading…</p>
-      </PrimaryLayout>
-    );
+  // Loading check for non-default networks
+  if (!isDefaultNetwork(network) && !_proposal) {
+    return <LoadingIndicator />;
+  }
 
   const proposal = isDefaultNetwork(network) ? prefetchedProposal : _proposal;
   // const spellDiffs = prefetchedSpellDiffs.length > 0 ? prefetchedSpellDiffs : diffs;


### PR DESCRIPTION
### What does this PR do?

Fixes the loading state for a proposal that isn't prebuilt by not immediately showing a 404 

### Steps for testing:
Load a proposal, such as `/executive/0x6D89a389C59113a9DA17f094c9b8772A97854593` and see that it shows loading state rather than a 404 while it fetches the spell data.

### Screenshots (if relevant):
Before:
![Screenshot 2025-04-04 at 1 26 54 PM](https://github.com/user-attachments/assets/47883d1c-f3fa-4869-b9a8-07961ecc721c)

After:
![Screenshot 2025-04-04 at 1 22 46 PM](https://github.com/user-attachments/assets/f9dc6db3-0093-437c-acdd-4c49fd6d6102)

