### PR TITLE
use Sky for sky in cheif stat

### DIFF
--- a/modules/app/components/SystemStatsSidebar.tsx
+++ b/modules/app/components/SystemStatsSidebar.tsx
@@ -70,7 +70,7 @@ export default function SystemStatsSidebar({
     },
     'sky in chief': key => {
       const chiefAddress = chiefAddressMapping[chainId];
-      const { data: chiefBalance } = useTokenBalance(Tokens.MKR, chiefAddress);
+      const { data: chiefBalance } = useTokenBalance(Tokens.SKY, chiefAddress);
 
       return (
         <Flex key={key} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>

--- a/modules/executive/api/fetchMkrInChief.ts
+++ b/modules/executive/api/fetchMkrInChief.ts
@@ -9,14 +9,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { SupportedNetworks } from 'modules/web3/constants/networks';
 import { networkNameToChainId } from 'modules/web3/helpers/chain';
 import { getPublicClient } from 'modules/web3/helpers/getPublicClient';
-import { chiefAddress, mkrAbi, mkrAddress } from 'modules/contracts/generated';
+import { chiefAddress, mkrAbi, skyAddress } from 'modules/contracts/generated';
 
 export async function fetchMkrInChief(network?: SupportedNetworks): Promise<bigint> {
   const chainId = network ? networkNameToChainId(network) : networkNameToChainId(SupportedNetworks.MAINNET);
   const publicClient = getPublicClient(chainId);
 
   const mkrInChief = await publicClient.readContract({
-    address: mkrAddress[chainId],
+    address: skyAddress[chainId],
     abi: mkrAbi,
     functionName: 'balanceOf',
     args: [chiefAddress[chainId]]

--- a/modules/home/components/GovernanceStats.tsx
+++ b/modules/home/components/GovernanceStats.tsx
@@ -40,7 +40,7 @@ export function GovernanceStats({ pollStats, stats, mkrOnHat, mkrInChief }: Prop
     {
       title: 'SKY Delegated',
       value: stats ? (
-        `${formatValue(BigInt(stats.totalMKRDelegated), 0, 2, true, false, 1e9)} SKY`
+        `${formatValue(BigInt(Math.floor(stats.totalMKRDelegated)), 0, 2, true, false, 1e9)} SKY`
       ) : (
         <Skeleton />
       )


### PR DESCRIPTION
Fixes a bug where it was showing 0 SKY in Chief on the homepage and in the sidebar

And fix decimal bug for total mkr delegated