### PR TITLE
Check if delegate is supporting address zero

### DIFF
--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -296,6 +296,7 @@ export const DelegateOverviewCard = memo(
         <CurrentlySupportingExecutive
           proposalsSupported={delegate.proposalsSupported}
           execSupported={delegate.execSupported}
+          delegateAddress={delegate.voteDelegateAddress}
         />
 
         {showDelegateModal && (

--- a/modules/executive/components/CurrentlySupportingExecutive.tsx
+++ b/modules/executive/components/CurrentlySupportingExecutive.tsx
@@ -6,16 +6,51 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 */
 
+import { chiefAbi, chiefAddress } from 'modules/contracts/generated';
+import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { Divider, Box, Text, Flex } from 'theme-ui';
+import { useChainId, useReadContract } from 'wagmi';
 
 export function CurrentlySupportingExecutive({
   proposalsSupported,
-  execSupported
+  execSupported,
+  delegateAddress
 }: {
   proposalsSupported: number;
   execSupported: { title: string; address: string } | undefined;
+  delegateAddress: string;
 }): React.ReactElement | null {
+  const chainId = useChainId();
+  const chiefParameters = {
+    address: chiefAddress[chainId],
+    abi: chiefAbi
+  };
+
+  // If no executive support is detected from the subgraph, check if delegate is supporting address(0)
+  const { data: vote } = useReadContract({
+    ...chiefParameters,
+    functionName: 'votes',
+    args: [delegateAddress as `0x${string}`],
+    query: {
+      enabled: proposalsSupported === 0
+    }
+  });
+
+  const { data: slate } = useReadContract({
+    ...chiefParameters,
+    functionName: 'slates',
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    args: [vote!, 0n],
+    query: {
+      enabled: proposalsSupported === 0 && !!vote
+    }
+  });
+
   const getSupportText = (): string | null => {
+    if (proposalsSupported === 0 && slate === ZERO_ADDRESS) {
+      return 'Currently supporting address(0)';
+    }
+
     if (proposalsSupported === 0) {
       return 'Currently no executive supported';
     }


### PR DESCRIPTION
TODO:
- [ ] Update the `address(0)` name if necessary

### What does this PR do?
If no executive support is detected from the subgraph, check if delegate is supporting address(0)