### PR TITLE
Update legacy navigation links in proposal and poll views

### DIFF
--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -82,7 +82,10 @@ export default function ExecutiveOverviewCard({
         <Flex sx={{ justifyContent: 'space-between' }}>
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
-              <InternalLink href={`/executive/${proposal.key}`} title="View executive details">
+              <InternalLink 
+                href={`/executive/${proposal.key}`} 
+                title="View executive details"
+              >
                 <>
                   <CardHeader text={postedDateString} />
                   <CardTitle title={proposal.title} styles={{ mt: 2 }} />
@@ -127,7 +130,10 @@ export default function ExecutiveOverviewCard({
                 gap: [0, 3]
               }}
             >
-              <InternalLink href={`/executive/${proposal.key}`} title="View executive details">
+              <InternalLink 
+                href={`/executive/${proposal.key}`} 
+                title="View executive details"
+              >
                 <Button
                   variant="outline"
                   sx={{

--- a/modules/polling/components/PollOverviewCard.tsx
+++ b/modules/polling/components/PollOverviewCard.tsx
@@ -111,7 +111,10 @@ const PollOverviewCard = memo(
                           text={`Posted ${formatDateWithTime(poll.startDate)} | Poll ID ${poll.pollId}`}
                           styles={{ mb: 2 }}
                         />
-                        <InternalLink href={`/polling/${poll.slug}`} title="View poll details">
+                        <InternalLink 
+                          href={`/polling/${poll.slug}`} 
+                          title="View poll details"
+                        >
                           <CardTitle
                             title={poll.title}
                             dataTestId="poll-overview-card-poll-title"
@@ -119,7 +122,10 @@ const PollOverviewCard = memo(
                           />
                         </InternalLink>
                       </Box>
-                      <InternalLink href={`/polling/${poll.slug}`} title="View poll details">
+                      <InternalLink 
+                        href={`/polling/${poll.slug}`} 
+                        title="View poll details"
+                      >
                         <CardSummary text={poll.summary} styles={{ my: 2 }} onVisit={onVisitPoll} />
                       </InternalLink>
                     </Box>
@@ -170,7 +176,10 @@ const PollOverviewCard = memo(
                       p: 0
                     }}
                   >
-                    <InternalLink href={`/polling/${poll.slug}`} title="View poll details">
+                    <InternalLink 
+                      href={`/polling/${poll.slug}`} 
+                      title="View poll details"
+                    >
                       <Button
                         variant="outline"
                         sx={{

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -162,11 +162,11 @@ const ProposalView = ({ proposal, spellDiffs }: Props): JSX.Element => {
       )}
       <SidebarLayout>
         <Box>
-          <InternalLink href={'/executive'} title="View executive proposals">
+          <InternalLink href="/legacy-executive" title="View legacy executive proposals">
             <Button variant="mutedOutline" mb={2}>
               <Flex sx={{ alignItems: 'center', whiteSpace: 'nowrap' }}>
                 <Icon name="chevron_left" sx={{ size: 2, mr: 2 }} />
-                Back to {bpi === 0 ? 'All' : 'Executive'} Proposals
+                Back to Legacy Execs
               </Flex>
             </Button>
           </InternalLink>

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -107,14 +107,14 @@ const PollView = ({ poll }: { poll: Poll }) => {
 
         <div>
           <Flex mb={2} sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
-            <InternalLink href={'/polling'} title="View polling page">
+            <InternalLink href="/legacy-polling" title="View legacy polling page">
               <Button variant="mutedOutline">
                 <Flex sx={{ display: ['none', 'block'], alignItems: 'center', whiteSpace: 'nowrap' }}>
                   <Icon name="chevron_left" sx={{ size: 2, mr: 2 }} />
-                  Back to All Polls
+                  Back to Legacy Polls
                 </Flex>
                 <Flex sx={{ display: ['block', 'none'], alignItems: 'center', whiteSpace: 'nowrap' }}>
-                  Back to all
+                  Back to Legacy
                 </Flex>
               </Button>
             </InternalLink>


### PR DESCRIPTION
### What does this PR do?

This PR updates the "Back" links on the executive and poll detail pages. These links now direct users to the respective legacy listing pages (`/legacy-executive` and `/legacy-polling`) and the link text has been updated to reflect this change.

Minor code formatting was also applied to the `ExecutiveOverviewCard` and `PollOverviewCard` components for better readability.

### Steps for testing:

**Executive Proposals:**
1.  Navigate to a legacy executive proposal detail page.
2.  Locate the "Back" button at the top left of the content area.
3.  Verify the button text is "Back to Legacy Execs".
4.  Click the button and confirm you are redirected to the `/legacy-executive` page.

**Polls:**
1.  Navigate to a legacy poll detail page.
2.  Locate the "Back" button at the top left.
3.  Verify the button text is "Back to Legacy Polls" (or "Back to Legacy" on smaller screens).
4.  Click the button and confirm you are redirected to the `/legacy-polling` page.