### PR TITLE
Fix skyDelegated formatted value after delegating

### DIFF
--- a/modules/delegates/components/DelegateOverviewCard.tsx
+++ b/modules/delegates/components/DelegateOverviewCard.tsx
@@ -91,7 +91,7 @@ export const DelegateOverviewCard = memo(
           if (d.voteDelegateAddress === delegate.voteDelegateAddress) {
             return {
               ...d,
-              skyDelegated: (parseEther(d.skyDelegated) + amount).toString()
+              skyDelegated: formatValue(parseEther(d.skyDelegated) + amount, 'wad', 2, false)
             };
           }
           return d;


### PR DESCRIPTION
### Before
After delegating some SKY (1 SKY is enough to test it) the formatted value was too long and wrong
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/ed0beaf4-cad5-4a0b-bb37-ac74879c0765" />

### After
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/a82b0983-3dbc-4ebd-a227-900abb038af1" />
