### PR TITLE
fix: return notFound for missing executive proposals and polls

### DIFF
--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -163,12 +163,24 @@ export async function getExecutiveProposal(
 
   const proposals = await getGithubExecutives(currentNetwork);
 
-  const proposal = proposals.find(
-    proposal =>
-      trimProposalKey(proposal.key) === proposalId ||
-      proposal.key === proposalId ||
-      proposal.address.toLowerCase() === proposalId.toLowerCase()
+  const matchByFullKey = proposals.find(p => p.key === proposalId);
+  const matchByTrimmedKey = proposals.find(p => trimProposalKey(p.key) === proposalId);
+  const matchByAddress = proposals.find(
+    p => p.address.toLowerCase() === proposalId.toLowerCase()
   );
+
+  console.log('[exec-debug] getExecutiveProposal lookup', {
+    proposalId,
+    proposalIdLen: proposalId?.length,
+    network: currentNetwork,
+    proposalsLen: proposals.length,
+    firstFew: proposals.slice(0, 3).map(p => ({ key: p.key, addr: p.address })),
+    matchByFullKey: matchByFullKey?.address,
+    matchByTrimmedKey: matchByTrimmedKey?.address,
+    matchByAddress: matchByAddress?.address
+  });
+
+  const proposal = matchByTrimmedKey || matchByFullKey || matchByAddress;
   if (!proposal) return null;
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
 

--- a/modules/executive/api/fetchExecutives.ts
+++ b/modules/executive/api/fetchExecutives.ts
@@ -163,24 +163,12 @@ export async function getExecutiveProposal(
 
   const proposals = await getGithubExecutives(currentNetwork);
 
-  const matchByFullKey = proposals.find(p => p.key === proposalId);
-  const matchByTrimmedKey = proposals.find(p => trimProposalKey(p.key) === proposalId);
-  const matchByAddress = proposals.find(
-    p => p.address.toLowerCase() === proposalId.toLowerCase()
+  const proposal = proposals.find(
+    proposal =>
+      trimProposalKey(proposal.key) === proposalId ||
+      proposal.key === proposalId ||
+      proposal.address.toLowerCase() === proposalId.toLowerCase()
   );
-
-  console.log('[exec-debug] getExecutiveProposal lookup', {
-    proposalId,
-    proposalIdLen: proposalId?.length,
-    network: currentNetwork,
-    proposalsLen: proposals.length,
-    firstFew: proposals.slice(0, 3).map(p => ({ key: p.key, addr: p.address })),
-    matchByFullKey: matchByFullKey?.address,
-    matchByTrimmedKey: matchByTrimmedKey?.address,
-    matchByAddress: matchByAddress?.address
-  });
-
-  const proposal = matchByTrimmedKey || matchByFullKey || matchByAddress;
   if (!proposal) return null;
   invariant(proposal, `proposal not found for proposal id ${proposalId}`);
 

--- a/modules/executive/components/ExecutiveOverviewCard.tsx
+++ b/modules/executive/components/ExecutiveOverviewCard.tsx
@@ -23,6 +23,7 @@ import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { StatBox } from 'modules/app/components/StatBox';
 import { StatusText } from 'modules/app/components/StatusText';
 import { config } from 'lib/config';
+import { trimProposalKey } from 'modules/executive/helpers/trimProposalKey';
 
 type Props = {
   proposal: Proposal;
@@ -65,7 +66,9 @@ export default function ExecutiveOverviewCard({
   }
 
   const canVote = !!account;
-  const executiveUrl = isLegacy ? `/executive/${proposal.key}` : `/sky-executive/${proposal.key}`;
+  const executiveUrl = isLegacy
+    ? `/executive/${trimProposalKey(proposal.key)}`
+    : `/sky-executive/${trimProposalKey(proposal.key)}`;
 
   return (
     <Card

--- a/modules/executive/components/SkyExecutiveDetailView.tsx
+++ b/modules/executive/components/SkyExecutiveDetailView.tsx
@@ -28,6 +28,7 @@ import { parseUnits } from 'viem';
 import { useSkyExecutiveSupportersForSpell } from 'modules/executive/hooks/useSkyExecutiveSupporters';
 import AddressIconBox from 'modules/address/components/AddressIconBox';
 import SkyExecutiveStatusBox from './SkyExecutiveStatusBox';
+import { trimProposalKey } from 'modules/executive/helpers/trimProposalKey';
 
 const editMarkdown = (content: string) => {
   // hide the duplicate proposal title
@@ -81,7 +82,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
             <Flex sx={{ justifyContent: 'space-between' }}>
               {executive.ctx?.prev?.key && (
                 <InternalLink
-                  href={`/sky-executive/${executive.ctx.prev.key}`}
+                  href={`/sky-executive/${trimProposalKey(executive.ctx.prev.key)}`}
                   title="View previous executive"
                   scroll={false}
                 >
@@ -95,7 +96,7 @@ const SkyExecutiveDetailView = ({ executive, skyOnHat }: SkyExecutiveDetailViewP
               )}
               {executive.ctx?.next?.key && (
                 <InternalLink
-                  href={`/sky-executive/${executive.ctx.next.key}`}
+                  href={`/sky-executive/${trimProposalKey(executive.ctx.next.key)}`}
                   title="View next executive"
                   scroll={false}
                   styles={{ ml: 2 }}

--- a/modules/executive/components/SkyExecutiveOverviewCard.tsx
+++ b/modules/executive/components/SkyExecutiveOverviewCard.tsx
@@ -20,6 +20,7 @@ import { CardSummary } from 'modules/app/components/Card/CardSummary';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { StatBox } from 'modules/app/components/StatBox';
 import { StatusText } from 'modules/app/components/StatusText';
+import { trimProposalKey } from 'modules/executive/helpers/trimProposalKey';
 
 type Props = {
   proposal: SkyProposal;
@@ -55,7 +56,7 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
               <InternalLink
-                href={`/sky-executive/${proposal.key}`}
+                href={`/sky-executive/${trimProposalKey(proposal.key)}`}
                 title="View executive details"
               >
                 <>
@@ -103,7 +104,7 @@ export default function SkyExecutiveOverviewCard({ proposal, isHat, skyOnHat }: 
               }}
             >
               <InternalLink
-                href={`/sky-executive/${proposal.key}`}
+                href={`/sky-executive/${trimProposalKey(proposal.key)}`}
                 title="View executive details"
               >
                 <Button

--- a/modules/executive/components/SkyExecutiveOverviewCardLanding.tsx
+++ b/modules/executive/components/SkyExecutiveOverviewCardLanding.tsx
@@ -19,6 +19,7 @@ import { CardSummary } from 'modules/app/components/Card/CardSummary';
 import { ZERO_ADDRESS } from 'modules/web3/constants/addresses';
 import { StatBox } from 'modules/app/components/StatBox';
 import { StatusText } from 'modules/app/components/StatusText';
+import { trimProposalKey } from 'modules/executive/helpers/trimProposalKey';
 
 type Props = {
   proposal: SkyProposal;
@@ -53,7 +54,7 @@ export default function SkyExecutiveOverviewCardLanding({ proposal, isHat, skyOn
           <Box>
             <Flex sx={{ flexDirection: 'column' }}>
               <ExternalLink
-                href={`https://vote.sky.money/executive/${proposal.key}`}
+                href={`https://vote.sky.money/executive/${trimProposalKey(proposal.key)}`}
                 title="View executive details"
               >
                 <>
@@ -102,7 +103,7 @@ export default function SkyExecutiveOverviewCardLanding({ proposal, isHat, skyOn
               }}
             >
               <ExternalLink
-                href={`https://vote.sky.money/executive/${proposal.key}`}
+                href={`https://vote.sky.money/executive/${trimProposalKey(proposal.key)}`}
                 title="View executive details on Sky portal"
               >
                 <Button

--- a/modules/executive/helpers/trimProposalKey.ts
+++ b/modules/executive/helpers/trimProposalKey.ts
@@ -7,8 +7,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 */
 
 // Trims the proposal key to a certain length (otherwise build can fail)
+// and strips trailing separators so the resulting slug doesn't end on a
+// hyphen — some routers normalize that away, breaking lookups.
 export function trimProposalKey(proposalKey: string): string {
   const MAX_SLUG_LENGTH = 200;
 
-  return proposalKey.substring(0, Math.min(proposalKey.length, MAX_SLUG_LENGTH));
+  return proposalKey.substring(0, Math.min(proposalKey.length, MAX_SLUG_LENGTH)).replace(/-+$/, '');
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "governance-portal-v2",
   "license": "AGPL-3.0-only",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -457,6 +457,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
 
+  if (!proposal) {
+    return { notFound: true, revalidate: 60 };
+  }
+
   /**Disabling spell-effects until multi-transactions endpoint is ready */
   // // Only fetch at build time if spell has been cast, and it's not older than two months (to speed up builds)
   // const spellDiffs: SpellDiff[] =

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -455,26 +455,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
-  console.log('[exec-debug] getStaticProps called', {
-    proposalId,
-    proposalIdLen: proposalId?.length,
-    network: DEFAULT_NETWORK.network,
-    hasGithubToken: !!process.env.GITHUB_TOKEN
-  });
-
-  let proposal: Proposal | null = null;
-  try {
-    proposal = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
-  } catch (e) {
-    console.error('[exec-debug] getExecutiveProposal threw', e);
-  }
-
-  console.log('[exec-debug] getStaticProps result', {
-    proposalId,
-    found: !!proposal,
-    key: proposal?.key,
-    keyLen: proposal?.key?.length
-  });
+  const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
 
   if (!proposal) {
     return { notFound: true, revalidate: 60 };

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -455,11 +455,18 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
-  console.log('[exec-debug]', { proposalId, len: proposalId?.length });
+  console.log('[exec-debug] entry', {
+    params,
+    paramsKeys: params ? Object.keys(params) : null,
+    proposalId,
+    proposalIdLen: proposalId?.length,
+    proposalIdType: typeof proposalId,
+    stack: new Error('trace').stack?.split('\n').slice(0, 8).join(' | ')
+  });
 
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
 
-  console.log('[exec-debug] result', { found: !!proposal, key: proposal?.key });
+  console.log('[exec-debug] result', { proposalId, found: !!proposal, key: proposal?.key });
 
   if (!proposal) {
     return { notFound: true, revalidate: 60 };

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -455,7 +455,26 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
-  const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
+  console.log('[exec-debug] getStaticProps called', {
+    proposalId,
+    proposalIdLen: proposalId?.length,
+    network: DEFAULT_NETWORK.network,
+    hasGithubToken: !!process.env.GITHUB_TOKEN
+  });
+
+  let proposal: Proposal | null = null;
+  try {
+    proposal = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
+  } catch (e) {
+    console.error('[exec-debug] getExecutiveProposal threw', e);
+  }
+
+  console.log('[exec-debug] getStaticProps result', {
+    proposalId,
+    found: !!proposal,
+    key: proposal?.key,
+    keyLen: proposal?.key?.length
+  });
 
   if (!proposal) {
     return { notFound: true, revalidate: 60 };

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -455,18 +455,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
-  console.log('[exec-debug] entry', {
-    params,
-    paramsKeys: params ? Object.keys(params) : null,
-    proposalId,
-    proposalIdLen: proposalId?.length,
-    proposalIdType: typeof proposalId,
-    stack: new Error('trace').stack?.split('\n').slice(0, 8).join(' | ')
-  });
-
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
-
-  console.log('[exec-debug] result', { proposalId, found: !!proposal, key: proposal?.key });
 
   if (!proposal) {
     return { notFound: true, revalidate: 60 };
@@ -501,6 +490,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true
+    fallback: 'blocking'
   };
 };

--- a/pages/executive/[proposal-id].tsx
+++ b/pages/executive/[proposal-id].tsx
@@ -455,7 +455,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   // fetch proposal contents at build-time if on the default network
   const proposalId = (params || {})['proposal-id'] as string;
 
+  console.log('[exec-debug]', { proposalId, len: proposalId?.length });
+
   const proposal: Proposal | null = await getExecutiveProposal(proposalId, DEFAULT_NETWORK.network);
+
+  console.log('[exec-debug] result', { found: !!proposal, key: proposal?.key });
 
   if (!proposal) {
     return { notFound: true, revalidate: 60 };

--- a/pages/legacy-polling/[poll-hash].tsx
+++ b/pages/legacy-polling/[poll-hash].tsx
@@ -452,7 +452,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const poll = await fetchSinglePoll(DEFAULT_NETWORK.network, pollIdOrSlug);
 
   if (!poll) {
-    return { revalidate: 30, props: { poll: null } };
+    return { notFound: true, revalidate: 30 };
   }
 
   return {

--- a/pages/legacy-polling/[poll-hash].tsx
+++ b/pages/legacy-polling/[poll-hash].tsx
@@ -482,6 +482,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true
+    fallback: 'blocking'
   };
 };

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -452,7 +452,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   const poll = await fetchSinglePoll(DEFAULT_NETWORK.network, pollIdOrSlug);
 
   if (!poll) {
-    return { revalidate: 30, props: { poll: null } };
+    return { notFound: true, revalidate: 30 };
   }
 
   return {

--- a/pages/polling/[poll-hash].tsx
+++ b/pages/polling/[poll-hash].tsx
@@ -482,6 +482,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: true
+    fallback: 'blocking'
   };
 };

--- a/pages/sky-executive/[proposal-id].tsx
+++ b/pages/sky-executive/[proposal-id].tsx
@@ -145,6 +145,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
   // In the future, we could pre-generate paths for the most recent Sky executives
   return {
     paths: [],
-    fallback: true
+    fallback: 'blocking'
   };
 };

--- a/pages/sky-executive/[proposal-id].tsx
+++ b/pages/sky-executive/[proposal-id].tsx
@@ -128,6 +128,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     console.log(`Sky executive ${proposalId} not found during static generation`);
   }
 
+  if (!executive) {
+    return { notFound: true, revalidate: 60 };
+  }
+
   return {
     revalidate: 60, // Revalidate every minute for Sky executives
     props: {


### PR DESCRIPTION
## Summary

- Switches `getStaticProps` in the executive, sky-executive, legacy-polling, and polling detail pages to return `{ notFound: true, revalidate: 60 }` when the proposal/poll isn't found, instead of `{ props: { proposal: null } }`.
- Bumps version to `0.12.2`.

## Why

Returning a successful `getStaticProps` with `proposal: null` lets Next.js cache the empty page just like a real page render. If the underlying fetch (GitHub, Redis cache, etc.) is briefly stale or unavailable when a fallback path is first generated, the resulting soft-404 gets pinned in the static cache and only clears on the next successful `revalidate` cycle — which itself can re-cache the same null result.

Returning `notFound: true` makes Next.js serve a real 404 (uncached) and the short `revalidate: 60` lets the page recover on the next visit once the data is reachable again.

## Test plan

- [ ] Visit a valid executive URL and confirm it renders normally
- [ ] Visit a known-bad executive slug and confirm it serves a real 404 (not the in-page ErrorPage)
- [ ] Same for `/sky-executive/...`, `/polling/...`, `/legacy-polling/...`