### PR TITLE
Add prepareError prop to ConfirmContent and related modals

### DIFF
--- a/modules/delegates/components/modals/Confirm.tsx
+++ b/modules/delegates/components/modals/Confirm.tsx
@@ -18,9 +18,17 @@ type Props = {
   onClick: () => void;
   disabled: boolean;
   onBack: () => void;
+  prepareError?: Error | null;
 };
 
-export const ConfirmContent = ({ skyToDeposit, delegate, onClick, disabled, onBack }: Props): JSX.Element => {
+export const ConfirmContent = ({
+  skyToDeposit,
+  delegate,
+  onClick,
+  disabled,
+  onBack,
+  prepareError
+}: Props): JSX.Element => {
   const { address, voteDelegateAddress } = delegate;
   const network = useNetwork();
 
@@ -57,6 +65,12 @@ export const ConfirmContent = ({ skyToDeposit, delegate, onClick, disabled, onBa
       <Button onClick={onBack} variant="textual" sx={{ color: 'secondary', fontSize: 2, mt: 1 }}>
         Back
       </Button>
+      {prepareError && (
+        <Text variant="smallText" sx={{ color: 'error', mt: 3 }}>
+          Something went wrong preparing the transaction. Please try again or contact support if the issue
+          persists.
+        </Text>
+      )}
     </Flex>
   );
 };

--- a/modules/delegates/components/modals/DelegateModal.tsx
+++ b/modules/delegates/components/modals/DelegateModal.tsx
@@ -153,6 +153,7 @@ export const DelegateModal = ({
                           !lock.prepared
                         }
                         onBack={() => setConfirmStep(false)}
+                        prepareError={lock.prepareError}
                       />
                     ) : (
                       <InputDelegateSky

--- a/modules/delegates/components/modals/InputDelegateSky.tsx
+++ b/modules/delegates/components/modals/InputDelegateSky.tsx
@@ -25,6 +25,7 @@ type Props = {
   onClick: () => void;
   disabled?: boolean;
   showAlert: boolean;
+  prepareError?: Error | null;
 };
 
 export function InputDelegateSky({
@@ -36,7 +37,8 @@ export function InputDelegateSky({
   onClick,
   disabled = false,
   showAlert,
-  disclaimer
+  disclaimer,
+  prepareError
 }: Props): React.ReactElement {
   const [value, setValue] = useState(0n);
   const { account } = useAccount();
@@ -65,6 +67,12 @@ export function InputDelegateSky({
         </Button>
         {disclaimer}
       </Box>
+      {prepareError && (
+        <Text variant="smallText" sx={{ color: 'error', mt: 3 }}>
+          Something went wrong preparing the transaction. Please try again or contact support if the issue
+          persists.
+        </Text>
+      )}
       {showAlert && lockedSky && lockedSky >= parseEther('0.1') && balance && balance > 0n && (
         <Alert variant="notice" sx={{ fontWeight: 'normal' }}>
           <Text>

--- a/modules/delegates/components/modals/UndelegateModal.tsx
+++ b/modules/delegates/components/modals/UndelegateModal.tsx
@@ -108,6 +108,7 @@ export const UndelegateModal = ({
                     }}
                     disabled={free.isLoading || !free.prepared}
                     showAlert={false}
+                    prepareError={free.prepareError}
                     disclaimer={
                       sealDelegated && sealDelegated > 0n ? (
                         <Text variant="smallText" sx={{ color: 'secondaryEmphasis', mt: 3 }}>


### PR DESCRIPTION
Enhance the ConfirmContent component to accept a prepareError prop, allowing for error handling during transaction preparation. Update DelegateModal and UndelegateModal to pass the prepareError state, improving user feedback in case of errors.

![Screenshot 2025-04-22 at 9 24 37 AM](https://github.com/user-attachments/assets/31ed1dc3-d17c-462e-9edb-e4aaa93f80e3)
