### PR TITLE
fix: cacheDel clears long-TTL keys (polls-hash, etc.)

### DIFF
--- a/modules/cache/cache.ts
+++ b/modules/cache/cache.ts
@@ -13,7 +13,7 @@ import { config } from 'lib/config';
 import Redis from 'ioredis';
 import packageJSON from '../../package.json';
 import logger from 'lib/logger';
-import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS } from 'modules/app/constants/time';
+import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, ONE_WEEK_IN_MS } from 'modules/app/constants/time';
 import { executiveProposalsCacheKey } from './constants/cache-keys';
 
 let isConnected = true;
@@ -50,8 +50,6 @@ function getFilePath(name: string, network: string, expiryMs?: number): string {
 }
 
 export const cacheDel = (name: string, network: SupportedNetworks, expiryMs?: number): void => {
-  const path = getFilePath(name, network, expiryMs);
-
   if (redisCacheEnabled()) {
     // if clearing proposals, we need to find all of them first
     if (name === 'proposals') {
@@ -81,11 +79,17 @@ export const cacheDel = (name: string, network: SupportedNetworks, expiryMs?: nu
         logger.error('Error deleting proposal keys:', error);
       });
     } else {
-      // otherwise just delete the file based on path
-      logger.debug('cacheDel redis: ', path);
-      redis?.del(path);
+      // getFilePath appends today's date when expiryMs <= ONE_DAY_IN_MS (or is absent).
+      // Callers like the invalidate endpoint don't know each key's original TTL, so
+      // delete both variants — the undated key (long-TTL writes) and the dated key
+      // (short-TTL writes for today).
+      const pathStable = getFilePath(name, network, ONE_WEEK_IN_MS);
+      const pathDated = getFilePath(name, network);
+      logger.debug('cacheDel redis: ', pathStable, pathDated);
+      redis?.del(pathStable, pathDated);
     }
   } else {
+    const path = getFilePath(name, network, expiryMs);
     try {
       logger.debug('cacheDel: ', path);
       memoryCache[path] = null;


### PR DESCRIPTION
## Summary

`cacheDel` was silently no-op'ing on long-TTL keys, which prevented `/api/cache/invalidate` from actually clearing `polls-hash` (and any other key written with `expiryMs > ONE_DAY_IN_MS`).

`getFilePath` appends today's date to the Redis key when `expiryMs <= ONE_DAY_IN_MS` *or* when `expiryMs` is `undefined`. Writes use the caller's `expiryMs`, but `cacheDel` was being called without one (e.g. `pages/api/cache/invalidate.ts:68`), so it computed a *dated* path while the actual stored key was *undated* — the `redis.del` ran against a key that didn't exist.

The fix: `cacheDel` now deletes both variants — the undated key (long-TTL writes) and the today-dated key (short-TTL writes) — so callers don't need to know each key's original TTL.

## Why this matters

Live evidence: poll detail pages on `vote.makerdao.com/legacy-polling/<slug>` and `vote.makerdao.com/polling/<slug>` were 404'ing for every poll because `fetchSinglePoll` was getting back `valid:true` from `checkCachedPollsValidity` (hash matched GitHub) but `pollSlugToIdsCacheKey` / `pollDetailsCacheKey` were empty in Redis — likely a past partial-write where the hash persisted but the data writes didn't flush before the serverless invocation tore down. The invalidate endpoint couldn't unstick it because of the bug above; we had to clear the keys directly via Redis CLI to recover.

With this fix, the same recovery is possible via:
```
POST /api/cache/invalidate
{ "password": "...", "cacheKey": "polls-hash" }
```

## Test plan

- [ ] On a staging deploy with Redis enabled, write a `polls-hash` value (e.g. let the gov portal cache populate naturally) and confirm via `redis-cli` that the stored key has no date suffix.
- [ ] `POST /api/cache/invalidate` with `cacheKey: "polls-hash"` and confirm the undated key is gone.
- [ ] Confirm short-TTL keys (e.g. `is-polls-hash-valid`) still get cleared correctly.
- [ ] Confirm poll detail pages render after a forced cache-rebuild cycle.

## Follow-ups (out of scope)

- `cacheSet` in `refetchPolls` (`modules/polling/api/fetchPolls.ts:273-274`) is fire-and-forget. Awaiting those writes — or at least the hash/validity writes — would prevent the partial-state recurrence that motivated this fix.
- `checkCachedPollsValidity` declares the cache valid based on hash alone; it doesn't verify the data keys exist. Adding a presence check on `pollSlugToIds` before returning `{valid: true}` would self-heal a stuck cache.