### PR TITLE
Bump sky portal version to use fresh cache keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "governance-portal-v2",
   "license": "AGPL-3.0-only",
-  "version": "0.12.2",
+  "version": "1.0.0",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
### What does this PR do?
As the format of some numbers were updated in the API responses, this PR bumps the version of the app so the deployments use new cache keys, so old cache items cannot potentially be parsed by the app attempting to use the new formats
