### PR TITLE
Fix metadata bugs

### DIFF
--- a/modules/delegates/api/fetchDelegates.ts
+++ b/modules/delegates/api/fetchDelegates.ts
@@ -261,8 +261,10 @@ export async function fetchDelegatesPaginated({
   ]);
 
   let combinedDelegates = [
-    ...(delegatesQueryRes.alignedDelegates || []),
-    ...(delegatesQueryRes.delegates || [])
+    // Include aligned delegates if the filter doesn't specify to only show shadow delegates
+    ...((delegateType !== DelegateTypeEnum.SHADOW && delegatesQueryRes.alignedDelegates) || []),
+    // Include shadow delegates if the filter doesn't specify to only show aligned delegates
+    ...((delegateType !== DelegateTypeEnum.ALIGNED && delegatesQueryRes.delegates) || [])
   ];
 
   const combinedDelegateOwnerAddresses = combinedDelegates.map(delegate =>

--- a/modules/delegates/components/DelegateMKRDelegatedStats.tsx
+++ b/modules/delegates/components/DelegateMKRDelegatedStats.tsx
@@ -6,14 +6,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
-import { Box, Flex } from 'theme-ui';
-import Icon from 'modules/app/components/Icon';
+import { Flex } from 'theme-ui';
 import { useMkrDelegatedByUser } from 'modules/mkr/hooks/useMkrDelegatedByUser';
 import { Delegate } from 'modules/delegates/types';
 import { StatBox } from 'modules/app/components/StatBox';
 import { useAccount } from 'modules/app/hooks/useAccount';
 import { formatValue } from 'lib/string';
-import Tooltip from 'modules/app/components/Tooltip';
 import { useSkyVotingWeight } from 'modules/mkr/hooks/useSkyVotingWeight';
 import Skeleton from 'react-loading-skeleton';
 
@@ -29,7 +27,9 @@ export function DelegateMKRDelegatedStats({
 
   const { data: mkrDelegatedData } = useMkrDelegatedByUser(account, delegate.voteDelegateAddress);
   const totalMkrDelegated = mkrDelegatedData?.totalDelegationAmount;
-  const { data: votingWeight } = useSkyVotingWeight({ address: delegate.voteDelegateAddress });
+  const { data: votingWeight, loading: votingWeightLoading } = useSkyVotingWeight({
+    address: delegate.voteDelegateAddress
+  });
 
   return (
     <Flex
@@ -43,9 +43,9 @@ export function DelegateMKRDelegatedStats({
     >
       <StatBox
         value={
-          !votingWeight ? (
+          votingWeightLoading ? (
             <Skeleton width="100%" height="15px" />
-          ) : votingWeight ? (
+          ) : typeof votingWeight !== 'undefined' ? (
             formatValue(votingWeight)
           ) : (
             'Untracked'

--- a/modules/gql/hooks/useLandingPageDelegates.ts
+++ b/modules/gql/hooks/useLandingPageDelegates.ts
@@ -13,7 +13,7 @@ import { useNetwork } from 'modules/app/hooks/useNetwork';
 import {
   DelegateOrderByEnum,
   OrderDirectionEnum,
-  DelegateStatusEnum
+  DelegateTypeEnum
 } from 'modules/delegates/delegates.constants';
 
 export const useLandingPageDelegates = (): [
@@ -22,7 +22,7 @@ export const useLandingPageDelegates = (): [
 ] => {
   const network = useNetwork();
   const { cache } = useSWRConfig();
-  const delegatesDataKey = `/api/delegates/v2?network=${network}&delegateType=${DelegateStatusEnum.aligned}&orderBy=${DelegateOrderByEnum.MKR}&orderDirection=${OrderDirectionEnum.DESC}&pageSize=0`;
+  const delegatesDataKey = `/api/delegates/v2?network=${network}&delegateType=${DelegateTypeEnum.ALIGNED}&orderBy=${DelegateOrderByEnum.MKR}&orderDirection=${OrderDirectionEnum.DESC}&pageSize=0`;
   const delegatesInfoDataKey = `/api/delegates/info?network=${network}`;
 
   const swrConfigObject = {

--- a/modules/home/api/fetchLandingPageData.ts
+++ b/modules/home/api/fetchLandingPageData.ts
@@ -28,6 +28,7 @@ export type LandingPageData = {
   pollTags: TagCount[];
   delegates: DelegatePaginated[];
   delegatesInfo: DelegateInfo[];
+  delegatesError: Error | null;
   stats?: DelegatesAPIStats;
   mkrOnHat?: string;
   hat?: string;

--- a/modules/mkr/hooks/useSkyVotingWeight.ts
+++ b/modules/mkr/hooks/useSkyVotingWeight.ts
@@ -44,7 +44,7 @@ export const useSkyVotingWeight = ({
 
   return {
     data,
-    loading: !error && !data,
+    loading: !error && data === undefined,
     error,
     mutate
   };

--- a/modules/polling/api/getPollTags.ts
+++ b/modules/polling/api/getPollTags.ts
@@ -25,7 +25,7 @@ export async function getPollTagsMapping(): Promise<{ [key: number]: string[] }>
     }
 
     const urlPollTags =
-      'https://raw.githubusercontent.com/makerdao/community/master/governance/polls/meta/poll-tags.json';
+      'https://raw.githubusercontent.com/jetstreamgg/gov-metadata/refs/heads/main/polls/meta/poll-tags.json';
     const pollTags = await fetch(urlPollTags);
     const dataPollTags = await pollTags.json();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,6 +50,7 @@ const LandingPage = ({
   pollTags,
   delegates,
   delegatesInfo,
+  delegatesError,
   stats,
   mkrOnHat,
   hat,
@@ -127,7 +128,7 @@ const LandingPage = ({
 
   return (
     <div>
-      {delegates.length === 0 && delegatesInfo.length === 0 && polls.length === 0 && (
+      {delegatesError && (
         <Alert variant="warning">
           <Text>There is a problem loading the governance data. Please, try again later.</Text>
         </Alert>
@@ -318,6 +319,7 @@ export default function Index({
     pollTags: isDefaultNetwork(network) ? prefetchedPollTags : data?.pollTags || [],
     delegates: delegatesData.data?.delegates?.slice(0, 5) ?? [],
     delegatesInfo: delegatesInfo.data ?? [],
+    delegatesError: delegatesData.error || delegatesInfo.error,
     stats: delegatesData.data?.stats,
     mkrOnHat: isDefaultNetwork(network) ? prefetchedMkrOnHat : data?.mkrOnHat ?? undefined,
     hat: isDefaultNetwork(network) ? prefetchedHat : data?.hat ?? undefined,

--- a/scripts/fetchTags.mjs
+++ b/scripts/fetchTags.mjs
@@ -17,7 +17,7 @@ async function main() {
 
     // poll-tags mapping
     const urlPollTags =
-      'https://raw.githubusercontent.com/makerdao/community/master/governance/polls/meta/poll-tags.json';
+      'https://raw.githubusercontent.com/jetstreamgg/gov-metadata/refs/heads/main/polls/meta/poll-tags.json';
     const pollTags = await fetch(urlPollTags);
     const dataPollTags = await pollTags.json();
     fs.writeFileSync(
@@ -29,7 +29,7 @@ async function main() {
 
     //poll tags
     const urlTags =
-      'https://raw.githubusercontent.com/makerdao/community/master/governance/polls/meta/tags.json';
+      'https://raw.githubusercontent.com/jetstreamgg/gov-metadata/refs/heads/main/polls/meta/tags.json';
     const tags = await fetch(urlTags);
     const dataTags = await tags.json();
     fs.writeFileSync(


### PR DESCRIPTION
### What does this PR do?
- Update Github URL for fetching poll tags to use the new metadata repo
- Update poll fetching logic to first fetch the polls, then the poll tag mapping and then attach the poll tags to the corresponding poll (previously the tags were coming along the poll from the aggregated file)
- Fix a delegate fetching bug that was displaying one shadow delegate when you query for only aligned delegates
- Update logic to display error message in the landing page to only be shown when there is an actual error fetching delegates, and not be displayed whenever the arrays are empty (which is the initial state when loading the page)
- Update a couple of places that were rendering an skeleton when the data was actually 0 (falsey value)
