### PR TITLE
add new api domain

### DIFF
--- a/modules/gql/gql.constants.ts
+++ b/modules/gql/gql.constants.ts
@@ -8,9 +8,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 /* Spock URLs */
 export const LOCAL_SPOCK_URL = 'http://localhost:3001/v1';
-export const STAGING_MAINNET_SPOCK_URL = 'https://staging-gov-polling.jetstream.gg/api/v1';
-export const MAINNET_SPOCK_URL = 'https://gov-polling.jetstream.gg/api/v1';
-export const TENDERLY_SPOCK_URL = 'https://pollingdb2-tenderly-staging.makerdao.com/api/v1';
+export const STAGING_MAINNET_SPOCK_URL = 'https://staging-gov-polling.sky.money/api/v1';
+export const MAINNET_SPOCK_URL = 'https://gov-polling.sky.money/api/v1';
+export const TENDERLY_SPOCK_URL = 'https://staging-gov-polling.sky.money/api/v1';
 
 /* Subgraph URLs (Envio HyperIndex) */
 


### PR DESCRIPTION
This pull request updates the URLs used for Spock API endpoints in the `gql.constants.ts` file to point to new domains. The changes ensure the application now communicates with the correct backend services.

**Spock API endpoint updates:**

* Updated `STAGING_MAINNET_SPOCK_URL`, `MAINNET_SPOCK_URL`, and `TENDERLY_SPOCK_URL` to use the `sky.money` domain instead of the previous `jetstream.gg` and `makerdao.com` domains. (`modules/gql/gql.constants.ts`)