### PR TITLE
fix: sky-executive detail pages 404 (relative fetch in getStaticProps)

### DIFF
--- a/modules/executive/api/fetchSkyExecutiveDetail.ts
+++ b/modules/executive/api/fetchSkyExecutiveDetail.ts
@@ -1,0 +1,84 @@
+/*
+
+SPDX-FileCopyrightText: © 2023 Dai Foundation <www.daifoundation.org>
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+*/
+
+import { ApiError } from 'modules/app/api/ApiError';
+import validateQueryParam from 'modules/app/api/validateQueryParam';
+import { SkyExecutiveDetailResponse } from 'modules/executive/types';
+
+/**
+ * Fetches a single Sky executive's detail from the upstream Sky API.
+ *
+ * This is shared between the `/api/sky/executives/[proposalIdOrKey]` route (client-facing)
+ * and `getStaticProps` for the `/sky-executive/[proposalId]` page. `getStaticProps` runs in
+ * Node, where relative URLs cannot be resolved, so it must call this directly rather than
+ * fetching its own API route over HTTP.
+ */
+export async function fetchSkyExecutiveDetail(
+  proposalIdOrKey: string
+): Promise<SkyExecutiveDetailResponse> {
+  try {
+    // Validate proposal-id format (kebab-case string or ethereum address)
+    const proposalId = validateQueryParam(
+      proposalIdOrKey,
+      'string',
+      { defaultValue: null },
+      (id: string) => {
+        if (!id || typeof id !== 'string') return false;
+        // Allow ethereum addresses (0x followed by 40 hex chars)
+        if (/^0x[a-fA-F0-9]{40}$/.test(id)) return true;
+        // Allow kebab-case strings (letters, numbers, hyphens, at least 3 chars)
+        if (/^[a-z0-9]+(-[a-z0-9]+)*$/.test(id) && id.length >= 3) return true;
+        return false;
+      },
+      new ApiError(
+        'Invalid proposal-id format',
+        400,
+        'Proposal ID must be a valid ethereum address or kebab-case string'
+      )
+    ) as string;
+
+    const apiUrl = `https://vote.sky.money/api/executive/${proposalId}`;
+
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      // Add timeout for the request
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Sky API responded with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Transform string dates to Date objects and convert officeHours to boolean
+    if (data.spellData) {
+      if (data.spellData.nextCastTime) {
+        data.spellData.nextCastTime = new Date(data.spellData.nextCastTime);
+      }
+      if (data.spellData.datePassed) {
+        data.spellData.datePassed = new Date(data.spellData.datePassed);
+      }
+      if (data.spellData.dateExecuted) {
+        data.spellData.dateExecuted = new Date(data.spellData.dateExecuted);
+      }
+      // Convert officeHours string to boolean
+      if (typeof data.spellData.officeHours === 'string') {
+        data.spellData.officeHours = data.spellData.officeHours === 'true';
+      }
+    }
+
+    return data;
+  } catch (error) {
+    console.error('Error fetching Sky executive detail:', error);
+    throw error;
+  }
+}

--- a/pages/api/sky/executives/[proposalIdOrKey].ts
+++ b/pages/api/sky/executives/[proposalIdOrKey].ts
@@ -9,71 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 import { NextApiRequest, NextApiResponse } from 'next';
 import withApiHandler from 'modules/app/api/withApiHandler';
 import { ApiError } from 'modules/app/api/ApiError';
-import { SkyExecutiveDetailResponse } from 'modules/executive/types';
-import validateQueryParam from 'modules/app/api/validateQueryParam';
-
-async function fetchSkyExecutiveDetail(proposalIdOrKey: string): Promise<SkyExecutiveDetailResponse> {
-  try {
-    // Validate proposal-id format (kebab-case string or ethereum address)
-    const proposalId = validateQueryParam(
-      proposalIdOrKey,
-      'string',
-      { defaultValue: null },
-      (id: string) => {
-        if (!id || typeof id !== 'string') return false;
-        // Allow ethereum addresses (0x followed by 40 hex chars)
-        if (/^0x[a-fA-F0-9]{40}$/.test(id)) return true;
-        // Allow kebab-case strings (letters, numbers, hyphens, at least 3 chars)
-        if (/^[a-z0-9]+(-[a-z0-9]+)*$/.test(id) && id.length >= 3) return true;
-        return false;
-      },
-      new ApiError(
-        'Invalid proposal-id format',
-        400,
-        'Proposal ID must be a valid ethereum address or kebab-case string'
-      )
-    ) as string;
-
-    const apiUrl = `https://vote.sky.money/api/executive/${proposalId}`;
-
-    const response = await fetch(apiUrl, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      // Add timeout for the request
-      signal: AbortSignal.timeout(10000)
-    });
-
-    if (!response.ok) {
-      throw new Error(`Sky API responded with status: ${response.status}`);
-    }
-
-    const data = await response.json();
-
-    // Transform string dates to Date objects and convert officeHours to boolean
-    if (data.spellData) {
-      if (data.spellData.nextCastTime) {
-        data.spellData.nextCastTime = new Date(data.spellData.nextCastTime);
-      }
-      if (data.spellData.datePassed) {
-        data.spellData.datePassed = new Date(data.spellData.datePassed);
-      }
-      if (data.spellData.dateExecuted) {
-        data.spellData.dateExecuted = new Date(data.spellData.dateExecuted);
-      }
-      // Convert officeHours string to boolean
-      if (typeof data.spellData.officeHours === 'string') {
-        data.spellData.officeHours = data.spellData.officeHours === 'true';
-      }
-    }
-
-    return data;
-  } catch (error) {
-    console.error('Error fetching Sky executive detail:', error);
-    throw error;
-  }
-}
+import { fetchSkyExecutiveDetail } from 'modules/executive/api/fetchSkyExecutiveDetail';
 
 export default withApiHandler(async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== 'GET') {

--- a/pages/sky-executive/[proposalId].tsx
+++ b/pages/sky-executive/[proposalId].tsx
@@ -19,6 +19,7 @@ import { useSkyExecutiveDetail } from 'modules/executive/hooks/useSkyExecutiveDe
 import SkyExecutiveDetailView from 'modules/executive/components/SkyExecutiveDetailView';
 import { ErrorBoundary } from 'modules/app/components/ErrorBoundary';
 import { fetchJson } from 'lib/fetchJson';
+import { fetchSkyExecutiveDetail } from 'modules/executive/api/fetchSkyExecutiveDetail';
 import { SkyExecutiveDetailResponse } from 'modules/executive/types';
 
 const LoadingIndicator = () => (
@@ -121,8 +122,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   let executive: SkyExecutiveDetailResponse | null = null;
 
   try {
-    // Try to fetch Sky executive data
-    executive = await fetchJson(`/api/sky/executives/${proposalId}`);
+    // Fetch the Sky executive data directly from the shared server-side function.
+    // getStaticProps runs in Node, where relative URLs (e.g. `/api/...`) cannot be
+    // resolved, so we must not fetch our own API route over HTTP here.
+    executive = await fetchSkyExecutiveDetail(proposalId);
   } catch (error) {
     // If Sky executive not found, that's okay - we'll handle it in the component
     console.log(`Sky executive ${proposalId} not found during static generation`);


### PR DESCRIPTION
## Problem

Every `/sky-executive/{key}` detail page returns a 404, even though the data is healthy:

| Endpoint | Status |
|---|---|
| Upstream `vote.sky.money/api/executive/{key}` | 200 |
| Portal proxy `vote.makerdao.com/api/sky/executives/{key}` | 200 |
| Page `vote.makerdao.com/sky-executive/{key}` | **404** |

## Root cause

`getStaticProps` fetched a **relative URL** (`/api/sky/executives/${proposalId}`). `getStaticProps` runs in Node, which has no origin to resolve a relative URL against, so `fetch` throws `TypeError: Failed to parse URL` immediately — no request is ever made. The `catch` swallowed the error, `executive` stayed `null`, and the page returned `notFound: true`. With `fallback: true`, this 404s every detail page on direct load.

(The recent `GITHUB_TOKEN` change is unrelated — this route proxies the Sky API and does not use GitHub.)

## Fix

- Extract the upstream-fetch logic into a shared server-side function `modules/executive/api/fetchSkyExecutiveDetail.ts`.
- `getStaticProps` now calls it **directly** (in-process, absolute upstream URL → resolvable in Node) instead of fetching its own API route over HTTP. This mirrors the working legacy `/executive` page, which calls `getExecutiveProposal(...)` directly.
- The API route imports the same function (behavior unchanged).
- The client-side `fetchJson('/api/...')` in the component is untouched — relative URLs are correct in the browser.

Scoped tightly to the bug; no behavior change to the API route or client fetching.

## Testing

Typecheck clean for the changed files. Please verify on the Vercel preview by loading a real key, e.g.:
`/sky-executive/template-executive-vote-rwa001-a-offboarding-keeper-network-adjustments-allocator-spark-a-parameter-updates-mkr-to-sky-delayed-upgrade-penalty-increase-prime-agent-proxy-spells-june-4-2026`

🤖 Generated with [Claude Code](https://claude.com/claude-code)