### PR TITLE
Fix winning support format

### DIFF
--- a/modules/polling/components/PollWinningOptionBox.tsx
+++ b/modules/polling/components/PollWinningOptionBox.tsx
@@ -88,13 +88,7 @@ export default function PollWinningOptionBox({
                   {!isDefault &&
                     (isInputFormatSingleChoice(poll.parameters) ||
                       isInputFormatChooseFree(poll.parameters)) &&
-                    ' with ' +
-                      formatValue(
-                        leadingOptionSupport.indexOf('.') !== -1
-                          ? parseEther(leadingOptionSupport)
-                          : BigInt(leadingOptionSupport)
-                      ) +
-                      ' SKY supporting.'}
+                    ' with ' + formatValue(parseEther(leadingOptionSupport)) + ' SKY supporting.'}
                   {!isDefault &&
                     isInputFormatRankFree(poll.parameters) &&
                     ' with ' +


### PR DESCRIPTION
After:
![Screenshot 2025-05-26 at 8 18 22 PM](https://github.com/user-attachments/assets/fa65635f-a634-4cf1-b9c1-87f03aa0f8d8)
