### PR TITLE
decode paths before comparison instead of encoding them

### DIFF
--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -88,9 +88,10 @@ export async function refetchPolls(network: SupportedNetworks): Promise<{
       const { id, url, multiHash } = poll;
 
       const foundPollMetadata = pollsMetadata.find(entry => {
-        const encodedUrl = encodeURIComponent(url);
-        const encodedPath = encodeURIComponent(entry.path);
-        return encodedUrl.includes(encodedPath);
+        // Decode both paths before comparing
+        const decodedUrlPath = decodeURIComponent(url);
+        const decodedMetadataPath = decodeURIComponent(entry.path);
+        return decodedUrlPath.includes(decodedMetadataPath);
       });
 
       if (!foundPollMetadata) {


### PR DESCRIPTION
This allows for handling polls where the metadata file name has special characters in it like spaces.

Before, we were trying to encode an already encoded URL which made the matching not work.

Now we can see poll 1506 on the testnet with this update.