### PR TITLE
chore: upgrade to pnpm v11.3.0 (APP-241)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.3.0
+          version: 11.5.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 11.3.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.17.0
+          version: 11.3.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.3.0
+          version: 11.5.0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-script-shell = bash
-minimum-release-age=10080

--- a/package.json
+++ b/package.json
@@ -118,22 +118,5 @@
     "vitest": "^3.0.9",
     "wait-for-expect": "^3.0.2"
   },
-  "resolutions": {
-    "elliptic": "^6.6.1"
-  },
-  "pnpm": {
-    "overrides": {
-      "elliptic": "^6.6.1",
-      "axios": "^1.12.0",
-      "dompurify": "^3.2.4",
-      "minimatch": "^9.0.5",
-      "node-forge": "^1.3.1",
-      "tar-fs": "^2.1.4",
-      "ws": "^8.18.3",
-      "cross-spawn": "^7.0.5",
-      "brace-expansion": "^2.0.2",
-      "picomatch": "^4.0.3"
-    }
-  },
-  "packageManager": "pnpm@10.17.0"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -118,5 +118,5 @@
     "vitest": "^3.0.9",
     "wait-for-expect": "^3.0.2"
   },
-  "packageManager": "pnpm@11.3.0"
+  "packageManager": "pnpm@11.5.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,43 @@
+# pnpm v11 reads project-wide settings only from this file.
+# - .npmrc is auth/registry only.
+# - The `pnpm` and `resolutions` fields of package.json are no longer read.
+
+# Supply-chain buffer: only install dependency versions published >= 7 days ago.
+# (v11 defaults to 1 day; we keep the 7-day window inherited from .npmrc.)
+minimumReleaseAge: 10080
+
+# Use bash for `scripts` (preserves prior .npmrc behaviour).
+scriptShell: bash
+
+# Security overrides. Migrated from `package.json#pnpm.overrides`, with
+# `elliptic` folded in from the top-level `resolutions` block (pnpm v11
+# no longer applies `resolutions`).
+overrides:
+  elliptic: ^6.6.1
+  axios: ^1.12.0
+  dompurify: ^3.2.4
+  minimatch: ^9.0.5
+  node-forge: ^1.3.1
+  tar-fs: ^2.1.4
+  ws: ^8.18.3
+  cross-spawn: ^7.0.5
+  brace-expansion: ^2.0.2
+  picomatch: ^4.0.3
+
+# pnpm v11 defaults `strictDepBuilds: true`, so any dependency with an
+# install/build script now fails the install unless it has an entry here.
+# Under v10 these were silently ignored — denying them preserves that
+# production behavior. Flip to `true` later if a runtime gap appears.
+allowBuilds:
+  '@scarf/scarf': false
+  '@tree-sitter-grammars/tree-sitter-yaml': false
+  bufferutil: false
+  core-js-pure: false
+  esbuild: false
+  fsevents: false
+  keccak: false
+  protobufjs: false
+  sharp: false
+  tree-sitter: false
+  tree-sitter-json: false
+  utf-8-validate: false


### PR DESCRIPTION
## Summary

Upgrades `governance-portal-v2` from pnpm 10.17.0 → 11.3.0. pnpm v11 introduces several breaking config changes — most notably, it no longer reads the `pnpm` field of `package.json` and only reads auth/registry settings from `.npmrc`. Without migration, the Wave 2 security overrides and the supply-chain `minimum-release-age` setting would be **silently dropped**, re-opening the vulnerabilities those overrides closed.

Mirrors the approach landed in [sky-governance-portal#105](https://github.com/skybase-foundation/sky-governance-portal/pull/105).

## Changes

- `packageManager` → `pnpm@11.3.0`; CI `pnpm/action-setup` version → `11.3.0` in `e2e.yml`, `unit.yml`.
- New `pnpm-workspace.yaml` holding everything pnpm v11 no longer reads from elsewhere:
  - `minimumReleaseAge: 10080` (was `minimum-release-age=10080` in `.npmrc`) — preserves the 7-day supply-chain buffer; v11's default would otherwise be 1 day.
  - `scriptShell: bash` (was `script-shell = bash` in `.npmrc`).
  - `overrides:` — the 10 Wave 2 entries (moved from `package.json` `pnpm.overrides`). The top-level `resolutions` block's lone `elliptic: ^6.6.1` was a duplicate of the same key in `pnpm.overrides`, so it collapses cleanly.
  - `allowBuilds:` — explicitly denies the 12 packages whose build scripts were ignored under v10 (`@scarf/scarf`, `@tree-sitter-grammars/tree-sitter-yaml`, `bufferutil`, `core-js-pure`, `esbuild`, `fsevents`, `keccak`, `protobufjs`, `sharp`, `tree-sitter`, `tree-sitter-json`, `utf-8-validate`). v11 defaults `strictDepBuilds: true`, so the previously-silent ignores would otherwise fail installs. Denying all preserves current production behavior; flip individual entries to `true` later if a perf or functionality gap surfaces.
- `package.json` — `pnpm.overrides` block and top-level `resolutions` block removed (both migrated above).
- `.npmrc` — deleted (its only contents migrated above; v11 reads it only for auth/registry, which we don't currently set).
- `pnpm-lock.yaml` — unchanged. Already at `lockfileVersion: '9.0'` (shared by v10 + v11); v11 re-validated it cleanly and the override move didn't churn any resolutions.

## Test plan

Locally on Node 22 (CI runs Node 24, matching `engines.node`):
- [x] `pnpm install` — supply-chain check passes (1876 entries against `minimumReleaseAge: 10080`); 1785 packages installed.
- [x] `pnpm install --frozen-lockfile` — "Already up to date", confirming CI's path is safe.
- [x] `pnpm lint` — 0 errors (39 pre-existing warnings).
- [x] `pnpm test` — 191/191 pass across 38 files.
- [x] `pnpm build` — Next.js compile succeeds in 28.3s. Static page-data collection for `/executive/[proposalId]` errors out locally on a GitHub `401 Bad credentials` from a stale local `GITHUB_TOKEN` — pre-existing, unrelated to pnpm. Vercel preview should build cleanly with valid creds.

Before merging:
- [ ] CI green on this PR (`unit.yml`, `e2e.yml`)
- [ ] Smoke-test a Vercel preview deploy
- [ ] Confirm Vercel project settings have no hardcoded `pnpm@10.x` in the build/install step

Closes APP-241.