### PR TITLE
Fix visual bugs on mobile

### DIFF
--- a/modules/app/components/layout/Header.tsx
+++ b/modules/app/components/layout/Header.tsx
@@ -281,7 +281,7 @@ const MobileMenu = ({ hide, router, gas, onToggleTheme, mode, network }) => {
   }, []);
 
   return (
-    <Container variant="modal">
+    <Container variant="modal" sx={{ width: '100vw', height: '100vh' }}>
       <Flex
         sx={{
           alignItems: 'center',

--- a/modules/delegates/components/TopDelegates.tsx
+++ b/modules/delegates/components/TopDelegates.tsx
@@ -49,7 +49,7 @@ export default function TopDelegates({
       </Container>
       <Card
         sx={{
-          p: [2, 4],
+          p: [3, 4],
           maxWidth: '926px',
           margin: '0 auto'
         }}

--- a/modules/home/components/Stats.tsx
+++ b/modules/home/components/Stats.tsx
@@ -58,7 +58,15 @@ export const Stats = ({ title, infoUnits, viewMoreUrl }: Props): JSX.Element => 
       </Box>
 
       {/* Mobile */}
-      <Box sx={{ display: ['block', 'none'], backgroundColor: 'surface', backdropFilter: 'blur(50px)' }}>
+      <Box
+        sx={{
+          display: ['block', 'none'],
+          backgroundColor: 'surface',
+          backdropFilter: 'blur(50px)',
+          p: 3,
+          borderRadius: 'round'
+        }}
+      >
         <Grid sx={{ p: 0 }}>
           <Flex sx={{ flexDirection: 'row', justifyContent: 'space-between' }}>
             <Heading>{title}</Heading>

--- a/pages/delegates/index.tsx
+++ b/pages/delegates/index.tsx
@@ -232,7 +232,7 @@ const Delegates = ({
           <Flex sx={{ alignItems: 'center' }}>
             <Button
               variant="textual"
-              sx={{ display: ['block', 'none'], color: 'onSecondary' }}
+              sx={{ display: ['block', 'none'], color: 'text' }}
               onClick={() => setShowFilters(!showFilters)}
             >
               <Text sx={{ mr: 1 }}>{showFilters ? 'Hide delegate filters' : 'Show delegate filters'}</Text>

--- a/pages/polling.tsx
+++ b/pages/polling.tsx
@@ -280,7 +280,7 @@ const PollingOverview = ({
           <Flex sx={{ alignItems: 'center' }}>
             <Button
               variant="textual"
-              sx={{ display: ['block', 'none'], color: 'onSecondary' }}
+              sx={{ display: ['block', 'none'], color: 'text' }}
               onClick={() => setShowFilters(!showFilters)}
             >
               <Text sx={{ mr: 1 }}>{showFilters ? 'Hide poll filters' : 'Show poll filters'}</Text>


### PR DESCRIPTION
### What does this PR do?
Mobile:
- Increase padding in homepage cards
- Fix size and background of the header menu popup
- Change color of texts over the image background that were almost unreadable