### PR TITLE
remove parts of participation section for now

### DIFF
--- a/modules/home/components/Participation.tsx
+++ b/modules/home/components/Participation.tsx
@@ -9,16 +9,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { Text, Image, Flex, Heading, Container, Link as ExternalLink, Card } from 'theme-ui';
 import Stack from 'modules/app/components/layout/layouts/Stack';
 import { ViewMore } from './ViewMore';
-import useSWR from 'swr';
-import { format, sub } from 'date-fns';
-import ParticipationChart from './ParticipationChart';
 import forumPosts from '../data/forumPosts.json';
 import { DelegateInfo, DelegatePaginated } from 'modules/delegates/types';
-import SkeletonThemed from 'modules/app/components/SkeletonThemed';
-import { AllLocksResponse, ForumPost } from '../types/participation';
-import DelegateAvatarNameLight from 'modules/delegates/components/DelegateAvatarNameLight';
-import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
-import { useNetwork } from 'modules/app/hooks/useNetwork';
+import { ForumPost } from '../types/participation';
 
 const ForumPosts = ({ posts, bpi }: { posts: ForumPost[]; bpi: number }) => {
   return (
@@ -75,21 +68,11 @@ const ForumPosts = ({ posts, bpi }: { posts: ForumPost[]; bpi: number }) => {
 };
 
 export default function Participation({
-  activeDelegates,
   bpi
 }: {
   activeDelegates: DelegateInfo[] | DelegatePaginated[];
   bpi: number;
 }): React.ReactElement {
-  const network = useNetwork();
-  const MONTHS_PAST = 6;
-  // This makes sure the timestamp is the same throughout the day so the SWR cache-key doesn't change
-  const unixtimeStart =
-    new Date(format(sub(new Date(), { months: MONTHS_PAST }), 'yyyy-MM-dd')).getTime() / 1000;
-
-  const { data: locks } = useSWR<AllLocksResponse[]>(
-    `/api/executive/all-locks?network=${network}&unixtimeStart=${unixtimeStart}`
-  );
 
   return (
     <Flex sx={{ flexDirection: 'column', gap: 4, mb: 4 }}>
@@ -103,75 +86,6 @@ export default function Participation({
       </Container>
 
       <ForumPosts posts={forumPosts} bpi={bpi} />
-
-      <Flex
-        sx={{
-          pt: 4,
-          justifyContent: 'space-between',
-          gap: [5, 3],
-          flexDirection: bpi > 1 ? 'row' : 'column'
-        }}
-      >
-        <ErrorBoundary componentName="Governance Participation">
-          <Flex sx={{ flexDirection: 'column', flex: 2, gap: 3 }}>
-            <Flex sx={{ justifyContent: 'space-between' }}>
-              <Heading>Governance Participation</Heading>
-            </Flex>
-            {locks ? (
-              locks.length > 0 ? (
-                <Card
-                  sx={{
-                    height: '100%',
-                    pr: [0, 3],
-                    pb: 3
-                  }}
-                >
-                  <ParticipationChart data={locks} monthsPast={MONTHS_PAST} />
-                </Card>
-              ) : null
-            ) : (
-              <SkeletonThemed height="300px" />
-            )}
-          </Flex>
-        </ErrorBoundary>
-
-        <ErrorBoundary componentName="Top Voters">
-          <Flex sx={{ flexDirection: 'column', flex: 1, gap: 3 }}>
-            <Flex sx={{ justifyContent: 'space-between' }}>
-              <Heading>Top Voters</Heading>
-            </Flex>
-            <Card
-              sx={{
-                flexDirection: 'column',
-                gap: 3,
-                p: 3,
-                height: '100%'
-              }}
-            >
-              <Flex sx={{ justifyContent: 'space-between' }}>
-                <Text variant="caps" sx={{ color: 'secondaryEmphasis' }}>
-                  Address
-                </Text>
-                <Text variant="caps" sx={{ color: 'secondaryEmphasis' }}>
-                  Participation
-                </Text>
-              </Flex>
-              {activeDelegates.map((delegate, i) => (
-                <Flex
-                  key={delegate.voteDelegateAddress}
-                  sx={{ justifyContent: 'space-between', alignItems: 'center', mt: 3 }}
-                >
-                  <Flex sx={{ alignItems: 'center', gap: 2 }}>
-                    <Text>{i + 1}</Text>
-                    <DelegateAvatarNameLight delegate={delegate} />
-                  </Flex>
-                  <Text>{delegate.combinedParticipation}</Text>
-                </Flex>
-              ))}
-            </Card>
-          </Flex>
-        </ErrorBoundary>
-      </Flex>
     </Flex>
   );
 }


### PR DESCRIPTION
Before:
<img width="1427" alt="Screenshot 2025-04-30 at 4 07 01 PM" src="https://github.com/user-attachments/assets/e7ce0409-4e0f-49c8-be3d-ef61447dd5d3" />

After

<img width="1316" alt="Screenshot 2025-04-30 at 4 28 11 PM" src="https://github.com/user-attachments/assets/09f78ccd-83ae-462b-ae31-fc4e713c3eb5" />

We can always add this back later, but removing this for now since the participation chart doesn't load and throws errors
