### PR TITLE
Update liquidity sidebar to also account for SKY

### DIFF
--- a/modules/web3/constants/conversions.ts
+++ b/modules/web3/constants/conversions.ts
@@ -1,0 +1,1 @@
+export const MKR_TO_SKY_PRICE_RATIO = 24000n;

--- a/pages/executive.tsx
+++ b/pages/executive.tsx
@@ -20,7 +20,7 @@ import { useMkrOnHat } from 'modules/executive/hooks/useMkrOnHat';
 import ProposalsSortBy from 'modules/executive/components/ProposalsSortBy';
 import DateFilter from 'modules/executive/components/DateFilter';
 import SystemStatsSidebar from 'modules/app/components/SystemStatsSidebar';
-import MkrLiquiditySidebar from 'modules/mkr/components/MkrLiquiditySidebar';
+import MkrSkyLiquiditySidebar from 'modules/mkr/components/MkrSkyLiquiditySidebar';
 import ResourceBox from 'modules/app/components/ResourceBox';
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import ExecutiveOverviewCard from 'modules/executive/components/ExecutiveOverviewCard';
@@ -328,7 +328,7 @@ export const ExecutiveOverview = ({ proposals }: { proposals?: Proposal[] }): JS
               />
             </ErrorBoundary>
             <ErrorBoundary componentName="MKR Liquidity">
-              <MkrLiquiditySidebar network={network} />
+              <MkrSkyLiquiditySidebar network={network} />
             </ErrorBoundary>
             <ResourceBox type={'executive'} />
             <ResourceBox type={'general'} />


### PR DESCRIPTION
TODO:
- [ ] Do we need to fetch from any other sources? The remaining sources in the sidebar don't seem to have SKY liquidity (Aave, Balancer, Sushi, Compound)

### What does this PR do?
- Add the Uniswap pools with the most SKY liquidity
- Include SKY liquidity sources in the sidebar
- Redenominate total in terms of SKY as that is the token used in the app now

![image](https://github.com/user-attachments/assets/70f37731-c2ae-463e-8e4a-319c6f9996e4)
