### PR TITLE
Update E2E tests to account for the read mode state

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,7 @@ jobs:
       TENDERLY_API_KEY: ${{ secrets.TENDERLY_API_KEY }}
       DEFENDER_API_SECRET_TESTNET: $${{ secrets.DEFENDER_API_SECRET_TESTNET}}
       DEFENDER_API_KEY_TESTNET: ${{ secrets.DEFENDER.API_KEY_TESTNET}}
+      READ_ONLY: true
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/modules/polling/components/VotingWeight.tsx
+++ b/modules/polling/components/VotingWeight.tsx
@@ -99,7 +99,9 @@ export default function VotingWeight(): JSX.Element {
           </Box>
         </Tooltip>
       </Flex>
-      <Text sx={{ color: 'text' }}>{votingWeight ? `${formatValue(votingWeight.total)} MKR` : '--'}</Text>
+      <Text sx={{ color: 'text' }} data-testid="voting-weight">
+        {votingWeight ? `${formatValue(votingWeight.total)} MKR` : '--'}
+      </Text>
     </Flex>
   );
 }

--- a/playwright/delegates.spec.ts
+++ b/playwright/delegates.spec.ts
@@ -1,6 +1,7 @@
-import { test } from './fixtures/base';
+import { expect, test } from './fixtures/base';
 import { connectWallet } from './shared';
 import './forkVnet';
+import { delegateMkr } from './helpers/delegateMkr';
 
 test('delegate MKR', async ({ page, delegatePage }) => {
   await test.step('navigate to delegate page', async () => {
@@ -13,20 +14,23 @@ test('delegate MKR', async ({ page, delegatePage }) => {
 
   // TODO: V2 delegates don't show up in tenderly e2e fork as contracts so their delegated amount doesn't show up
   // neither does the delegation actions work
-  await test.step('sort delegates and perform delegation', async () => {
+  await test.step('sort delegates and check delegate button is disabled', async () => {
     await delegatePage.sortByHighestFirst();
-    await delegatePage.delegate('2');
-    await delegatePage.verifyDelegatedAmount('2');
+    await delegatePage.verifyDelegateButtonIsDisabled();
   });
 
   await test.step('undelegate MKR', async () => {
+    // Delegate MKR through an RPC call directly since it's not possible from the app
+    const delegationSuccessful = await delegateMkr('2');
+    expect(delegationSuccessful).toBe(true);
+
+    await page.reload();
+    await connectWallet(page);
+    await delegatePage.sortByHighestFirst();
     await delegatePage.undelegate();
   });
 
-  // TODO: The remove funds from delegate test is not working well because the modal keeps showing the button
-  // To approve the contract, even it's approved. We have to approve it like 3 times to work
-  // Check what is the problem and uncomment the following code
-  /*
-  await delegatePage.undelegateAll();
-  */
+  await test.step('undelegate all MKR', async () => {
+    await delegatePage.undelegateAll();
+  });
 });

--- a/playwright/esmodule.spec.ts
+++ b/playwright/esmodule.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { connectWallet, closeModal } from './shared';
+import { connectWallet } from './shared';
 import './forkVnet';
 
-test.skip('Input 150,000MKR and burn it', async ({ page }) => {
+test('ESM data is rendered in read only mode', async ({ page }) => {
   await page.goto('/esmodule');
 
   await expect(page.locator('text=Emergency Shutdown Module')).toBeVisible();
@@ -13,67 +13,12 @@ test.skip('Input 150,000MKR and burn it', async ({ page }) => {
 
   await expect(page.locator('text=Burn Your MKR')).toBeVisible();
 
-  //Click "burn your MKR button"
-  await page.locator('text=Burn Your MKR').click();
+  await page.waitForLoadState('networkidle');
 
-  // Checks the modal is open
-  await expect(page.locator('text=Are you sure you want to burn MKR?')).toBeVisible();
+  // The burn MKR button remains disabled in read mode
+  await expect(page.locator('text=Burn Your MKR')).toBeDisabled();
 
-  // Closes modal
-  await page.locator('text=Cancel').click();
-
-  // Click "burn your MKR button"
-  await page.locator('text=Burn Your MKR').click();
-
-  // Click continue
-  await page.locator('text=Continue').click();
-
-  // Enter 150000 MKR to pass the threshold
-  await page.locator('[data-testid="mkr-input"]').fill('150000');
-
-  // Continue with the burn
-  await page.locator('text=Continue').click();
-
-  // Type the passphrase
-  await page.locator('[data-testid="confirm-input"]').fill('I am burning 150,000 MKR');
-
-  // Unlock mkr
-  await page.locator('[data-testid="allowance-toggle"]').click();
-
-  // click on checkbox of accepted terms
-  await page.locator('[data-testid="tosCheck"]').click();
-
-  // The continue button should be enabled
-  await expect(page.locator('[data-testid="continue-burn"]')).not.toBeDisabled();
-
-  // Click continue
-  await page.locator('[data-testid="continue-burn"]').click();
-
-  // See confirmation
-  //commenting out because this is only briefly shown if the threshold is met
-  //await expect(page.locator('text=MKR successfully burned in ESM')).toBeVisible();
-
-  // Close modal
-  await closeModal(page);
-
-  // Click "Initiate Emergency Shutdown" button
-  await page.locator('text=Initiate Emergency Shutdown').click();
-
-  // See that the limit has been reached
-  await expect(page.locator('text=The 150,000 MKR limit for the emergency shutdown module has been reached.')).toBeVisible();
-
-  // Continue and send the shutdown tx
-  await page.locator('text=Continue').click();
-
-  // Wait for signature
-  await expect(page.locator('text=Sign TX to start Emergency Shutdown.')).toBeVisible();
-
-  // // Wait for signature
-  // await expect(page.locator('text=Transaction Sent!')).toBeVisible();
-
-  // // Close modal
-  // await page.locator('button:has-text("Close")').click();
-
-  // Shows banner after shutdown
-  // await expect(page.locator('[data-testid="es-initiated"]').locator('text=Emergency shutdown has been initiated on')).toBeVisible();
+  // ESM History events are displayed in the table
+  const rowCount = await page.locator('tr').count();
+  expect(rowCount).toBeGreaterThanOrEqual(1);
 });

--- a/playwright/executives.spec.ts
+++ b/playwright/executives.spec.ts
@@ -16,7 +16,7 @@ test('navigates to executives and can withdraw from chief', async ({ page, execu
     await executivePage.verifyDepositDisabled();
   });
 
-  await test.step('withdraw from chief contract', async () => {
+  await test.step('deposit into chief from the API', async () => {
     // Deposit MKR into the Chief through an RPC call directly since it's not possible from the app
     const depositSuccessful = await depositMkr('0.01');
     expect(depositSuccessful).toBe(true);
@@ -26,7 +26,13 @@ test('navigates to executives and can withdraw from chief', async ({ page, execu
 
     await executivePage.verifyVotingContract();
     await executivePage.verifyLockedMkr('0.01');
+  });
 
+  await test.step('verify voting is disabled', async () => {
+    await executivePage.verifyDepositDisabled();
+  });
+
+  await test.step('withdraw from chief contract', async () => {
     await executivePage.withdrawFromChief();
     await executivePage.withdrawMkr('0.01');
     await executivePage.verifyLockedMkr('0');

--- a/playwright/executives.spec.ts
+++ b/playwright/executives.spec.ts
@@ -1,8 +1,9 @@
-import { test } from './fixtures/base';
+import { expect, test } from './fixtures/base';
 import { connectWallet } from './shared';
 import './forkVnet';
+import { depositMkr } from './helpers/depositMkr';
 
-test('navigates to executives and can deposit into chief', async ({ page, executivePage }) => {
+test('navigates to executives and can withdraw from chief', async ({ page, executivePage }) => {
   await test.step('navigate to executives page', async () => {
     await executivePage.goto();
   });
@@ -11,14 +12,23 @@ test('navigates to executives and can deposit into chief', async ({ page, execut
     await connectWallet(page);
   });
 
-  await test.step('verify and deposit into chief contract', async () => {
-    await executivePage.verifyVotingContract();
-    await executivePage.depositIntoChief();
-    await executivePage.depositMkr('0.01');
-    await executivePage.verifyLockedMkr('0.01');
+  await test.step('verify chief contract deposits are disabled', async () => {
+    await executivePage.verifyDepositDisabled();
   });
 
-  await test.step('vote on executive', async () => {
-    await executivePage.vote();
+  await test.step('withdraw from chief contract', async () => {
+    // Deposit MKR into the Chief through an RPC call directly since it's not possible from the app
+    const depositSuccessful = await depositMkr('0.01');
+    expect(depositSuccessful).toBe(true);
+
+    await page.reload();
+    await connectWallet(page);
+
+    await executivePage.verifyVotingContract();
+    await executivePage.verifyLockedMkr('0.01');
+
+    await executivePage.withdrawFromChief();
+    await executivePage.withdrawMkr('0.01');
+    await executivePage.verifyLockedMkr('0');
   });
 });

--- a/playwright/fixtures/delegate.ts
+++ b/playwright/fixtures/delegate.ts
@@ -42,12 +42,12 @@ export class DelegatePage {
     this.delegatingText = this.page.locator('text=You are delegating');
     this.congratsText = this.page.locator('text=Congratulations, you delegated');
     this.delegatedByYouText = this.page.locator('[data-testid="mkr-delegated-by-you"]');
-    this.undelegateButton = this.page.locator('[data-testid="button-undelegate"]');
+    this.undelegateButton = this.page.locator('[data-testid="button-undelegate"]:enabled');
     this.withdrawText = this.page.locator('text=Withdraw from delegate contract');
     this.setMaxButton = this.page.locator('button[data-testid="mkr-input-set-max"]');
     this.undelegateMkrButton = this.page.locator('button:has-text("Undelegate MKR")');
     this.transactionPendingText = this.page.locator('text=Transaction Pending');
-    this.transactionSentText = this.page.locator('text=Transaction Sent');
+    this.transactionSentText = this.page.locator('text=/You undelegated \\d+ from \\w+$/');
   }
 
   async goto() {
@@ -79,6 +79,10 @@ export class DelegatePage {
     await expect(this.delegatedByYouText.first()).toHaveText(amount);
   }
 
+  async verifyDelegateButtonIsDisabled() {
+    await expect(this.delegateButton).toHaveCount(0);
+  }
+
   async undelegate() {
     await this.undelegateButton.first().click();
     await this.approveDelegateButton.click();
@@ -91,7 +95,5 @@ export class DelegatePage {
     await this.undelegateMkrButton.click();
     await expect(this.transactionPendingText).toBeVisible();
     await expect(this.transactionSentText).toBeVisible();
-    closeModal(this.page);
-    await expect(this.delegatedByYouText.contains('0.000')).toBeVisible();
   }
 }

--- a/playwright/fixtures/executive.ts
+++ b/playwright/fixtures/executive.ts
@@ -80,6 +80,10 @@ export class ExecutivePage {
   }
 
   async verifyDepositDisabled() {
+    await expect(this.voteButton.first()).toBeDisabled();
+  }
+
+  async verifyVoteDisabled() {
     await expect(this.depositButton).toBeDisabled();
   }
 

--- a/playwright/fixtures/executive.ts
+++ b/playwright/fixtures/executive.ts
@@ -7,11 +7,15 @@ export class ExecutivePage {
   // Locators
   private votingContractText: any;
   private depositButton: any;
+  private withdrawButton: any;
   private depositApproveButton: any;
+  private withdrawApproveButton: any;
   private confirmTransactionText: any;
   private depositIntoContractText: any;
+  private withdrawFromContractText: any;
   private mkrInput: any;
   private depositMkrButton: any;
+  private withdrawMkrButton: any;
   private transactionSuccessfulText: any;
   private lockedMkr: any;
   private voteButton: any;
@@ -26,11 +30,15 @@ export class ExecutivePage {
   private initializeLocators() {
     this.votingContractText = this.page.locator('text=/In voting contract/');
     this.depositButton = this.page.locator('[data-testid="deposit-button"]');
+    this.withdrawButton = this.page.locator('[data-testid="withdraw-button"]');
     this.depositApproveButton = this.page.locator('[data-testid="deposit-approve-button"]');
+    this.withdrawApproveButton = this.page.locator('[data-testid="withdraw-approve-button"]');
     this.confirmTransactionText = this.page.locator('text=/Confirm Transaction/');
     this.depositIntoContractText = this.page.locator('text=/Deposit into voting contract/');
+    this.withdrawFromContractText = this.page.locator('text=/Withdraw from voting contract/');
     this.mkrInput = this.page.locator('[data-testid="mkr-input"]');
     this.depositMkrButton = this.page.locator('[data-testid="button-deposit-mkr"]');
+    this.withdrawMkrButton = this.page.locator('[data-testid="button-withdraw-mkr"]');
     this.transactionSuccessfulText = this.page.locator('text=/Transaction Successful/');
     this.lockedMkr = this.page.locator('[data-testid="locked-mkr"]');
     this.voteButton = this.page.locator('[data-testid="vote-button-exec-overview-card"]');
@@ -69,5 +77,24 @@ export class ExecutivePage {
     await this.voteButton.first().click();
     await this.voteModalButton.click();
     await expect(this.transactionSentText).toBeVisible();
+  }
+
+  async verifyDepositDisabled() {
+    await expect(this.depositButton).toBeDisabled();
+  }
+
+  async withdrawFromChief() {
+    await this.withdrawButton.click();
+    await this.withdrawApproveButton.click();
+    await expect(this.confirmTransactionText).toBeVisible();
+  }
+
+  async withdrawMkr(amount: string) {
+    await expect(this.withdrawFromContractText).toBeVisible();
+    await this.mkrInput.fill(amount);
+    await this.withdrawMkrButton.click();
+    await expect(this.confirmTransactionText).toBeVisible();
+    await expect(this.transactionSuccessfulText).toBeVisible();
+    closeModal(this.page);
   }
 }

--- a/playwright/fixtures/polling.ts
+++ b/playwright/fixtures/polling.ts
@@ -21,6 +21,7 @@ export class PollingPage {
   private voteSubmissionText: any;
   private pollOverviewCard: any;
   private submitGaslessButton: any;
+  private votingWeightText: any;
 
   constructor(page: Page) {
     this.page = page;
@@ -49,6 +50,7 @@ export class PollingPage {
     );
     this.pollOverviewCard = this.page.locator('[data-testid="poll-overview-card"]');
     this.submitGaslessButton = this.page.locator('[data-testid="submit-ballot-gasless-button"]');
+    this.votingWeightText = this.page.locator('[data-testid="voting-weight"]');
   }
 
   private getSingleSelectOption(choice: 'Yes' | 'No') {
@@ -118,5 +120,17 @@ export class PollingPage {
   async verifyVoteSubmission() {
     await expect(this.voteSubmissionText).toBeVisible({ timeout: 10000 });
     await expect(this.pollOverviewCard).toHaveCount(1);
+  }
+
+  async verifyVotingWeight(votingWeight: string) {
+    await expect(this.votingWeightText).toHaveText(votingWeight);
+  }
+
+  async verifyAddToBallotDisabled() {
+    await expect(this.addToBallotButton.first()).toBeDisabled();
+  }
+
+  async verifyReviewBallotDisabled() {
+    await expect(this.reviewButton).toBeDisabled();
   }
 }

--- a/playwright/helpers/delegateMkr.ts
+++ b/playwright/helpers/delegateMkr.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'fs/promises';
+import { TEST_ACCOUNTS } from '../shared';
+import { encodeFunctionData, parseUnits } from 'viem';
+import { voteDelegateAbi } from '../../modules/contracts/ethers/abis';
+import { mkrAbi, mkrAddress } from '../../modules/contracts/generated';
+import { SupportedChainId } from '../../modules/web3/constants/chainID';
+
+const TEST_DELEGATE_CONTRACT = '0xc1a1bdb7d60b7cb3920787a15a2b583786c52fb6';
+
+export async function delegateMkr(amount: string) {
+  const file = await readFile('./tenderlyTestnetData.json', 'utf-8');
+  const { TENDERLY_RPC_URL } = JSON.parse(file);
+
+  const approvalResponse = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: TEST_ACCOUNTS.normal.address,
+          to: mkrAddress[SupportedChainId.TENDERLY],
+          gas: '0x7A1200',
+          gasPrice: '0x0',
+          value: '0x0',
+          data: encodeFunctionData({
+            abi: mkrAbi,
+            functionName: 'approve',
+            args: [TEST_DELEGATE_CONTRACT]
+          })
+        }
+      ]
+    })
+  });
+
+  if (!approvalResponse.ok) {
+    throw new Error(`Error approving MKR contract: ${approvalResponse.statusText}`);
+  }
+
+  const response = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: TEST_ACCOUNTS.normal.address,
+          to: TEST_DELEGATE_CONTRACT,
+          gas: '0x7A1200',
+          gasPrice: '0x0',
+          value: '0x0',
+          data: encodeFunctionData({
+            abi: voteDelegateAbi,
+            functionName: 'lock',
+            args: [parseUnits(amount, 18)]
+          })
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error delegating MKR to test delegate: ${response.statusText}`);
+  }
+
+  // Mine a block to confirm the transaction
+  const blockMineResponse = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'evm_mine',
+      params: []
+    })
+  });
+
+  if (!blockMineResponse.ok) {
+    throw new Error(`Error mining block: ${blockMineResponse.statusText}`);
+  }
+
+  console.log('Successfully delegated MKR to test delegate');
+  return response.ok;
+}

--- a/playwright/helpers/depositMkr.ts
+++ b/playwright/helpers/depositMkr.ts
@@ -1,0 +1,91 @@
+import { readFile } from 'fs/promises';
+import { TEST_ACCOUNTS } from '../shared';
+import { encodeFunctionData, parseUnits } from 'viem';
+import { mkrAbi, mkrAddress, chiefAddress, chiefAbi } from '../../modules/contracts/generated';
+import { SupportedChainId } from '../../modules/web3/constants/chainID';
+
+export async function depositMkr(amount: string) {
+  const file = await readFile('./tenderlyTestnetData.json', 'utf-8');
+  const { TENDERLY_RPC_URL } = JSON.parse(file);
+
+  const approvalResponse = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: TEST_ACCOUNTS.normal.address,
+          to: mkrAddress[SupportedChainId.TENDERLY],
+          gas: '0x7A1200',
+          gasPrice: '0x0',
+          value: '0x0',
+          data: encodeFunctionData({
+            abi: mkrAbi,
+            functionName: 'approve',
+            args: [chiefAddress[SupportedChainId.TENDERLY]]
+          })
+        }
+      ]
+    })
+  });
+
+  if (!approvalResponse.ok) {
+    throw new Error(`Error approving MKR contract: ${approvalResponse.statusText}`);
+  }
+
+  const response = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: TEST_ACCOUNTS.normal.address,
+          to: chiefAddress[SupportedChainId.TENDERLY],
+          gas: '0x7A1200',
+          gasPrice: '0x0',
+          value: '0x0',
+          data: encodeFunctionData({
+            abi: chiefAbi,
+            functionName: 'lock',
+            args: [parseUnits(amount, 18)]
+          })
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error delegating MKR to test delegate: ${response.statusText}`);
+  }
+
+  // Mine a block to confirm the transaction
+  const blockMineResponse = await fetch(TENDERLY_RPC_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'evm_mine',
+      params: []
+    })
+  });
+
+  if (!blockMineResponse.ok) {
+    throw new Error(`Error mining block: ${blockMineResponse.statusText}`);
+  }
+
+  console.log('Successfully delegated MKR to test delegate');
+  return response.ok;
+}

--- a/playwright/polling.spec.ts
+++ b/playwright/polling.spec.ts
@@ -20,12 +20,7 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('Adds polls to review and navigates to review page and votes with the legacy system', async ({
-  page,
-  pollingPage
-}) => {
-  const selectedPollId = 1107;
-
+test('Can see polls, but cannot vote on them', async ({ page, pollingPage }) => {
   await test.step('navigate to polling page', async () => {
     await pollingPage.goto();
     await pollingPage.waitForPolls();
@@ -35,55 +30,16 @@ test('Adds polls to review and navigates to review page and votes with the legac
     await connectWallet(page);
   });
 
-  await test.step('select poll choice and add to ballot', async () => {
+  await test.step('verify voting weight', async () => {
+    await pollingPage.verifyVotingWeight('150,001 MKR');
+  });
+
+  await test.step('select poll choice but cannot add to ballot', async () => {
     await pollingPage.selectChoice('Yes');
-    await pollingPage.addToBallot();
+    await pollingPage.verifyAddToBallotDisabled();
   });
 
-  await test.step('review and edit ballot', async () => {
-    await pollingPage.navigateToReview();
-    await pollingPage.verifyPollId(selectedPollId);
-    await pollingPage.editChoice('No');
-  });
-
-  await test.step('submit vote using legacy system', async () => {
-    await pollingPage.submitBallot();
-    await pollingPage.switchToLegacyVoting();
-    await pollingPage.submitLegacyVote();
-    await pollingPage.verifyVoteSubmission();
-  });
-});
-
-//Skip this test because eth_signTypedData_v4 doesn't work with the mock connector
-//We'd need to find a way to update the CustomizedBridge to handle eth_signTypedData_v4 to get this to work.
-test.skip('Adds polls to review and navigates to review page and votes with the gasless system', async ({
-  page,
-  pollingPage
-}) => {
-  const selectedPollId = 1107;
-
-  await test.step('navigate to polling page', async () => {
-    await pollingPage.goto();
-    await pollingPage.waitForPolls();
-  });
-
-  await test.step('connect wallet', async () => {
-    await connectWallet(page);
-  });
-
-  await test.step('select poll choice and add to ballot', async () => {
-    await pollingPage.selectChoice('Yes');
-    await pollingPage.addToBallot();
-  });
-
-  await test.step('review and edit ballot', async () => {
-    await pollingPage.navigateToReview();
-    await pollingPage.verifyPollId(selectedPollId);
-    await pollingPage.editChoice('No');
-  });
-
-  await test.step('submit vote using gasless system', async () => {
-    await pollingPage.submitBallot();
-    await pollingPage.submitGaslessVote();
+  await test.step('review ballot button is disabled', async () => {
+    await pollingPage.verifyReviewBallotDisabled();
   });
 });


### PR DESCRIPTION
- Test that all write actions are disabled except for undelegating and withdrawing

Delegates:
- Verify delegating is disabled
- Test successfully undelegating after delegating from the API

ESM:
- Verify user can't interact with the burn button

Polling:
- Verify user can't add polls to ballot and can't submit ballot

Executive:
- Verify depositing is disabled
- Verify user can't vote even after depositing through the API
- Test successfully withdrawing MKR from chief