### PR TITLE
Truncate some large numbers

### DIFF
--- a/lib/string.ts
+++ b/lib/string.ts
@@ -23,30 +23,30 @@ export function formatValue(
   dp = 2,
   withCommas = true,
   roundDown = false,
-  truncateLarge = false
+  truncateThreshold?: number
 ): string {
   if (typeof type === 'string') {
     switch (type) {
       case 'ray':
-        return formatValue(value, 27, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 27, dp, withCommas, roundDown, truncateThreshold);
       case 'rad':
-        return formatValue(value, 45, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 45, dp, withCommas, roundDown, truncateThreshold);
       case 'wei':
-        return formatValue(value, 0, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 0, dp, withCommas, roundDown, truncateThreshold);
       case 'kwei':
-        return formatValue(value, 3, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 3, dp, withCommas, roundDown, truncateThreshold);
       case 'mwei':
-        return formatValue(value, 6, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 6, dp, withCommas, roundDown, truncateThreshold);
       case 'gwei':
-        return formatValue(value, 9, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 9, dp, withCommas, roundDown, truncateThreshold);
       case 'szabo':
-        return formatValue(value, 12, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 12, dp, withCommas, roundDown, truncateThreshold);
       case 'finney':
-        return formatValue(value, 15, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 15, dp, withCommas, roundDown, truncateThreshold);
       case 'ether':
       case 'wad':
       default:
-        return formatValue(value, 18, dp, withCommas, roundDown, truncateLarge);
+        return formatValue(value, 18, dp, withCommas, roundDown, truncateThreshold);
     }
   }
 
@@ -58,8 +58,13 @@ export function formatValue(
   const fixed = dp || dp === 0 ? (+formatted).toFixed(dp) : formatted;
   if (+fixed < 0.01 && roundDown) return '≈0.00';
   
-  if (truncateLarge && +fixed >= 1e9) {
-    return (+fixed / 1e9).toFixed(2) + 'B';
+  if (truncateThreshold && +fixed >= truncateThreshold) {
+    //truncate the number to the nearest thousand, million, billion, or trillion
+    //and remove any trailing zeros
+    if (+fixed >= 1e12) return (+fixed / 1e12).toFixed(2).replace(/\.?0+$/, '') + 'T';
+    if (+fixed >= 1e9) return (+fixed / 1e9).toFixed(2).replace(/\.?0+$/, '') + 'B';
+    if (+fixed >= 1e6) return (+fixed / 1e6).toFixed(2).replace(/\.?0+$/, '') + 'M';
+    if (+fixed >= 1e3) return (+fixed / 1e3).toFixed(2).replace(/\.?0+$/, '') + 'K';
   }
   
   const finished = withCommas ? (+fixed).toLocaleString(undefined, { maximumFractionDigits: dp }) : fixed;

--- a/lib/string.ts
+++ b/lib/string.ts
@@ -22,30 +22,31 @@ export function formatValue(
   type: string | number = 'wad',
   dp = 2,
   withCommas = true,
-  roundDown = false
+  roundDown = false,
+  truncateLarge = false
 ): string {
   if (typeof type === 'string') {
     switch (type) {
       case 'ray':
-        return formatValue(value, 27, dp, withCommas, roundDown);
+        return formatValue(value, 27, dp, withCommas, roundDown, truncateLarge);
       case 'rad':
-        return formatValue(value, 45, dp, withCommas, roundDown);
+        return formatValue(value, 45, dp, withCommas, roundDown, truncateLarge);
       case 'wei':
-        return formatValue(value, 0, dp, withCommas, roundDown);
+        return formatValue(value, 0, dp, withCommas, roundDown, truncateLarge);
       case 'kwei':
-        return formatValue(value, 3, dp, withCommas, roundDown);
+        return formatValue(value, 3, dp, withCommas, roundDown, truncateLarge);
       case 'mwei':
-        return formatValue(value, 6, dp, withCommas, roundDown);
+        return formatValue(value, 6, dp, withCommas, roundDown, truncateLarge);
       case 'gwei':
-        return formatValue(value, 9, dp, withCommas, roundDown);
+        return formatValue(value, 9, dp, withCommas, roundDown, truncateLarge);
       case 'szabo':
-        return formatValue(value, 12, dp, withCommas, roundDown);
+        return formatValue(value, 12, dp, withCommas, roundDown, truncateLarge);
       case 'finney':
-        return formatValue(value, 15, dp, withCommas, roundDown);
+        return formatValue(value, 15, dp, withCommas, roundDown, truncateLarge);
       case 'ether':
       case 'wad':
       default:
-        return formatValue(value, 18, dp, withCommas, roundDown);
+        return formatValue(value, 18, dp, withCommas, roundDown, truncateLarge);
     }
   }
 
@@ -56,6 +57,11 @@ export function formatValue(
   if (+formatted > 999) dp = 0;
   const fixed = dp || dp === 0 ? (+formatted).toFixed(dp) : formatted;
   if (+fixed < 0.01 && roundDown) return '≈0.00';
+  
+  if (truncateLarge && +fixed >= 1e9) {
+    return (+fixed / 1e9).toFixed(2) + 'B';
+  }
+  
   const finished = withCommas ? (+fixed).toLocaleString(undefined, { maximumFractionDigits: dp }) : fixed;
   return finished;
 }

--- a/modules/delegates/components/DelegateMKRChart.tsx
+++ b/modules/delegates/components/DelegateMKRChart.tsx
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { Box, Text, Flex, useThemeUI } from 'theme-ui';
 import { Delegate } from '../types';
 import { MenuItem } from '@reach/menu-button';
+import { formatValue } from 'lib/string';
 
 import {
   CartesianGrid,
@@ -73,7 +74,7 @@ export function DelegateMKRChart({ delegate }: { delegate: Delegate }): React.Re
       <Box>
         {monthMKR && <Text as="p">{formatXAxis(monthMKR.date)}</Text>}
         <Text as="p">
-          SKY Weight: {(monthMKR?.MKR || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}
+          SKY Weight: {formatValue(BigInt(monthMKR?.MKR || 0), 0, 2, true, false, 1e6)}
         </Text>
       </Box>
     );
@@ -88,7 +89,7 @@ export function DelegateMKRChart({ delegate }: { delegate: Delegate }): React.Re
   };
 
   const formatYAxis = tickItem => {
-    return tickItem.toLocaleString();
+    return formatValue(BigInt(tickItem), 0, 2, true, false, 1e6);
   };
 
   return (

--- a/modules/home/api/fetchLandingPageData.ts
+++ b/modules/home/api/fetchLandingPageData.ts
@@ -80,8 +80,8 @@ export async function fetchLandingPageData(
     polls: pollsData ? (pollsData as PollsPaginatedResponse).polls : [],
     pollStats: pollsData ? (pollsData as PollsPaginatedResponse).stats : { active: 0, finished: 0, total: 0 },
     pollTags: pollsData ? (pollsData as PollsPaginatedResponse).tags : [],
-    mkrOnHat: mkrOnHatResponse ? formatValue((mkrOnHatResponse as MkrOnHatResponse).mkrOnHat, 'wad', 2, true, false, true) : undefined,
+    mkrOnHat: mkrOnHatResponse ? formatValue((mkrOnHatResponse as MkrOnHatResponse).mkrOnHat, 'wad', 2, true, false, 1e9) : undefined,
     hat: mkrOnHatResponse ? (mkrOnHatResponse as MkrOnHatResponse).hat : undefined,
-    mkrInChief: mkrInChief === 0n || mkrInChief ? formatValue(mkrInChief as bigint, 'wad', 2, true, false, true) : undefined
+    mkrInChief: mkrInChief === 0n || mkrInChief ? formatValue(mkrInChief as bigint, 'wad', 2, true, false, 1e9) : undefined
   };
 }

--- a/modules/home/api/fetchLandingPageData.ts
+++ b/modules/home/api/fetchLandingPageData.ts
@@ -80,8 +80,8 @@ export async function fetchLandingPageData(
     polls: pollsData ? (pollsData as PollsPaginatedResponse).polls : [],
     pollStats: pollsData ? (pollsData as PollsPaginatedResponse).stats : { active: 0, finished: 0, total: 0 },
     pollTags: pollsData ? (pollsData as PollsPaginatedResponse).tags : [],
-    mkrOnHat: mkrOnHatResponse ? formatValue((mkrOnHatResponse as MkrOnHatResponse).mkrOnHat) : undefined,
+    mkrOnHat: mkrOnHatResponse ? formatValue((mkrOnHatResponse as MkrOnHatResponse).mkrOnHat, 'wad', 2, true, false, true) : undefined,
     hat: mkrOnHatResponse ? (mkrOnHatResponse as MkrOnHatResponse).hat : undefined,
-    mkrInChief: mkrInChief === 0n || mkrInChief ? formatValue(mkrInChief as bigint) : undefined
+    mkrInChief: mkrInChief === 0n || mkrInChief ? formatValue(mkrInChief as bigint, 'wad', 2, true, false, true) : undefined
   };
 }

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -40,7 +40,7 @@ export function GovernanceStats({ pollStats, stats, mkrOnHat, mkrInChief }: Prop
     {
       title: 'SKY Delegated',
       value: stats ? (
-        `${formatValue(BigInt(stats.totalMKRDelegated), 0, 2, true, false, true)} SKY`
+        `${formatValue(BigInt(stats.totalMKRDelegated), 0, 2, true, false, 1e9)} SKY`
       ) : (
         <Skeleton />
       )

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -10,6 +10,7 @@ import Skeleton from 'modules/app/components/SkeletonThemed';
 import { Stats } from 'modules/home/components/Stats';
 import { DelegatesAPIStats } from 'modules/delegates/types';
 import { PollsResponse } from 'modules/polling/types/pollsResponse';
+import { formatValue } from 'lib/string';
 
 type Props = {
   pollStats: PollsResponse['stats'];
@@ -39,7 +40,7 @@ export function GovernanceStats({ pollStats, stats, mkrOnHat, mkrInChief }: Prop
     {
       title: 'SKY Delegated',
       value: stats ? (
-        `${stats.totalMKRDelegated.toLocaleString(undefined, { maximumFractionDigits: 0 })} SKY`
+        `${formatValue(BigInt(stats.totalMKRDelegated), 0, 2, true, false, true)} SKY`
       ) : (
         <Skeleton />
       )


### PR DESCRIPTION
Truncate numbers greater than 1B on the homepage governance stats, and also numbers greater than 1 million on the delegate chart

<img width="1285" alt="Screenshot 2025-04-29 at 6 54 45 PM" src="https://github.com/user-attachments/assets/a77fc655-c3ef-44bc-bd79-8dcf80d14775" />

<img width="700" alt="Screenshot 2025-04-29 at 7 09 54 PM" src="https://github.com/user-attachments/assets/3600324f-23fc-4bbd-bfd8-e54eca5cff23" />

