### PR TITLE
chore: remove minimum-release-age exceptions for Next.js packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,14 +1,2 @@
 script-shell = bash
 minimum-release-age=10080
-minimum-release-age-exclude[]=next
-minimum-release-age-exclude[]=@next/env
-minimum-release-age-exclude[]=@next/eslint-plugin-next
-minimum-release-age-exclude[]=@next/swc-darwin-x64
-minimum-release-age-exclude[]=@next/swc-darwin-arm64
-minimum-release-age-exclude[]=@next/swc-linux-x64-gnu
-minimum-release-age-exclude[]=@next/swc-linux-x64-musl
-minimum-release-age-exclude[]=@next/swc-linux-arm64-gnu
-minimum-release-age-exclude[]=@next/swc-linux-arm64-musl
-minimum-release-age-exclude[]=@next/swc-win32-x64-msvc
-minimum-release-age-exclude[]=@next/swc-win32-arm64-msvc
-minimum-release-age-exclude[]=eslint-config-next


### PR DESCRIPTION
### [DON'T MERGE UNTIL 7 DAYS FROM NEXTJS LIB PUBLICATION - 2026-05-14]

The Next.js 15 upgrade is complete, so the per-package cooldown exceptions added during the upgrade are no longer needed. Drop all 13 minimum-release-age-exclude entries from .npmrc.

Note: next@15.5.18 was published 2026-05-07, so fresh installs will fail the 7-day cooldown until 2026-05-14 — worth holding the merge until then or pinning to an older patch.

### What does this PR do?

### Steps for testing:

### Screenshots (if relevant):

### Any additional helpful information?:
