### PR TITLE
Add mainnet staging metadata

### DIFF
--- a/modules/app/components/layout/header/VotingWeight.tsx
+++ b/modules/app/components/layout/header/VotingWeight.tsx
@@ -24,7 +24,7 @@ export default function VotingWeight(): JSX.Element {
       </Flex>
       <Flex>
         <Text sx={{ fontSize: 5 }} data-testid="polling-voting-weight">
-          {votingWeight ? `${formatValue(votingWeight)} SKY` : '--'}
+          {(votingWeight || votingWeight === 0n) ? `${formatValue(votingWeight)} SKY` : '--'}
         </Text>
       </Flex>
       <Flex sx={{ py: 1 }}>

--- a/modules/delegates/api/getDelegatesRepositoryInfo.ts
+++ b/modules/delegates/api/getDelegatesRepositoryInfo.ts
@@ -16,7 +16,7 @@ export type RepositoryInfo = {
 
 export function getDelegatesRepositoryInformation(network: SupportedNetworks): RepositoryInfo {
   const repoMainnet = {
-    owner: 'makerdao',
+    owner: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' ? 'jetstreamgg' : 'makerdao',
     repo: 'delegates',
     branch: 'main'
   };

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -27,7 +27,7 @@ export async function getGithubExecutives(network: SupportedNetworks): Promise<C
   }
 
   const githubRepo = {
-    owner: network === SupportedNetworks.MAINNET ? 'makerdao' : 'jetstreamgg',
+    owner: network === SupportedNetworks.MAINNET && process.env.NEXT_PUBLIC_VERCEL_ENV !== 'development' ? 'jetstreamgg' : 'makerdao',
     repo: 'executive-votes',
     branch: network === SupportedNetworks.MAINNET ? 'main' : 'testnet'
   };

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -27,7 +27,7 @@ export async function getGithubExecutives(network: SupportedNetworks): Promise<C
   }
 
   const githubRepo = {
-    owner: network === SupportedNetworks.MAINNET && process.env.NEXT_PUBLIC_VERCEL_ENV !== 'development' ? 'jetstreamgg' : 'makerdao',
+    owner: network === SupportedNetworks.MAINNET && process.env.NEXT_PUBLIC_VERCEL_ENV !== 'development' ? 'makerdao' : 'jetstreamgg',
     repo: 'executive-votes',
     branch: network === SupportedNetworks.MAINNET ? 'main' : 'testnet'
   };

--- a/modules/polling/api/fetchPolls.ts
+++ b/modules/polling/api/fetchPolls.ts
@@ -39,9 +39,9 @@ export async function refetchPolls(network: SupportedNetworks): Promise<{
   while (refetchSubgraph) {
     const response = await gqlRequest<Promise<{ arbitrumPolls: SubgraphPoll[] }>>({
       chainId: arbitrumChainId,
-      query: network === SupportedNetworks.MAINNET ? arbitrumPollsQueryWithWhitelist : arbitrumPollsQuery,
+      query: network === SupportedNetworks.MAINNET && process.env.NEXT_PUBLIC_VERCEL_ENV !== 'development' ? arbitrumPollsQueryWithWhitelist : arbitrumPollsQuery,
       variables:
-        network === SupportedNetworks.MAINNET
+        network === SupportedNetworks.MAINNET && process.env.NEXT_PUBLIC_VERCEL_ENV !== 'development'
           ? { argsSkip: skip, creatorWhitelist: POLL_CREATOR_WHITELIST }
           : { argsSkip: skip }
     });

--- a/modules/polling/components/VotingWeight.tsx
+++ b/modules/polling/components/VotingWeight.tsx
@@ -33,7 +33,7 @@ export default function VotingWeight(): JSX.Element {
             Voting weight
           </Text>
         </Flex>
-        <Text sx={{ color: 'text' }}>{votingWeight ? `${formatValue(votingWeight)} SKY` : '--'}</Text>
+        <Text sx={{ color: 'text' }}>{(votingWeight || votingWeight === 0n) ? `${formatValue(votingWeight)} SKY` : '--'}</Text>
       </Flex>
       {!voteDelegateContractAddress && (
         <Flex sx={{ mt: [3, 2], gap: 2, alignItems: 'center', justifyContent: 'center', width: '100%' }}>

--- a/modules/polling/polling.constants.ts
+++ b/modules/polling/polling.constants.ts
@@ -67,7 +67,9 @@ export enum PollStatusEnum {
 }
 
 export const AGGREGATED_POLLS_FILE_URL = {
-  [SupportedNetworks.MAINNET]: 'https://raw.githubusercontent.com/makerdao/polls/refs/heads/main/index.json',
+  [SupportedNetworks.MAINNET]: process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' ? 
+  'https://raw.githubusercontent.com/jetstreamgg/polls/refs/heads/main/index.json'
+  : 'https://raw.githubusercontent.com/makerdao/polls/refs/heads/main/index.json',
   [SupportedNetworks.TENDERLY]:
     'https://raw.githubusercontent.com/jetstreamgg/polls/refs/heads/testnet/index.json'
 };

--- a/modules/polling/polling.constants.ts
+++ b/modules/polling/polling.constants.ts
@@ -74,8 +74,9 @@ export const AGGREGATED_POLLS_FILE_URL = {
     'https://raw.githubusercontent.com/jetstreamgg/polls/refs/heads/testnet/index.json'
 };
 
-export const SKY_PORTAL_START_DATE_MAINNET = new Date('2025-05-19');
+
 export const SKY_PORTAL_START_DATE_TENDERLY = new Date('2025-03-17');
+export const SKY_PORTAL_START_DATE_MAINNET = process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' ? SKY_PORTAL_START_DATE_TENDERLY : new Date('2025-05-19');
 
 export function getSkyPortalStartDate(network?: SupportedNetworks): Date {
   if (network === SupportedNetworks.TENDERLY) {


### PR DESCRIPTION
When NEXT_PUBLIC_VERCEL_ENV = "development" we show the forked metadata instead of the makerdao metadata.

Alternatively, we could add a different environment variable that we use for this instead, if we want to default to makerdao metadata on development. What do we think?